### PR TITLE
Agent termination fix & All OCI models tool calling fixes

### DIFF
--- a/docs/wayflowcore/source/core/api/agentspec.rst
+++ b/docs/wayflowcore/source/core/api/agentspec.rst
@@ -167,6 +167,13 @@ Messages
 .. autoclass:: wayflowcore.agentspec.components.transforms.PluginReactMergeToolRequestAndCallsTransform
     :exclude-members: model_post_init, model_config
 
+.. _agentspeccanonicalizationmessagetransform:
+.. autoclass:: wayflowcore.agentspec.components.transforms.PluginCanonicalizationMessageTransform
+    :exclude-members: model_post_init, model_config
+
+.. _agentspecsplitpromptonmarkermessagetransform:
+.. autoclass:: wayflowcore.agentspec.components.transforms.PluginSplitPromptOnMarkerMessageTransform
+    :exclude-members: model_post_init, model_config
 
 Nodes
 ^^^^^

--- a/docs/wayflowcore/source/core/api/prompttemplate.rst
+++ b/docs/wayflowcore/source/core/api/prompttemplate.rst
@@ -39,6 +39,9 @@ Message transforms
 
 .. autoclass:: wayflowcore.transforms.SplitPromptOnMarkerMessageTransform
 
+.. _canonicalizationtransform:
+.. autoclass:: wayflowcore.transforms.CanonicalizationMessageTransform
+
 .. _messagesummarizationtransform:
 .. autoclass:: wayflowcore.transforms.MessageSummarizationTransform
 

--- a/docs/wayflowcore/source/core/changelog.rst
+++ b/docs/wayflowcore/source/core/changelog.rst
@@ -176,6 +176,18 @@ Bug fixes
   Fixed a bug where instantiating an Agent with an ``agent_template``, ``initial_message=None`` and ``custom_instruction=None`` would raise an exception.
   Now, users can fully specify the agent template without having to additionally specify initial messages or custom instructions.
 
+* **Fixed tool calling for OCI models**
+
+  Resolved an issue that sent incorrectly formatted chat histories to OCI endpoints, degrading
+  tool-calling and agentic performance for ``google`` and ``cohere`` models.
+  All OCI models can now more reliably and efficiently leverage tool calling.
+
+* **Fixed agent termination when ``caller_input_mode`` was set to never**
+
+  Corrected an issue where agents without outputs and ``caller_input_mode=CallerInputMode.NEVER``
+  would repeatedly iterate until the maximum limit.
+  Agents can now better complete the task and exit as expected.
+
 
 WayFlow 25.4.2
 --------------

--- a/docs/wayflowcore/source/core/howtoguides/llm_from_different_providers.rst
+++ b/docs/wayflowcore/source/core/howtoguides/llm_from_different_providers.rst
@@ -307,6 +307,14 @@ To disable this behavior, set ``use_tools`` to ``False`` and ensure the prompt d
 See `this documentation <https://arxiv.org/abs/2210.03629>`_ for more details on the ReAct prompting technique.
 
 
+Troubleshooting
+---------------
+
+In certain situations, models may require messages to follow a specific order.
+Message transforms such as :ref:`CanonicalizationMessageTransform <canonicalizationtransform>` can
+be used to enforce the correct ordering of messages (for example, when working with Google models).
+For additional details on LLM prompting, refer to the :doc:`Prompt Template guide <howto_prompttemplate>`.
+
 Recap
 -----
 

--- a/wayflowcore/src/wayflowcore/agent.py
+++ b/wayflowcore/src/wayflowcore/agent.py
@@ -18,7 +18,7 @@ from wayflowcore.executors._executor import ConversationExecutor
 from wayflowcore.idgeneration import IdGenerator
 from wayflowcore.messagelist import Message, MessageList
 from wayflowcore.models.llmmodel import LlmModel
-from wayflowcore.property import Property, _cast_value_into, _empty_default
+from wayflowcore.property import Property, StringProperty, _cast_value_into, _empty_default
 from wayflowcore.serialization.serializer import SerializableDataclassMixin, SerializableObject
 from wayflowcore.templates import PromptTemplate
 from wayflowcore.tools import DescribedAgent, DescribedFlow, Tool, ToolBox
