### PR TITLE
Add SplitPromptOnDashTransform to handle script-based multiturn prompts

### DIFF
--- a/wayflowcore/src/wayflowcore/transforms.py
+++ b/wayflowcore/src/wayflowcore/transforms.py
@@ -5,7 +5,7 @@
 # 2.0 (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0), at your option.
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, List
+from typing import TYPE_CHECKING, Any, Callable, List, Optional
 
 from wayflowcore._utils.async_helpers import is_coroutine_function, run_sync_in_thread
 from wayflowcore.serialization.serializer import SerializableCallable, SerializableObject
@@ -113,3 +113,27 @@ class AppendTrailingSystemMessageToUserMessageTransform(MessageTransform, Serial
 
         penultimate_message.contents.extend(last_message.contents)
         return messages[:-2] + [penultimate_message]
+
+
+class SplitPromptOnMarkerMessageTransform(MessageTransform, SerializableObject):
+    """
+    Split prompts on a marker into multiple messages with the same role. Only apply to the messages without tool_requests and tool_result.
+
+    This transform is useful for script-based execution flows, where a single prompt script can be converted into multiple conversation turns for step-by-step reasoning.
+    """
+
+    def __init__(self, marker: Optional[str] = None):
+        self.marker = marker if marker is not None else "\n---"
+
+    def __call__(self, messages: list["Message"]) -> list["Message"]:
+        new_messages = []
+
+        for msg in messages:
+            if msg.tool_requests is None and msg.tool_result is None and self.marker in msg.content:
+                for part in (p.strip() for p in msg.content.split(self.marker) if p.strip()):
+                    new_msg = msg.copy(content=part)
+                    new_messages.append(new_msg)
+            else:
+                new_messages.append(msg)
+
+        return new_messages

--- a/wayflowcore/tests/serialization/test_serializableobject.py
+++ b/wayflowcore/tests/serialization/test_serializableobject.py
@@ -71,6 +71,7 @@ ALL_SERIALIZABLE_CLASSES = {
     "ImageContent",
     "MessageContent",
     "AppendTrailingSystemMessageToUserMessageTransform",
+    "SplitPromptOnMarkerMessageTransform",
     "_ToolRequestAndCallsTransform",
     "CoalesceSystemMessagesTransform",
     "RemoveEmptyNonUserMessageTransform",

--- a/wayflowcore/tests/test_transforms.py
+++ b/wayflowcore/tests/test_transforms.py
@@ -14,6 +14,7 @@ from wayflowcore.tools import ToolRequest, ToolResult
 from wayflowcore.transforms import (
     CoalesceSystemMessagesTransform,
     RemoveEmptyNonUserMessageTransform,
+    SplitPromptOnMarkerMessageTransform,
 )
 
 
@@ -173,5 +174,31 @@ COMPLEX_TOOL_REQUEST = Message(
 )
 def test_python_merge_tool_request(messages, expected_messages):
     transform = _PythonMergeToolRequestAndCallsTransform()
+    transformed_messages = transform(messages)
+    assert_messages_are_correct(transformed_messages, expected_messages)
+
+
+@pytest.mark.parametrize(
+    "messages,expected_messages",
+    [
+        (
+            [Message(message_type=MessageType.USER, content="First part\n---\nSecond part")],
+            [
+                Message(message_type=MessageType.USER, content="First part"),
+                Message(message_type=MessageType.USER, content="Second part"),
+            ],
+        ),
+        (
+            [Message(message_type=MessageType.USER, content="A\n---\nB\n---\nC")],
+            [
+                Message(message_type=MessageType.USER, content="A"),
+                Message(message_type=MessageType.USER, content="B"),
+                Message(message_type=MessageType.USER, content="C"),
+            ],
+        ),
+    ],
+)
+def test_split_prompt_on_marker(messages, expected_messages):
+    transform = SplitPromptOnMarkerMessageTransform()
     transformed_messages = transform(messages)
     assert_messages_are_correct(transformed_messages, expected_messages)


### PR DESCRIPTION
This transform is useful for script-based execution flows, allowing a single prompt script to be split into multiple conversational turns for step-by-step reasoning, leveraging the model’s strength with structured instructions. We are using script-based prompt a lot in our workflow. e.g.

example.script
```
Analyze A and do step one.

---
Now based on the result of your analysis, perform step two.

---
Now generate a json result following below format:
....

```