@@ -531,6 +531,7 @@ class Agent(ConversationalComponent, SerializableDataclassMixin, SerializableObj
         add_talk_to_user_tool: bool,
     ) -> List[Tool]:
         from wayflowcore.executors._agentexecutor import (
+            _SUMMARY_OUTPUT_NAME,
             _TALK_TO_USER_TOOL_NAME,
             _agent_as_client_tool,
             _get_end_conversation_tool,
@@ -582,6 +583,19 @@ class Agent(ConversationalComponent, SerializableDataclassMixin, SerializableObj
             all_tools += [
                 _make_submit_output_tool(
                     caller_input_mode=caller_input_mode, outputs=output_descriptors
+                )
+            ]
+        elif can_finish_conversation is False and caller_input_mode == CallerInputMode.NEVER:
+            # when the agent has no outputs and caller input mode NEVER
+            # we just ask the agent to output a short summary of what was done
+            # to force the agent to reflect and act before finishing
+            summary_output_descriptor = StringProperty(
+                name=_SUMMARY_OUTPUT_NAME,
+                description="1 sentence summary of what was done to achieve the task",
+            )
+            all_tools += [
+                _make_submit_output_tool(
+                    caller_input_mode=caller_input_mode, outputs=[summary_output_descriptor]
                 )
             ]
 

--- a/wayflowcore/src/wayflowcore/agentspec/components/transforms.py
+++ b/wayflowcore/src/wayflowcore/agentspec/components/transforms.py
@@ -4,6 +4,8 @@
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
+from typing import Optional
+
 from pyagentspec.component import Component
 
 from wayflowcore.agentspec.components._pydantic_plugins import (
@@ -66,6 +68,37 @@ class PluginSwarmToolRequestAndCallsTransform(PluginMessageTransform):
     sequence of messages."""
 
 
+class PluginCanonicalizationMessageTransform(PluginMessageTransform):
+    """
+    Produce a conversation shaped like:
+
+        System   (optional, at most one, always first if present)
+        User
+        Assistant
+        User
+        Assistant
+        ...
+
+    This is useful because some models (like Gemma) require such formatting of the messages.
+
+    * several system messages are merged
+    * consecutive assistant (resp. user) messages are merged, unless there are several tool calls,
+    in which case they are split and their responses are interleaving the requests.
+    """
+
+
+class PluginSplitPromptOnMarkerMessageTransform(PluginMessageTransform):
+    """
+    Split prompts on a marker into multiple messages with the same role. Only apply to the messages without
+    tool_requests and tool_result.
+
+    This transform is useful for script-based execution flows, where a single prompt script can be converted
+    into multiple conversation turns for step-by-step reasoning.
+    """
+
+    marker: Optional[str] = None
+
+
 messagetransform_serialization_plugin = PydanticComponentSerializationPlugin(
     name="MessageTransformPlugin",
     component_types_and_models={
@@ -75,6 +108,8 @@ messagetransform_serialization_plugin = PydanticComponentSerializationPlugin(
         PluginLlamaMergeToolRequestAndCallsTransform.__name__: PluginLlamaMergeToolRequestAndCallsTransform,
         PluginReactMergeToolRequestAndCallsTransform.__name__: PluginReactMergeToolRequestAndCallsTransform,
         PluginSwarmToolRequestAndCallsTransform.__name__: PluginSwarmToolRequestAndCallsTransform,
+        PluginCanonicalizationMessageTransform.__name__: PluginCanonicalizationMessageTransform,
+        PluginSplitPromptOnMarkerMessageTransform.__name__: PluginSplitPromptOnMarkerMessageTransform,
     },
 )
 messagetransform_deserialization_plugin = PydanticComponentDeserializationPlugin(
@@ -86,5 +121,7 @@ messagetransform_deserialization_plugin = PydanticComponentDeserializationPlugin
         PluginLlamaMergeToolRequestAndCallsTransform.__name__: PluginLlamaMergeToolRequestAndCallsTransform,
         PluginReactMergeToolRequestAndCallsTransform.__name__: PluginReactMergeToolRequestAndCallsTransform,
         PluginSwarmToolRequestAndCallsTransform.__name__: PluginSwarmToolRequestAndCallsTransform,
+        PluginCanonicalizationMessageTransform.__name__: PluginCanonicalizationMessageTransform,
+        PluginSplitPromptOnMarkerMessageTransform.__name__: PluginSplitPromptOnMarkerMessageTransform,
     },
 )

--- a/wayflowcore/src/wayflowcore/component.py
+++ b/wayflowcore/src/wayflowcore/component.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import ClassVar, Optional
 
 from wayflowcore._metadata import MetadataType
+from wayflowcore.idgeneration import IdGenerator
 from wayflowcore.serialization.serializer import (
     FrozenSerializableDataclass,
     SerializableDataclass,
@@ -30,6 +31,11 @@ class Component(SerializableObject, ABC):
         super().__init__(id=id, __metadata_info__=__metadata_info__)
         self.name = name or self.id
         self.description = description
+
+    def _get_display_name(self) -> str:
+        return (
+            self.name if not IdGenerator.is_auto_generated(self.name) else self.__class__.__name__
+        )
 
 
 @dataclass(kw_only=True)

--- a/wayflowcore/src/wayflowcore/contextproviders/toolcontextprovider.py
+++ b/wayflowcore/src/wayflowcore/contextproviders/toolcontextprovider.py
@@ -112,6 +112,7 @@ class ToolContextProvider(ContextProvider):
                     args={},
                     tool_request_id=tool_request_id,
                 ),
+                name=f"ToolExecution[{self.tool.name}]",
             ) as tool_span:
                 tool_output = await self.tool.run_async()
                 tool_span.record_end_span_event(

--- a/wayflowcore/src/wayflowcore/executors/_flowexecutor.py
+++ b/wayflowcore/src/wayflowcore/executors/_flowexecutor.py
@@ -458,7 +458,7 @@ class FlowConversationExecutor(ConversationExecutor):
         else:
             if not value_descriptor.has_default:
                 raise ValueError(
-                    f"Step {current_step_name} with field {value_name} is not required but it does not have a default value"
+                    f"Step {current_step_name} has input field {value_name} but it was not produced yet and it does not have a default value"
                 )
             value = value_descriptor.default_value
 
@@ -698,7 +698,10 @@ class FlowConversationExecutor(ConversationExecutor):
         try:
             with get_interrupts_event_listener_context_for_conversation(conversation):
                 conversation.state._set_execution_interrupts(execution_interrupts)
-                with FlowExecutionSpan(conversational_component=conversation.component) as span:
+                with FlowExecutionSpan(
+                    conversational_component=conversation.component,
+                    name=f"FlowExecution[{conversation.component._get_display_name()}]",
+                ) as span:
                     execution_status = await FlowConversationExecutor._execute_flow(
                         conversation, execution_interrupts
                     )

--- a/wayflowcore/src/wayflowcore/models/_modelhelpers.py
+++ b/wayflowcore/src/wayflowcore/models/_modelhelpers.py
@@ -78,3 +78,11 @@ def _fetch_tool_calling_support(llm: "LlmModel") -> bool:
         if "API streaming request failed after retries" not in str(e):
             raise e
     return False
+
+
+def _is_gemma_model(model_id: str) -> bool:
+    return "gemma" in model_id.lower()
+
+
+def _is_llama_legacy_model(model_id: str) -> bool:
+    return "llama" in model_id.lower() and "3." in model_id

--- a/wayflowcore/src/wayflowcore/models/_openaihelpers/_api_processor.py
+++ b/wayflowcore/src/wayflowcore/models/_openaihelpers/_api_processor.py
@@ -34,7 +34,9 @@ class _APIProcessor(ABC):
     def _extract_usage(self, response_data: Dict[str, Any]) -> Optional[TokenUsage]:
         """Extract Token Usage information from the response"""
 
-    def _generate_request_params(self, prompt: "Prompt", stream: bool) -> Dict[str, Any]:
+    def _generate_request_params(
+        self, prompt: "Prompt", stream: bool, supports_tool_role: bool
+    ) -> Dict[str, Any]:
         """Generate Request Parameters for the API type"""
         url = _build_request_url(base_url=self.base_url, api_type=self.api_type)
 
@@ -42,7 +44,7 @@ class _APIProcessor(ABC):
             "model": self.model_id,
             "store": False,
             "stream": stream,
-            **self._convert_prompt(prompt),
+            **self._convert_prompt(prompt, supports_tool_role),
             **self._convert_generation_params(prompt.generation_config),
         }
 
@@ -116,7 +118,7 @@ class _APIProcessor(ABC):
             return {}
 
     @abstractmethod
-    def _convert_prompt(self, prompt: "Prompt") -> Dict[str, Any]:
+    def _convert_prompt(self, prompt: "Prompt", supports_tool_role: bool) -> Dict[str, Any]:
         """Convert a prompt to OpenAI-Compatible Format"""
 
     @abstractmethod

--- a/wayflowcore/src/wayflowcore/models/_openaihelpers/_responses_processor.py
+++ b/wayflowcore/src/wayflowcore/models/_openaihelpers/_responses_processor.py
@@ -120,7 +120,9 @@ class _ResponsesAPIProcessor(_APIProcessor):
         else:
             return [openai_dict]
 
-    def _convert_message_into_openai_message_dict(self, m: Message) -> List[Dict[str, Any]]:
+    def _convert_message_into_openai_message_dict(
+        self, m: Message, supports_tool_role: bool
+    ) -> List[Dict[str, Any]]:
         """
         Convert a WayFlow ``Message`` object into a list of dictionaries compatible with the OpenAI Responses API.
 
@@ -180,12 +182,12 @@ class _ResponsesAPIProcessor(_APIProcessor):
         else:
             return self._convert_message_with_content_into_openai_message(m)
 
-    def _convert_prompt(self, prompt: "Prompt") -> Dict[str, Any]:
+    def _convert_prompt(self, prompt: "Prompt", supports_tool_role: bool) -> Dict[str, Any]:
         payload_arguments: Dict[str, Any] = {
             "input": [
                 m
                 for message in prompt.messages
-                for m in self._convert_message_into_openai_message_dict(message)
+                for m in self._convert_message_into_openai_message_dict(message, supports_tool_role)
             ],
         }
 

--- a/wayflowcore/src/wayflowcore/models/llmmodel.py
+++ b/wayflowcore/src/wayflowcore/models/llmmodel.py
@@ -218,7 +218,9 @@ class LlmModel(Component, SerializableObject, ABC):
 
         self._check_supports_prompt(prompt)
 
-        with LlmGenerationSpan(llm=self, prompt=prompt) as span:
+        with LlmGenerationSpan(
+            llm=self, prompt=prompt, name=f"LlmGeneration[{self._get_display_name()}]"
+        ) as span:
             logger.debug("LLM generating: %s", prompt)
             completion = await self._generate_impl(prompt)
             logger.debug("LLM output: %s", completion.message)
@@ -280,12 +282,15 @@ class LlmModel(Component, SerializableObject, ABC):
 
         self._check_supports_prompt(prompt)
 
-        with LlmGenerationSpan(llm=self, prompt=prompt) as span:
+        with LlmGenerationSpan(
+            llm=self, prompt=prompt, name=f"LlmGeneration[{self._get_display_name()}]"
+        ) as span:
             logger.debug("LLM generating: %s", prompt)
             final_chunk: Optional["Message"] = None
             async for chunk_type, chunk, token_usage in self._stream_generate_impl(prompt):
                 if chunk_type == StreamChunkType.END_CHUNK:
                     final_chunk = chunk
+                    logger.debug("Llm streamed the final chunk: %s", final_chunk)
                 yield chunk_type, chunk
 
             if final_chunk is None:

--- a/wayflowcore/src/wayflowcore/serialization/_builtins_components.py
+++ b/wayflowcore/src/wayflowcore/serialization/_builtins_components.py
@@ -14,6 +14,7 @@ _BUILTIN_COMPONENTS = {
     "AgentConversation",
     "AgentConversationExecutionState",
     "AgentExecutionStep",
+    "CanonicalizationMessageTransform",
     "AnyProperty",
     "ApiCallStep",
     "AppendTrailingSystemMessageToUserMessageTransform",

--- a/wayflowcore/src/wayflowcore/serialization/_builtins_deserialization_plugin.py
+++ b/wayflowcore/src/wayflowcore/serialization/_builtins_deserialization_plugin.py
@@ -115,7 +115,9 @@ from wayflowcore.agentspec.components import (
 from wayflowcore.agentspec.components import (
     PluginVllmEmbeddingConfig as AgentSpecPluginVllmEmbeddingConfig,
 )
-from wayflowcore.agentspec.components import all_deserialization_plugin
+from wayflowcore.agentspec.components import (
+    all_deserialization_plugin,
+)
 from wayflowcore.agentspec.components.agent import ExtendedAgent as AgentSpecExtendedAgent
 from wayflowcore.agentspec.components.contextprovider import (
     PluginConstantContextProvider as AgentSpecPluginConstantContextProvider,
@@ -256,6 +258,9 @@ from wayflowcore.agentspec.components.transforms import (
     PluginAppendTrailingSystemMessageToUserMessageTransform as AgentSpecPluginAppendTrailingSystemMessageToUserMessageTransform,
 )
 from wayflowcore.agentspec.components.transforms import (
+    PluginCanonicalizationMessageTransform as AgentSpecPluginCanonicalizationMessageTransform,
+)
+from wayflowcore.agentspec.components.transforms import (
     PluginCoalesceSystemMessagesTransform as AgentSpecPluginCoalesceSystemMessagesTransform,
 )
 from wayflowcore.agentspec.components.transforms import (
@@ -269,6 +274,9 @@ from wayflowcore.agentspec.components.transforms import (
 )
 from wayflowcore.agentspec.components.transforms import (
     PluginRemoveEmptyNonUserMessageTransform as AgentSpecPluginRemoveEmptyNonUserMessageTransform,
+)
+from wayflowcore.agentspec.components.transforms import (
+    PluginSplitPromptOnMarkerMessageTransform as AgentSpecPluginSplitPromptOnMarkerMessageTransform,
 )
 from wayflowcore.agentspec.components.transforms import (
     PluginSwarmToolRequestAndCallsTransform as AgentSpecPluginSwarmToolRequestAndCallsTransform,
@@ -426,6 +434,12 @@ from wayflowcore.transforms import (
 )
 from wayflowcore.transforms import (
     RemoveEmptyNonUserMessageTransform as RuntimeRemoveEmptyNonUserMessageTransform,
+)
+from wayflowcore.transforms.canonicalizationtransform import (
+    CanonicalizationMessageTransform as RuntimeCanonicalizationMessageTransform,
+)
+from wayflowcore.transforms.transforms import (
+    SplitPromptOnMarkerMessageTransform as RuntimeSplitPromptOnMarkerMessageTransform,
 )
 from wayflowcore.variable import Variable as RuntimeVariable
 
@@ -1672,6 +1686,12 @@ class WayflowBuiltinsDeserializationPlugin(WayflowDeserializationPlugin):
                 return RuntimeReactMergeToolRequestAndCallsTransform()
             elif isinstance(agentspec_component, AgentSpecPluginSwarmToolRequestAndCallsTransform):
                 return RuntimeSwarmToolRequestAndCallsTransform()
+            elif isinstance(agentspec_component, AgentSpecPluginCanonicalizationMessageTransform):
+                return RuntimeCanonicalizationMessageTransform()
+            elif isinstance(
+                agentspec_component, AgentSpecPluginSplitPromptOnMarkerMessageTransform
+            ):
+                return RuntimeSplitPromptOnMarkerMessageTransform(marker=agentspec_component.marker)
             raise ValueError(f"Unsupported type of MessageTransform: {type(agentspec_component)}")
 
         elif isinstance(agentspec_component, AgentSpecPluginOutputParser):

--- a/wayflowcore/src/wayflowcore/serialization/_builtins_serialization_plugin.py
+++ b/wayflowcore/src/wayflowcore/serialization/_builtins_serialization_plugin.py
@@ -110,7 +110,9 @@ from wayflowcore.agentspec.components import (
 from wayflowcore.agentspec.components import (
     PluginVllmEmbeddingConfig as AgentSpecPluginVllmEmbeddingConfig,
 )
-from wayflowcore.agentspec.components import all_serialization_plugin
+from wayflowcore.agentspec.components import (
+    all_serialization_plugin,
+)
 from wayflowcore.agentspec.components.agent import ExtendedAgent as AgentSpecExtendedAgent
 from wayflowcore.agentspec.components.contextprovider import (
     PluginConstantContextProvider as AgentSpecPluginConstantContextProvider,
@@ -250,6 +252,9 @@ from wayflowcore.agentspec.components.transforms import (
     PluginAppendTrailingSystemMessageToUserMessageTransform as AgentSpecPluginAppendTrailingSystemMessageToUserMessageTransform,
 )
 from wayflowcore.agentspec.components.transforms import (
+    PluginCanonicalizationMessageTransform as AgentSpecPluginCanonicalizationMessageTransform,
+)
+from wayflowcore.agentspec.components.transforms import (
     PluginCoalesceSystemMessagesTransform as AgentSpecPluginCoalesceSystemMessagesTransform,
 )
 from wayflowcore.agentspec.components.transforms import (
@@ -263,6 +268,9 @@ from wayflowcore.agentspec.components.transforms import (
 )
 from wayflowcore.agentspec.components.transforms import (
     PluginRemoveEmptyNonUserMessageTransform as AgentSpecPluginRemoveEmptyNonUserMessageTransform,
+)
+from wayflowcore.agentspec.components.transforms import (
+    PluginSplitPromptOnMarkerMessageTransform as AgentSpecPluginSplitPromptOnMarkerMessageTransform,
 )
 from wayflowcore.agentspec.components.transforms import (
     PluginSwarmToolRequestAndCallsTransform as AgentSpecPluginSwarmToolRequestAndCallsTransform,
@@ -354,7 +362,9 @@ from wayflowcore.models.ociclientconfig import (
 from wayflowcore.models.ociclientconfig import (
     OCIClientConfigWithUserAuthentication as RuntimeOCIClientConfigWithUserAuthentication,
 )
-from wayflowcore.models.openaicompatiblemodel import EMPTY_API_KEY
+from wayflowcore.models.openaicompatiblemodel import (
+    EMPTY_API_KEY,
+)
 from wayflowcore.models.openaicompatiblemodel import (
     OpenAICompatibleModel as RuntimeOpenAICompatibleModel,
 )
@@ -436,6 +446,12 @@ from wayflowcore.transforms import (
 from wayflowcore.transforms import MessageTransform as RuntimeMessageTransform
 from wayflowcore.transforms import (
     RemoveEmptyNonUserMessageTransform as RuntimeRemoveEmptyNonUserMessageTransform,
+)
+from wayflowcore.transforms.canonicalizationtransform import (
+    CanonicalizationMessageTransform as RuntimeCanonicalizationMessageTransform,
+)
+from wayflowcore.transforms.transforms import (
+    SplitPromptOnMarkerMessageTransform as RuntimeSplitPromptOnMarkerMessageTransform,
 )
 from wayflowcore.variable import Variable as RuntimeVariable
 
@@ -1467,6 +1483,21 @@ class WayflowBuiltinsSerializationPlugin(WayflowSerializationPlugin):
                     runtime_messagetransform
                 ),
             )
+        elif isinstance(runtime_messagetransform, RuntimeCanonicalizationMessageTransform):
+            return AgentSpecPluginCanonicalizationMessageTransform(
+                name="canonicalization_messagetransform",
+                metadata=_create_agentspec_metadata_from_runtime_component(
+                    runtime_messagetransform
+                ),
+            )
+        elif isinstance(runtime_messagetransform, RuntimeSplitPromptOnMarkerMessageTransform):
+            return AgentSpecPluginSplitPromptOnMarkerMessageTransform(
+                name="splitpromptonmarker_messagetransform",
+                metadata=_create_agentspec_metadata_from_runtime_component(
+                    runtime_messagetransform
+                ),
+                marker=runtime_messagetransform.marker,
+            )
         raise ValueError(
             f"Unsupported type of MessageTransform in Agent Spec: {type(runtime_messagetransform)}"
         )
@@ -1908,7 +1939,10 @@ class WayflowBuiltinsSerializationPlugin(WayflowSerializationPlugin):
                         runtime_agent.agent_template,
                         referenced_objects,
                     )
-                    if isinstance(runtime_agent.agent_template, RuntimePromptTemplate)
+                    if (
+                        isinstance(runtime_agent.agent_template, RuntimePromptTemplate)
+                        and runtime_agent.agent_template is not runtime_agent.llm.agent_template
+                    )
                     else None
                 ),
             )

--- a/wayflowcore/src/wayflowcore/steps/step.py
+++ b/wayflowcore/src/wayflowcore/steps/step.py
@@ -971,8 +971,7 @@ class Step(ComponentWithInputsOutputs, SerializableObject, metaclass=_StepRegist
                 f"the provided conversation to a flow must be of type FlowConversation but was {type(conversation).__name__}"
             )
         with StepInvocationSpan(
-            step=self,
-            inputs=inputs,
+            step=self, inputs=inputs, name=f"StepInvocation[{self.name}]"
         ) as span:
             internal_inputs = self.remap_inputs(inputs)
             if self._has_async_implemented():

--- a/wayflowcore/src/wayflowcore/steps/toolexecutionstep.py
+++ b/wayflowcore/src/wayflowcore/steps/toolexecutionstep.py
@@ -366,8 +366,7 @@ class ToolExecutionStep(Step):
 
             elif isinstance(tool, ServerTool) and tool_request._tool_execution_confirmed:
                 with ToolExecutionSpan(
-                    tool=tool,
-                    tool_request=tool_request,
+                    tool=tool, tool_request=tool_request, name=f"ToolExecution[{tool.name}]"
                 ) as span:
                     tool_output = await self._execute_tool(tool, tool_request.args)
                     span.record_end_span_event(
@@ -407,6 +406,7 @@ class ToolExecutionStep(Step):
                 args=inputs,
                 tool_request_id=tool_request_id,
             ),
+            name=f"ToolExecution[{tool.name}]",
         ) as span:
             tool_output = await self._execute_tool(tool, inputs)
             span.record_end_span_event(

--- a/wayflowcore/src/wayflowcore/templates/llamatemplates.py
+++ b/wayflowcore/src/wayflowcore/templates/llamatemplates.py
@@ -91,6 +91,7 @@ LLAMA_CHAT_TEMPLATE = PromptTemplate(
     ],
     output_parser=JsonToolOutputParser(),
 )
+"""Chat template for legacy llama models"""
 
 LLAMA_AGENT_TEMPLATE = PromptTemplate(
     messages=[
@@ -113,3 +114,4 @@ LLAMA_AGENT_TEMPLATE = PromptTemplate(
     ],
     output_parser=JsonToolOutputParser(),
 )
+"""Agent template for legacy llama models"""

--- a/wayflowcore/src/wayflowcore/templates/nativetemplates.py
+++ b/wayflowcore/src/wayflowcore/templates/nativetemplates.py
@@ -12,6 +12,7 @@ NATIVE_CHAT_TEMPLATE = PromptTemplate(
     messages=[PromptTemplate.CHAT_HISTORY_PLACEHOLDER],
     post_rendering_transforms=[RemoveEmptyNonUserMessageTransform()],
 )
+"""Native chat template. Should be prioritized if the model supports native tool calling."""
 
 NATIVE_AGENT_TEMPLATE = PromptTemplate(
     messages=[
@@ -27,3 +28,4 @@ NATIVE_AGENT_TEMPLATE = PromptTemplate(
     ],
     post_rendering_transforms=[RemoveEmptyNonUserMessageTransform()],
 )
+"""Native agent template. Should be prioritized if the model supports native tool calling."""

--- a/wayflowcore/src/wayflowcore/templates/pythoncalltemplates.py
+++ b/wayflowcore/src/wayflowcore/templates/pythoncalltemplates.py
@@ -13,6 +13,7 @@ from wayflowcore.serialization.serializer import SerializableObject
 from wayflowcore.templates.template import PromptTemplate
 from wayflowcore.tools import ToolRequest, ToolResult
 from wayflowcore.transforms import (
+    CanonicalizationMessageTransform,
     CoalesceSystemMessagesTransform,
     MessageTransform,
     RemoveEmptyNonUserMessageTransform,
@@ -105,6 +106,7 @@ PYTHON_CALL_CHAT_TEMPLATE = PromptTemplate(
     ],
     output_parser=PythonToolOutputParser(),
 )
+"""Pythonic chat template that leverages python syntax to write tool calls"""
 
 PYTHON_CALL_AGENT_TEMPLATE = PromptTemplate(
     messages=[
@@ -127,3 +129,10 @@ PYTHON_CALL_AGENT_TEMPLATE = PromptTemplate(
     ],
     output_parser=PythonToolOutputParser(),
 )
+"""Pythonic agent template that leverages python syntax to write tool calls"""
+
+
+GEMMA_AGENT_TEMPLATE = PYTHON_CALL_AGENT_TEMPLATE.with_additional_post_rendering_transform(
+    CanonicalizationMessageTransform()
+)
+"""Template for gemma models that do not support native tool calling"""

--- a/wayflowcore/src/wayflowcore/templates/reacttemplates.py
+++ b/wayflowcore/src/wayflowcore/templates/reacttemplates.py
@@ -175,6 +175,7 @@ REACT_CHAT_TEMPLATE = PromptTemplate(
     output_parser=ReactToolOutputParser(),
     generation_config=LlmGenerationConfig(stop=["## Observation"]),
 )
+"""React chat template for models that do not support native tool calling or reasoning."""
 
 
 REACT_AGENT_TEMPLATE = PromptTemplate(
@@ -200,3 +201,4 @@ REACT_AGENT_TEMPLATE = PromptTemplate(
     output_parser=ReactToolOutputParser(),
     generation_config=LlmGenerationConfig(stop=["## Observation"]),
 )
+"""React agent template for models that do not support native tool calling or reasoning."""

--- a/wayflowcore/src/wayflowcore/transforms/__init__.py
+++ b/wayflowcore/src/wayflowcore/transforms/__init__.py
@@ -4,6 +4,7 @@
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
+from .canonicalizationtransform import CanonicalizationMessageTransform
 from .summarization import ConversationSummarizationTransform, MessageSummarizationTransform
 from .transforms import (
     AppendTrailingSystemMessageToUserMessageTransform,
@@ -15,6 +16,7 @@ from .transforms import (
 )
 
 __all__ = [
+    "CanonicalizationMessageTransform",
     "AppendTrailingSystemMessageToUserMessageTransform",
     "CallableMessageTransform",
     "CoalesceSystemMessagesTransform",

--- a/wayflowcore/src/wayflowcore/transforms/canonicalizationtransform.py
+++ b/wayflowcore/src/wayflowcore/transforms/canonicalizationtransform.py
@@ -1,0 +1,161 @@
+# Copyright © 2025 Oracle and/or its affiliates.
+#
+# This software is under the Apache License 2.0
+# (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
+# (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
+import logging
+from typing import List, Optional
+
+from wayflowcore.messagelist import Message, TextContent
+from wayflowcore.serialization.serializer import SerializableObject
+
+from .transforms import MessageTransform
+
+logger = logging.getLogger(__name__)
+
+
+class CanonicalizationMessageTransform(MessageTransform, SerializableObject):
+    """
+    Produce a conversation shaped like:
+
+        System   (optional, at most one, always first if present)
+        User
+        Assistant
+        User
+        Assistant
+        ...
+
+    This is useful because some models (like Gemma) require such formatting of the messages.
+
+    * several system messages are merged
+    * consecutive assistant (resp. user) messages are merged, unless there are several tool calls,
+    in which case they are split and their responses are interleaving the requests.
+    """
+
+    FIRST_DUMMY_USER_TEXT = "begin"
+    NEXT_DUMMY_USER_TEXT = "continue"
+
+    def __call__(self, messages: List["Message"]) -> List["Message"]:
+        system_msg: Message | None = None
+        formatted_messages: List[Message] = []
+        modified = False
+
+        tool_requests_queue = []
+
+        dummy_user_count = 0  # track number of dummy message added
+
+        def last_role() -> str:
+            return formatted_messages[-1].role if formatted_messages else ""
+
+        def make_dummy_user() -> Message:
+            nonlocal dummy_user_count
+            text = (
+                self.FIRST_DUMMY_USER_TEXT if dummy_user_count == 0 else self.NEXT_DUMMY_USER_TEXT
+            )
+            dummy_user_count += 1
+            return Message(role="user", contents=[TextContent(text)])
+
+        def merge_contents(a: Message, b: Message, prefix: Optional[str] = None) -> Message:
+            extra = ([TextContent(prefix)] if prefix else []) + b.contents
+            return a.copy(contents=a.contents + extra)
+
+        def merge_assistant_tool_requests(a: Message, b: Message) -> Message:
+            return a.copy(
+                tool_requests=(a.tool_requests or []) + (b.tool_requests or []),
+            )
+
+        def append_user_or_merge(msg: Message) -> None:
+            nonlocal modified
+            if last_role() == "user":
+                prev = formatted_messages[-1]
+                if msg.tool_result:
+                    if prev.tool_result:
+                        # both messages have tool results, we
+                        # need to insert an assistant message containing
+                        # the associated tool call
+                        formatted_messages.append(
+                            find_associated_tool_request_message(msg.tool_result.tool_request_id)
+                        )
+                        formatted_messages.append(msg)
+                        return
+                    else:
+                        # we add the tool result to the previous user message
+                        prev = prev.copy(tool_result=msg.tool_result)
+
+                formatted_messages[-1] = merge_contents(prev, msg)
+                modified = True
+            else:
+                formatted_messages.append(msg)
+
+        def append_assistant_or_merge(msg: Message) -> None:
+            nonlocal modified
+            if last_role() == "assistant":
+                prev = formatted_messages[-1]
+                merged = merge_contents(prev, msg)
+                merged = merge_assistant_tool_requests(merged, msg)
+                formatted_messages[-1] = merged
+                modified = True
+            else:
+                formatted_messages.append(msg)
+
+        def split_message_with_several_tool_requests_if_needed(msg: Message) -> Message:
+            if msg.tool_requests is None or len(msg.tool_requests) <= 1:
+                return msg
+            kept_tool_request, remaining_tool_requests = msg.tool_requests[0], msg.tool_requests[1:]
+            # these tool requests should be added later with their responses
+            tool_requests_queue.extend(remaining_tool_requests)
+            return msg.copy(tool_requests=[kept_tool_request])
+
+        def find_associated_tool_request_message(tool_request_id: str) -> Message:
+            for tool_request_idx in range(len(tool_requests_queue)):
+                tool_request = tool_requests_queue[tool_request_idx]
+                if tool_request.tool_request_id == tool_request_id:
+                    tool_requests_queue.pop(tool_request_idx)
+                    return Message(tool_requests=[tool_request])
+            raise RuntimeError(f"No tool request with id {tool_request_id} found")
+
+        # ensure alternation & merge message when needed
+        for msg in messages:
+            role = msg.role
+
+            if role == "system":
+                if system_msg is None:
+                    system_msg = msg
+                else:
+                    system_msg = merge_contents(system_msg, msg)
+                    modified = True
+            elif role == "assistant":
+                msg = split_message_with_several_tool_requests_if_needed(msg)
+
+                if not formatted_messages or last_role() == "system":
+                    formatted_messages.append(make_dummy_user())
+                    modified = True
+
+                append_assistant_or_merge(msg)
+            elif role == "user":  # role == "user"
+                append_user_or_merge(msg)
+            else:
+                raise ValueError(f"Unsupported role: {role}")
+
+        # check we don't have ay remaining requests
+        if len(tool_requests_queue) > 0:
+            raise ValueError(
+                f"Some tool requests are missing their tool results: {tool_requests_queue}"
+            )
+
+        # guarantee at least one user exists
+        if not any(m.role == "user" for m in formatted_messages):
+            formatted_messages.append(make_dummy_user())
+            modified = True
+
+        # add the system message
+        if system_msg is not None:
+            formatted_messages.insert(0, system_msg)
+
+        if modified:
+            logger.debug(
+                "Message list modified to strictly alternate user/assistant: %s",
+                formatted_messages,
+            )
+
+        return formatted_messages

--- a/wayflowcore/src/wayflowcore/transforms/transforms.py
+++ b/wayflowcore/src/wayflowcore/transforms/transforms.py
@@ -98,17 +98,12 @@ class AppendTrailingSystemMessageToUserMessageTransform(MessageTransform, Serial
     """
 
     def __call__(self, messages: List["Message"]) -> List["Message"]:
-        from wayflowcore.messagelist import MessageType
-
         if len(messages) < 2:
             return messages
 
         last_message = messages[-1]
         penultimate_message = messages[-2].copy()
-        if (
-            last_message.message_type != MessageType.SYSTEM
-            or penultimate_message.message_type != MessageType.USER
-        ):
+        if last_message.role != "system" or penultimate_message.role != "user":
             return messages
 
         penultimate_message.contents.extend(last_message.contents)

--- a/wayflowcore/tests/agentspec/test_prompttemplate.py
+++ b/wayflowcore/tests/agentspec/test_prompttemplate.py
@@ -18,8 +18,11 @@ from wayflowcore.templates.reacttemplates import (
     _ReactMergeToolRequestAndCallsTransform,
 )
 from wayflowcore.transforms import (
+    AppendTrailingSystemMessageToUserMessageTransform,
+    CanonicalizationMessageTransform,
     CoalesceSystemMessagesTransform,
     RemoveEmptyNonUserMessageTransform,
+    SplitPromptOnMarkerMessageTransform,
 )
 
 
@@ -34,6 +37,9 @@ def test_prompttemplate_can_be_exported_to_agentspec_then_imported(remotely_host
             _ReactMergeToolRequestAndCallsTransform(),
             CoalesceSystemMessagesTransform(),
             RemoveEmptyNonUserMessageTransform(),
+            CanonicalizationMessageTransform(),
+            AppendTrailingSystemMessageToUserMessageTransform(),
+            SplitPromptOnMarkerMessageTransform(),
         ],
         output_parser=ReactToolOutputParser(),
         generation_config=LlmGenerationConfig(stop=["## Observation"]),

--- a/wayflowcore/tests/conftest.py
+++ b/wayflowcore/tests/conftest.py
@@ -3,7 +3,7 @@
 # This software is under the Apache License 2.0
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
-
+import contextlib
 import logging
 import os
 import re
@@ -838,3 +838,20 @@ def pytest_sessionfinish(session, exitstatus):
             f"{t.name}: {t.daemon}, {t.is_alive()}" for t in threads
         )
         raise ValueError(text)
+
+
+@contextlib.contextmanager
+def disable_streaming():
+    """Temporarily disable message streaming of LLMs"""
+    from wayflowcore.executors._agentexecutor import _DISABLE_STREAMING
+
+    old_value = os.environ.get(_DISABLE_STREAMING, None)
+    if old_value is None:
+        os.environ[_DISABLE_STREAMING] = "true"
+    try:
+        yield
+    finally:
+        if old_value is not None:
+            os.environ[_DISABLE_STREAMING] = old_value
+        else:
+            del os.environ[_DISABLE_STREAMING]

--- a/wayflowcore/tests/integration/steps/test_agentexecution_step.py
+++ b/wayflowcore/tests/integration/steps/test_agentexecution_step.py
@@ -322,7 +322,7 @@ def test_agent_only_uses_max_iterations_in_total_during_agent_execution_step(rem
     status = conv.execute()
     assert isinstance(status, FinishedStatus)
     assert dummy_llm.output is None  # all generations used
-    assert len([m for m in conv.get_messages() if "I'm not available" in m.content]) == 3
+    assert len([m for m in conv.get_messages() if "The user is not available" in m.content]) == 3
 
 
 @retry_test(max_attempts=7)

--- a/wayflowcore/tests/integration/test_agent.py
+++ b/wayflowcore/tests/integration/test_agent.py
@@ -2304,3 +2304,19 @@ def test_exception_during_parallel_tool_calls_with_flow(remotely_hosted_llm):
         status = conversation.execute()
 
     _check_each_tool_request_is_followed_by_single_matching_tool_result(conversation.get_messages())
+
+
+def test_agent_does_not_loop_until_max_iterations(remotely_hosted_llm):
+    # when caller_input_mode == NEVER, can_finish_conversation=False and no outputs,
+    # the agent does not have the exit conversation nor the submit tool
+    # we still need it to be able to exit
+    agent = Agent(
+        llm=remotely_hosted_llm,
+        can_finish_conversation=False,
+        caller_input_mode=CallerInputMode.NEVER,
+        custom_instruction="do something",
+    )
+    conv = agent.start_conversation()
+    status = conv.execute()
+    # it should not have exited because of max_iter
+    assert conv.state.curr_iter != agent.max_iterations

--- a/wayflowcore/tests/serialization/test_serializableobject.py
+++ b/wayflowcore/tests/serialization/test_serializableobject.py
@@ -22,6 +22,7 @@ ALL_SERIALIZABLE_CLASSES = {
     "AgentConversation",
     "AgentConversationExecutionState",
     "AgentExecutionStep",
+    "CanonicalizationMessageTransform",
     "AnyProperty",
     "ApiCallStep",
     "AppendTrailingSystemMessageToUserMessageTransform",

--- a/wayflowcore/tests/test_interrupts.py
+++ b/wayflowcore/tests/test_interrupts.py
@@ -4,8 +4,6 @@
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
-import contextlib
-import os
 from typing import Any, Dict, Optional, Type
 
 import pytest
@@ -35,21 +33,8 @@ from wayflowcore.steps import PromptExecutionStep, StartStep
 from wayflowcore.steps.step import Step
 from wayflowcore.tools import ServerTool, ToolRequest, tool
 
+from .conftest import disable_streaming
 from .testhelpers.dummy import DoNothingStep, DummyModel, SleepStep
-
-
-@contextlib.contextmanager
-def disable_streaming():
-    """Temporarily disable message streaming of LLMs"""
-    from wayflowcore.executors._agentexecutor import _DISABLE_STREAMING
-
-    old_value = os.environ.get(_DISABLE_STREAMING, None)
-    if old_value is None:
-        os.environ[_DISABLE_STREAMING] = "true"
-    try:
-        yield
-    finally:
-        del os.environ[_DISABLE_STREAMING]
 
 
 def assert_conversations_are_equivalent(

--- a/wayflowcore/tests/testhelpers/patching.py
+++ b/wayflowcore/tests/testhelpers/patching.py
@@ -4,8 +4,8 @@
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 from contextlib import contextmanager
-from typing import Any, AsyncIterable, AsyncIterator, Callable, Dict, Generator, List, Union
-from unittest.mock import patch
+from typing import Any, AsyncIterable, AsyncIterator, Callable, Dict, Generator, List, Tuple, Union
+from unittest.mock import AsyncMock, patch
 
 from wayflowcore import Message, MessageType
 from wayflowcore.models import (
@@ -54,7 +54,7 @@ def patch_llm(
     llm: "LlmModel",
     outputs: List[Union[str, List["ToolRequest"], "Message"]],
     patch_internal: bool = False,
-) -> Generator[None, None, None]:
+) -> Generator[Tuple[AsyncMock, AsyncMock], None, None]:
     """
     Patch `llm.generate` and `llm.stream_generate` so that every call returns
     the next element in outputs.
@@ -119,7 +119,7 @@ def patch_llm(
         )
 
     with patch_generate, patch_stream:
-        yield
+        yield patch_generate.get_original()[0], patch_stream.get_original()[0]
 
 
 @contextmanager


### PR DESCRIPTION
Several bugfixes before the release:

- improve the names of spans for tracing
- agent step in mapstep without outputs + test
- add helpers on PromptTemplate and TokenUsage + move tests in proper file
- all default templates of supported models should work by default