### PR TITLE
Oracle datastore example

### DIFF
--- a/docs/wayflowcore/source/core/code_examples/howto_connect_to_oracle_database.py
+++ b/docs/wayflowcore/source/core/code_examples/howto_connect_to_oracle_database.py
@@ -1,0 +1,258 @@
+# Copyright © 2025 Oracle and/or its affiliates.
+#
+# This software is under the Apache License 2.0
+# (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
+# (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
+# isort:skip_file
+# fmt: off
+# mypy: ignore-errors
+
+# docs-title: WayFlow Code Example - How to Connect To Oracle Database
+
+import os  # docs-skiprow
+import sys  # docs-skiprow
+
+
+def _env_cfg():  # docs-skiprow
+    mtls_vars = (  # docs-skiprow
+        "ADB_CONFIG_DIR",  # docs-skiprow
+        "ADB_WALLET_DIR",  # docs-skiprow
+        "ADB_WALLET_SECRET",  # docs-skiprow
+        "ADB_DB_USER",  # docs-skiprow
+        "ADB_DB_PASSWORD",  # docs-skiprow
+        "ADB_DSN",  # docs-skiprow
+    )  # docs-skiprow
+    tls_vars = ("ADB_DB_USER", "ADB_DB_PASSWORD", "ADB_DSN")  # docs-skiprow
+    if all(v in os.environ for v in mtls_vars):  # docs-skiprow
+        return MTlsOracleDatabaseConnectionConfig(  # docs-skiprow
+            config_dir=os.environ["ADB_CONFIG_DIR"],  # docs-skiprow
+            wallet_location=os.environ["ADB_WALLET_DIR"],  # docs-skiprow
+            wallet_password=os.environ["ADB_WALLET_SECRET"],  # docs-skiprow
+            user=os.environ["ADB_DB_USER"],  # docs-skiprow
+            password=os.environ["ADB_DB_PASSWORD"],  # docs-skiprow
+            dsn=os.environ["ADB_DSN"],  # docs-skiprow
+            id="oracle_datastore_connection_config",  # docs-skiprow
+        )  # docs-skiprow
+    if all(v in os.environ for v in tls_vars):  # docs-skiprow
+        return TlsOracleDatabaseConnectionConfig(  # docs-skiprow
+            user=os.environ["ADB_DB_USER"],  # docs-skiprow
+            password=os.environ["ADB_DB_PASSWORD"],  # docs-skiprow
+            dsn=os.environ["ADB_DSN"],  # docs-skiprow
+            id="oracle_datastore_connection_config",  # docs-skiprow
+        )  # docs-skiprow
+    print("Required OracleDB environment variables not found; exiting.")  # docs-skiprow
+    sys.exit(0)  # docs-skiprow
+
+from wayflowcore.models.llmmodelfactory import LlmModelFactory  # docs-skiprow
+model_cfg = {  # docs-skiprow
+    "model_type": "vllm",  # docs-skiprow
+    "host_port": "VLLM_HOST_PORT",  # docs-skiprow
+    "model_id": "/storage/models/Llama-3.1-70B-Instruct",  # docs-skiprow
+}  # docs-skiprow
+# .. start-##_Define_the_llm
+from wayflowcore.models import VllmModel
+
+llm = VllmModel(
+    model_id="LLAMA_MODEL_ID",
+    host_port="LLAMA_API_URL",
+)
+# .. end-##_Define_the_llm
+(llm,) = _update_globals(["llm_small"])  # docs-skiprow
+# .. start-##_imports:
+from textwrap import dedent
+
+
+from wayflowcore.controlconnection import ControlFlowEdge
+from wayflowcore.dataconnection import DataFlowEdge
+
+from wayflowcore.datastore import (
+    Entity,
+    MTlsOracleDatabaseConnectionConfig,
+    OracleDatabaseDatastore,
+    TlsOracleDatabaseConnectionConfig,
+)
+from wayflowcore.datastore.entity import nullable
+from wayflowcore.flow import Flow
+from wayflowcore.property import (
+    FloatProperty,
+    IntegerProperty,
+    ObjectProperty,
+    StringProperty,
+)
+from wayflowcore.steps import OutputMessageStep, PromptExecutionStep
+from wayflowcore.steps.datastoresteps import DatastoreQueryStep
+# .. end-##_Imports:
+# .. start-##_TLS_Connection:
+connection_config = TlsOracleDatabaseConnectionConfig(
+    user="<db user>",  # Replace with your DB user
+    password="<db password>",  # Replace with your DB password  # nosec: this is just a placeholder
+    dsn="<db connection string>",  # e.g. "(description=(retry_count=2)..."
+    # This is optional, but helpful to re-configure credentials when loading the AgentSpec config for this object
+    id="oracle_datastore_connection_config",
+)
+# .. end-##_TLS_Connection
+# .. start-##_mTLS_Connection:
+from wayflowcore.datastore import MTlsOracleDatabaseConnectionConfig
+
+connection_config = MTlsOracleDatabaseConnectionConfig(
+    config_dir="./oracle-wallet",
+    dsn="<dbname>",  # Entry in tnsnames.ora
+    wallet_location="./oracle-wallet",
+    wallet_password="<your wallet password>",  # Replace with your wallet password  # nosec: this is just a placeholder
+    user="<db user>",  # Replace with your DB user
+    password="<db password>",  # Replace with your DB password  # nosec: this is just a placeholder
+    # This is optional, but helpful to re-configure credentials when loading the AgentSpec config for this object
+    id="oracle_datastore_connection_config",
+)
+# .. end-##_mTLS_Connection
+connection_config = _env_cfg()  # docs-skiprow
+connection = connection_config.get_connection()  # docs-skiprow
+connection.cursor().execute("DROP TABLE IF EXISTS products")  # docs-skiprow
+connection.close() # docs-skiprow
+# Datastore and Entity definitions
+# .. start-##_Schema
+connection = connection_config.get_connection()
+
+table_definition = """CREATE TABLE products (
+    ID NUMBER PRIMARY KEY,
+    title VARCHAR2(255) NOT NULL,
+    description VARCHAR2(255) NOT NULL,
+    price NUMBER NOT NULL,
+    category VARCHAR(255) DEFAULT NULL,
+    external_system_id NUMBER DEFAULT NULL
+)"""
+
+connection.cursor().execute(table_definition)
+connection.close()
+
+product = Entity(
+    properties={
+        "ID": IntegerProperty(description="Unique product identifier"),
+        # Descriptions can be helpful if an LLM needs to fill these fields,
+        # or generally disambiguate non-obvious property names
+        "title": StringProperty(description="Brief summary of the product"),
+        "description": StringProperty(),
+        "price": FloatProperty(default_value=0.1),
+        # Use nullable to define optional properties
+        "category": nullable(StringProperty()),
+    },
+)
+
+datastore = OracleDatabaseDatastore(
+    schema={"products": product}, connection_config=connection_config
+)
+
+dummy_data = [
+    {
+        "ID": 0,
+        "title": "Broccoli",
+        "description": "Healthy and delicious cruciferous vegetable!",
+        "price": 1.5,
+        "category": "Produce",
+    },
+    {
+        "ID": 1,
+        "title": "Oranges",
+        "description": "Vitamin C-filled cirus fruits",
+        "price": 1.8,
+        "category": "Produce",
+    },
+    {
+        "ID": 2,
+        "title": "Shampoo",
+        "description": "Shiny smooth hair in just 10 applications!",
+        "price": 4.5,
+        "category": "Personal hygiene",
+    },
+    {
+        "ID": 3,
+        "title": "Crushed ice",
+        "description": "Cool any drink in seconds!",
+        "price": 4.5,
+        "category": "Food",
+    },
+]
+
+# Create supports both bulk-creation, as well as single element creation
+datastore.create(collection_name="products", entities=dummy_data)
+# .. end-##_Schema
+# .. start-##_Create_Datastore_step_and_flow
+datastore_query_step = DatastoreQueryStep(
+    datastore,
+    "SELECT title, description FROM products WHERE category = :product_category",
+    name="product_selection_step",
+    input_descriptors=[
+        ObjectProperty("bind_variables", properties={"product_category": StringProperty("")})
+    ],
+)
+
+detect_issues_prompt_template = dedent(
+    """You are an inventory assistant.
+
+    Your task:
+        - Summarize potential inconstencies across descriptions of products in the same category.
+          For example, identify typos and hightlight improvement opportunities
+    Important:
+        - Be helpful and concise in your messages
+
+    Here are the product description:
+    {{ products }}
+    """
+)
+
+llm_issue_detection_step = PromptExecutionStep(
+    prompt_template=detect_issues_prompt_template,
+    llm=llm,
+)
+
+user_output_step = OutputMessageStep(
+    message_template="The following issues have been identified: {{ issues }}",
+)
+
+assistant = Flow(
+    begin_step=datastore_query_step,
+    control_flow_edges=[
+        ControlFlowEdge(
+            source_step=datastore_query_step, destination_step=llm_issue_detection_step
+        ),
+        ControlFlowEdge(source_step=llm_issue_detection_step, destination_step=user_output_step),
+        ControlFlowEdge(source_step=user_output_step, destination_step=None),
+    ],
+    data_flow_edges=[
+        DataFlowEdge(
+            datastore_query_step, DatastoreQueryStep.RESULT, llm_issue_detection_step, "products"
+        ),
+        DataFlowEdge(
+            llm_issue_detection_step, PromptExecutionStep.OUTPUT, user_output_step, "issues"
+        ),
+    ],
+)
+# .. end-##_Create_Datastore_step_and_flow
+# .. start-##_Execute_flow
+conversation = assistant.start_conversation({"bind_variables": {"product_category": "Produce"}})
+conversation.execute()
+print(conversation.get_last_message().content)
+# .. end-##_Execute_flow
+# .. start-##_Export_config_to_Agent_Spec
+from wayflowcore.agentspec import AgentSpecExporter
+
+serialized_flow = AgentSpecExporter().to_json(assistant)
+# .. end-##_Export_config_to_Agent_Spec
+# .. start-##_Provide_sensitive_information_when_loading_the_Agent_Spec_config
+component_registry = {
+    # We map the ID of the sensitive fields in the connection config to their values
+    "oracle_datastore_connection_config.user": "<db user>",  # Replace with your DB user
+    "oracle_datastore_connection_config.password": "<db password>",  # Replace with your DB password  # nosec: this is just a placeholder
+    "oracle_datastore_connection_config.dsn": "<db connection string>",  # e.g. "(description=(retry_count=2)..."
+}
+# .. end-##_Provide_sensitive_information_when_loading_the_Agent_Spec_config
+component_registry = {
+    "oracle_datastore_connection_config.user": os.environ["ADB_DB_USER"],  # docs-skiprow
+    "oracle_datastore_connection_config.password": os.environ["ADB_DB_PASSWORD"],  # docs-skiprow
+    "oracle_datastore_connection_config.dsn": os.environ["ADB_DSN"],  # docs-skiprow
+}
+# .. start-##_Load_Agent_Spec_config
+from wayflowcore.agentspec import AgentSpecLoader
+
+agent = AgentSpecLoader().load_json(serialized_flow, components_registry=component_registry)
+# .. end-##_Load_Agent_Spec_config

--- a/docs/wayflowcore/source/core/code_examples/howto_datastores.py
+++ b/docs/wayflowcore/source/core/code_examples/howto_datastores.py
@@ -264,7 +264,7 @@ delete_product_flow = Flow.from_steps(
     description="Delete a product in the data source by its title.",
 )
 # .. end-##_Create_agent_flows
-# .. start-##_Create_agent
+# .. start-##_Create_the_agent
 agent = Agent(
     llm=llm,
     flows=[
@@ -276,7 +276,7 @@ agent = Agent(
     ],
     custom_instruction=AGENT_PROMPT,
 )
-# .. end-##_Create_agent
+# .. end-##_Create_the_agent
 # .. start-##_Export_config_to_Agent_Spec
 from wayflowcore.agentspec import AgentSpecExporter
 

--- a/docs/wayflowcore/source/core/config_examples/howto_connect_to_oracle_database.json
+++ b/docs/wayflowcore/source/core/config_examples/howto_connect_to_oracle_database.json
@@ -1,0 +1,497 @@
+{
+    "component_type": "Flow",
+    "id": "e1ce33a4-df88-4652-9714-6b51fea8871b",
+    "name": "flow_2b8b504d__auto",
+    "description": "",
+    "metadata": {
+        "__metadata_info__": {}
+    },
+    "inputs": [
+        {
+            "type": "object",
+            "properties": {
+                "product_category": {
+                    "type": "string"
+                }
+            },
+            "title": "bind_variables"
+        }
+    ],
+    "outputs": [
+        {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": {},
+                "key_type": {
+                    "type": "string"
+                }
+            },
+            "title": "result"
+        },
+        {
+            "description": "the generated text",
+            "type": "string",
+            "title": "output"
+        },
+        {
+            "description": "the message added to the messages list",
+            "type": "string",
+            "title": "output_message"
+        }
+    ],
+    "start_node": {
+        "$component_ref": "9162d8ad-cf00-4fc2-bed7-a73ffed79b32"
+    },
+    "nodes": [
+        {
+            "$component_ref": "85190204-2604-4fd0-b94a-6b4eb8e37f4f"
+        },
+        {
+            "$component_ref": "309c4bda-986e-4fd6-82b8-a83a91168d8d"
+        },
+        {
+            "$component_ref": "9eab48d6-a51c-412e-a459-a7fd05283e1a"
+        },
+        {
+            "$component_ref": "9162d8ad-cf00-4fc2-bed7-a73ffed79b32"
+        },
+        {
+            "$component_ref": "992516a7-a3f8-4cac-ac0d-0b1cac4eb936"
+        }
+    ],
+    "control_flow_connections": [
+        {
+            "component_type": "ControlFlowEdge",
+            "id": "153fa298-b907-4453-84e4-7fa334fce680",
+            "name": "product_selection_step_to_step_PromptExecutionStep_8f995292__auto_control_flow_edge",
+            "description": null,
+            "metadata": {
+                "__metadata_info__": {}
+            },
+            "from_node": {
+                "$component_ref": "85190204-2604-4fd0-b94a-6b4eb8e37f4f"
+            },
+            "from_branch": null,
+            "to_node": {
+                "$component_ref": "309c4bda-986e-4fd6-82b8-a83a91168d8d"
+            }
+        },
+        {
+            "component_type": "ControlFlowEdge",
+            "id": "bbb9d505-4aa6-4b58-8e8d-d50b1f4cc659",
+            "name": "step_PromptExecutionStep_8f995292__auto_to_step_OutputMessageStep_2c68bdae__auto_control_flow_edge",
+            "description": null,
+            "metadata": {
+                "__metadata_info__": {}
+            },
+            "from_node": {
+                "$component_ref": "309c4bda-986e-4fd6-82b8-a83a91168d8d"
+            },
+            "from_branch": null,
+            "to_node": {
+                "$component_ref": "9eab48d6-a51c-412e-a459-a7fd05283e1a"
+            }
+        },
+        {
+            "component_type": "ControlFlowEdge",
+            "id": "8c4158f0-f48e-4a7b-8686-999efb70b7cb",
+            "name": "__StartStep___to_product_selection_step_control_flow_edge",
+            "description": null,
+            "metadata": {
+                "__metadata_info__": {}
+            },
+            "from_node": {
+                "$component_ref": "9162d8ad-cf00-4fc2-bed7-a73ffed79b32"
+            },
+            "from_branch": null,
+            "to_node": {
+                "$component_ref": "85190204-2604-4fd0-b94a-6b4eb8e37f4f"
+            }
+        },
+        {
+            "component_type": "ControlFlowEdge",
+            "id": "05d5f99c-be1a-4f70-b0e2-4e85331016e1",
+            "name": "step_OutputMessageStep_2c68bdae__auto_to_None End node_control_flow_edge",
+            "description": null,
+            "metadata": {},
+            "from_node": {
+                "$component_ref": "9eab48d6-a51c-412e-a459-a7fd05283e1a"
+            },
+            "from_branch": null,
+            "to_node": {
+                "$component_ref": "992516a7-a3f8-4cac-ac0d-0b1cac4eb936"
+            }
+        }
+    ],
+    "data_flow_connections": [
+        {
+            "component_type": "DataFlowEdge",
+            "id": "b34e1582-9c08-4ad2-871b-628edf98a0ee",
+            "name": "product_selection_step_result_to_step_PromptExecutionStep_8f995292__auto_products_data_flow_edge",
+            "description": null,
+            "metadata": {
+                "__metadata_info__": {}
+            },
+            "source_node": {
+                "$component_ref": "85190204-2604-4fd0-b94a-6b4eb8e37f4f"
+            },
+            "source_output": "result",
+            "destination_node": {
+                "$component_ref": "309c4bda-986e-4fd6-82b8-a83a91168d8d"
+            },
+            "destination_input": "products"
+        },
+        {
+            "component_type": "DataFlowEdge",
+            "id": "d29d24f2-d0d1-469f-9ab4-fa12af5e76ee",
+            "name": "step_PromptExecutionStep_8f995292__auto_output_to_step_OutputMessageStep_2c68bdae__auto_issues_data_flow_edge",
+            "description": null,
+            "metadata": {
+                "__metadata_info__": {}
+            },
+            "source_node": {
+                "$component_ref": "309c4bda-986e-4fd6-82b8-a83a91168d8d"
+            },
+            "source_output": "output",
+            "destination_node": {
+                "$component_ref": "9eab48d6-a51c-412e-a459-a7fd05283e1a"
+            },
+            "destination_input": "issues"
+        },
+        {
+            "component_type": "DataFlowEdge",
+            "id": "bc7a1760-8c23-4d0b-a985-b5b2cc14a90d",
+            "name": "__StartStep___bind_variables_to_product_selection_step_bind_variables_data_flow_edge",
+            "description": null,
+            "metadata": {
+                "__metadata_info__": {}
+            },
+            "source_node": {
+                "$component_ref": "9162d8ad-cf00-4fc2-bed7-a73ffed79b32"
+            },
+            "source_output": "bind_variables",
+            "destination_node": {
+                "$component_ref": "85190204-2604-4fd0-b94a-6b4eb8e37f4f"
+            },
+            "destination_input": "bind_variables"
+        },
+        {
+            "component_type": "DataFlowEdge",
+            "id": "b3b92de4-10df-4abf-a9b0-149079c46408",
+            "name": "product_selection_step_result_to_None End node_result_data_flow_edge",
+            "description": null,
+            "metadata": {},
+            "source_node": {
+                "$component_ref": "85190204-2604-4fd0-b94a-6b4eb8e37f4f"
+            },
+            "source_output": "result",
+            "destination_node": {
+                "$component_ref": "992516a7-a3f8-4cac-ac0d-0b1cac4eb936"
+            },
+            "destination_input": "result"
+        },
+        {
+            "component_type": "DataFlowEdge",
+            "id": "fa6df9aa-3e40-4923-a1d4-58cd7428c588",
+            "name": "step_PromptExecutionStep_8f995292__auto_output_to_None End node_output_data_flow_edge",
+            "description": null,
+            "metadata": {},
+            "source_node": {
+                "$component_ref": "309c4bda-986e-4fd6-82b8-a83a91168d8d"
+            },
+            "source_output": "output",
+            "destination_node": {
+                "$component_ref": "992516a7-a3f8-4cac-ac0d-0b1cac4eb936"
+            },
+            "destination_input": "output"
+        },
+        {
+            "component_type": "DataFlowEdge",
+            "id": "aa996728-8289-48d2-a7b0-004d371b2d64",
+            "name": "step_OutputMessageStep_2c68bdae__auto_output_message_to_None End node_output_message_data_flow_edge",
+            "description": null,
+            "metadata": {},
+            "source_node": {
+                "$component_ref": "9eab48d6-a51c-412e-a459-a7fd05283e1a"
+            },
+            "source_output": "output_message",
+            "destination_node": {
+                "$component_ref": "992516a7-a3f8-4cac-ac0d-0b1cac4eb936"
+            },
+            "destination_input": "output_message"
+        }
+    ],
+    "$referenced_components": {
+        "9162d8ad-cf00-4fc2-bed7-a73ffed79b32": {
+            "component_type": "StartNode",
+            "id": "9162d8ad-cf00-4fc2-bed7-a73ffed79b32",
+            "name": "__StartStep__",
+            "description": "",
+            "metadata": {
+                "__metadata_info__": {}
+            },
+            "inputs": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "product_category": {
+                            "type": "string"
+                        }
+                    },
+                    "title": "bind_variables"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "product_category": {
+                            "type": "string"
+                        }
+                    },
+                    "title": "bind_variables"
+                }
+            ],
+            "branches": [
+                "next"
+            ]
+        },
+        "85190204-2604-4fd0-b94a-6b4eb8e37f4f": {
+            "component_type": "PluginDatastoreQueryNode",
+            "id": "85190204-2604-4fd0-b94a-6b4eb8e37f4f",
+            "name": "product_selection_step",
+            "description": "",
+            "metadata": {
+                "__metadata_info__": {}
+            },
+            "inputs": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "product_category": {
+                            "type": "string"
+                        }
+                    },
+                    "title": "bind_variables"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": {},
+                        "key_type": {
+                            "type": "string"
+                        }
+                    },
+                    "title": "result"
+                }
+            ],
+            "branches": [
+                "next"
+            ],
+            "input_mapping": {},
+            "output_mapping": {},
+            "datastore": {
+                "component_type": "PluginOracleDatabaseDatastore",
+                "id": "2515997a-1dbf-47cb-9dfb-d1dd2dca1cee",
+                "name": "PluginOracleDatabaseDatastore",
+                "description": null,
+                "metadata": {},
+                "datastore_schema": {
+                    "products": {
+                        "description": "",
+                        "title": "",
+                        "properties": {
+                            "description": {
+                                "type": "string"
+                            },
+                            "ID": {
+                                "description": "Unique product identifier",
+                                "type": "integer"
+                            },
+                            "title": {
+                                "description": "Brief summary of the product",
+                                "type": "string"
+                            },
+                            "price": {
+                                "type": "number",
+                                "default": 0.1
+                            },
+                            "category": {
+                                "anyOf": [
+                                    {
+                                        "type": "null"
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ],
+                                "default": null
+                            }
+                        }
+                    }
+                },
+                "connection_config": {
+                    "component_type": "PluginTlsOracleDatabaseConnectionConfig",
+                    "id": "13f2fc32-f442-49fb-b7cc-142a240bb8bc",
+                    "name": "PluginTlsOracleDatabaseConnectionConfig",
+                    "description": null,
+                    "metadata": {},
+                    "user": {
+                        "$component_ref": "13f2fc32-f442-49fb-b7cc-142a240bb8bc.user"
+                    },
+                    "password": {
+                        "$component_ref": "13f2fc32-f442-49fb-b7cc-142a240bb8bc.password"
+                    },
+                    "dsn": {
+                        "$component_ref": "13f2fc32-f442-49fb-b7cc-142a240bb8bc.dsn"
+                    },
+                    "config_dir": null,
+                    "component_plugin_name": "DatastorePlugin",
+                    "component_plugin_version": "26.1.0.dev0"
+                },
+                "component_plugin_name": "DatastorePlugin",
+                "component_plugin_version": "26.1.0.dev0"
+            },
+            "query": "SELECT title, description FROM products WHERE category = :product_category",
+            "RESULT": "result",
+            "component_plugin_name": "DatastorePlugin",
+            "component_plugin_version": "26.1.0.dev0"
+        },
+        "309c4bda-986e-4fd6-82b8-a83a91168d8d": {
+            "component_type": "LlmNode",
+            "id": "309c4bda-986e-4fd6-82b8-a83a91168d8d",
+            "name": "step_PromptExecutionStep_8f995292__auto",
+            "description": "",
+            "metadata": {
+                "__metadata_info__": {}
+            },
+            "inputs": [
+                {
+                    "description": "\"products\" input variable for the template",
+                    "type": "string",
+                    "title": "products"
+                }
+            ],
+            "outputs": [
+                {
+                    "description": "the generated text",
+                    "type": "string",
+                    "title": "output"
+                }
+            ],
+            "branches": [
+                "next"
+            ],
+            "llm_config": {
+                "component_type": "VllmConfig",
+                "id": "115a6849-0e1b-4b1b-8bd2-be872c9bc64b",
+                "name": "llm_41795d1f__auto",
+                "description": null,
+                "metadata": {
+                    "__metadata_info__": {}
+                },
+                "default_generation_parameters": null,
+                "url": "LLAMA_API_URL",
+                "model_id": "LLAMA_MODEL_ID",
+                "api_type": "chat_completions",
+                "api_key": null
+            },
+            "prompt_template": "You are an inventory assistant.\n\n    Your task:\n        - Summarize potential inconstencies across descriptions of products in the same category.\n          For example, identify typos and hightlight improvement opportunities\n    Important:\n        - Be helpful and concise in your messages\n\n    Here are the product description:\n    {{ products }}\n"
+        },
+        "9eab48d6-a51c-412e-a459-a7fd05283e1a": {
+            "component_type": "PluginOutputMessageNode",
+            "id": "9eab48d6-a51c-412e-a459-a7fd05283e1a",
+            "name": "step_OutputMessageStep_2c68bdae__auto",
+            "description": "",
+            "metadata": {
+                "__metadata_info__": {}
+            },
+            "inputs": [
+                {
+                    "description": "\"issues\" input variable for the template",
+                    "type": "string",
+                    "title": "issues"
+                }
+            ],
+            "outputs": [
+                {
+                    "description": "the message added to the messages list",
+                    "type": "string",
+                    "title": "output_message"
+                }
+            ],
+            "branches": [
+                "next"
+            ],
+            "message": "The following issues have been identified: {{ issues }}",
+            "input_mapping": {},
+            "output_mapping": {},
+            "message_type": "AGENT",
+            "rephrase": false,
+            "llm_config": null,
+            "expose_message_as_output": true,
+            "component_plugin_name": "NodesPlugin",
+            "component_plugin_version": "26.1.0.dev0"
+        },
+        "992516a7-a3f8-4cac-ac0d-0b1cac4eb936": {
+            "component_type": "EndNode",
+            "id": "992516a7-a3f8-4cac-ac0d-0b1cac4eb936",
+            "name": "None End node",
+            "description": "End node representing all transitions to None in the WayFlow flow",
+            "metadata": {},
+            "inputs": [
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": {},
+                        "key_type": {
+                            "type": "string"
+                        }
+                    },
+                    "title": "result"
+                },
+                {
+                    "description": "the generated text",
+                    "type": "string",
+                    "title": "output"
+                },
+                {
+                    "description": "the message added to the messages list",
+                    "type": "string",
+                    "title": "output_message"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": {},
+                        "key_type": {
+                            "type": "string"
+                        }
+                    },
+                    "title": "result"
+                },
+                {
+                    "description": "the generated text",
+                    "type": "string",
+                    "title": "output"
+                },
+                {
+                    "description": "the message added to the messages list",
+                    "type": "string",
+                    "title": "output_message"
+                }
+            ],
+            "branches": [],
+            "branch_name": "next"
+        }
+    },
+    "agentspec_version": "26.1.0"
+}

--- a/docs/wayflowcore/source/core/config_examples/howto_connect_to_oracle_database.yaml
+++ b/docs/wayflowcore/source/core/config_examples/howto_connect_to_oracle_database.yaml
@@ -1,0 +1,340 @@
+component_type: Flow
+id: e1ce33a4-df88-4652-9714-6b51fea8871b
+name: flow_2b8b504d__auto
+description: ''
+metadata:
+  __metadata_info__: {}
+inputs:
+- type: object
+  properties:
+    product_category:
+      type: string
+  title: bind_variables
+outputs:
+- type: array
+  items:
+    type: object
+    additionalProperties: {}
+    key_type:
+      type: string
+  title: result
+- description: the generated text
+  type: string
+  title: output
+- description: the message added to the messages list
+  type: string
+  title: output_message
+start_node:
+  $component_ref: 9162d8ad-cf00-4fc2-bed7-a73ffed79b32
+nodes:
+- $component_ref: 85190204-2604-4fd0-b94a-6b4eb8e37f4f
+- $component_ref: 309c4bda-986e-4fd6-82b8-a83a91168d8d
+- $component_ref: 9eab48d6-a51c-412e-a459-a7fd05283e1a
+- $component_ref: 9162d8ad-cf00-4fc2-bed7-a73ffed79b32
+- $component_ref: 9f7c1027-0ed4-480d-918b-22a74656a00f
+control_flow_connections:
+- component_type: ControlFlowEdge
+  id: 153fa298-b907-4453-84e4-7fa334fce680
+  name: product_selection_step_to_step_PromptExecutionStep_8f995292__auto_control_flow_edge
+  description: null
+  metadata:
+    __metadata_info__: {}
+  from_node:
+    $component_ref: 85190204-2604-4fd0-b94a-6b4eb8e37f4f
+  from_branch: null
+  to_node:
+    $component_ref: 309c4bda-986e-4fd6-82b8-a83a91168d8d
+- component_type: ControlFlowEdge
+  id: bbb9d505-4aa6-4b58-8e8d-d50b1f4cc659
+  name: step_PromptExecutionStep_8f995292__auto_to_step_OutputMessageStep_2c68bdae__auto_control_flow_edge
+  description: null
+  metadata:
+    __metadata_info__: {}
+  from_node:
+    $component_ref: 309c4bda-986e-4fd6-82b8-a83a91168d8d
+  from_branch: null
+  to_node:
+    $component_ref: 9eab48d6-a51c-412e-a459-a7fd05283e1a
+- component_type: ControlFlowEdge
+  id: 8c4158f0-f48e-4a7b-8686-999efb70b7cb
+  name: __StartStep___to_product_selection_step_control_flow_edge
+  description: null
+  metadata:
+    __metadata_info__: {}
+  from_node:
+    $component_ref: 9162d8ad-cf00-4fc2-bed7-a73ffed79b32
+  from_branch: null
+  to_node:
+    $component_ref: 85190204-2604-4fd0-b94a-6b4eb8e37f4f
+- component_type: ControlFlowEdge
+  id: 0127ead7-7e68-477a-847f-dc037dc0bcac
+  name: step_OutputMessageStep_2c68bdae__auto_to_None End node_control_flow_edge
+  description: null
+  metadata: {}
+  from_node:
+    $component_ref: 9eab48d6-a51c-412e-a459-a7fd05283e1a
+  from_branch: null
+  to_node:
+    $component_ref: 9f7c1027-0ed4-480d-918b-22a74656a00f
+data_flow_connections:
+- component_type: DataFlowEdge
+  id: b34e1582-9c08-4ad2-871b-628edf98a0ee
+  name: product_selection_step_result_to_step_PromptExecutionStep_8f995292__auto_products_data_flow_edge
+  description: null
+  metadata:
+    __metadata_info__: {}
+  source_node:
+    $component_ref: 85190204-2604-4fd0-b94a-6b4eb8e37f4f
+  source_output: result
+  destination_node:
+    $component_ref: 309c4bda-986e-4fd6-82b8-a83a91168d8d
+  destination_input: products
+- component_type: DataFlowEdge
+  id: d29d24f2-d0d1-469f-9ab4-fa12af5e76ee
+  name: step_PromptExecutionStep_8f995292__auto_output_to_step_OutputMessageStep_2c68bdae__auto_issues_data_flow_edge
+  description: null
+  metadata:
+    __metadata_info__: {}
+  source_node:
+    $component_ref: 309c4bda-986e-4fd6-82b8-a83a91168d8d
+  source_output: output
+  destination_node:
+    $component_ref: 9eab48d6-a51c-412e-a459-a7fd05283e1a
+  destination_input: issues
+- component_type: DataFlowEdge
+  id: bc7a1760-8c23-4d0b-a985-b5b2cc14a90d
+  name: __StartStep___bind_variables_to_product_selection_step_bind_variables_data_flow_edge
+  description: null
+  metadata:
+    __metadata_info__: {}
+  source_node:
+    $component_ref: 9162d8ad-cf00-4fc2-bed7-a73ffed79b32
+  source_output: bind_variables
+  destination_node:
+    $component_ref: 85190204-2604-4fd0-b94a-6b4eb8e37f4f
+  destination_input: bind_variables
+- component_type: DataFlowEdge
+  id: 973bd0b2-b264-458f-88bd-269f39e96e4d
+  name: product_selection_step_result_to_None End node_result_data_flow_edge
+  description: null
+  metadata: {}
+  source_node:
+    $component_ref: 85190204-2604-4fd0-b94a-6b4eb8e37f4f
+  source_output: result
+  destination_node:
+    $component_ref: 9f7c1027-0ed4-480d-918b-22a74656a00f
+  destination_input: result
+- component_type: DataFlowEdge
+  id: 8238696f-31f2-4f4e-9b5c-02ed64e93d15
+  name: step_PromptExecutionStep_8f995292__auto_output_to_None End node_output_data_flow_edge
+  description: null
+  metadata: {}
+  source_node:
+    $component_ref: 309c4bda-986e-4fd6-82b8-a83a91168d8d
+  source_output: output
+  destination_node:
+    $component_ref: 9f7c1027-0ed4-480d-918b-22a74656a00f
+  destination_input: output
+- component_type: DataFlowEdge
+  id: ee8f92a3-f52c-4f04-aceb-0d1c9666eafc
+  name: step_OutputMessageStep_2c68bdae__auto_output_message_to_None End node_output_message_data_flow_edge
+  description: null
+  metadata: {}
+  source_node:
+    $component_ref: 9eab48d6-a51c-412e-a459-a7fd05283e1a
+  source_output: output_message
+  destination_node:
+    $component_ref: 9f7c1027-0ed4-480d-918b-22a74656a00f
+  destination_input: output_message
+$referenced_components:
+  9162d8ad-cf00-4fc2-bed7-a73ffed79b32:
+    component_type: StartNode
+    id: 9162d8ad-cf00-4fc2-bed7-a73ffed79b32
+    name: __StartStep__
+    description: ''
+    metadata:
+      __metadata_info__: {}
+    inputs:
+    - type: object
+      properties:
+        product_category:
+          type: string
+      title: bind_variables
+    outputs:
+    - type: object
+      properties:
+        product_category:
+          type: string
+      title: bind_variables
+    branches:
+    - next
+  85190204-2604-4fd0-b94a-6b4eb8e37f4f:
+    component_type: PluginDatastoreQueryNode
+    id: 85190204-2604-4fd0-b94a-6b4eb8e37f4f
+    name: product_selection_step
+    description: ''
+    metadata:
+      __metadata_info__: {}
+    inputs:
+    - type: object
+      properties:
+        product_category:
+          type: string
+      title: bind_variables
+    outputs:
+    - type: array
+      items:
+        type: object
+        additionalProperties: {}
+        key_type:
+          type: string
+      title: result
+    branches:
+    - next
+    input_mapping: {}
+    output_mapping: {}
+    datastore:
+      component_type: PluginOracleDatabaseDatastore
+      id: 2515997a-1dbf-47cb-9dfb-d1dd2dca1cee
+      name: PluginOracleDatabaseDatastore
+      description: null
+      metadata: {}
+      datastore_schema:
+        products:
+          description: ''
+          title: ''
+          properties:
+            description:
+              type: string
+            ID:
+              description: Unique product identifier
+              type: integer
+            title:
+              description: Brief summary of the product
+              type: string
+            price:
+              type: number
+              default: 0.1
+            category:
+              anyOf:
+              - type: 'null'
+              - type: string
+              default: null
+      connection_config:
+        component_type: PluginTlsOracleDatabaseConnectionConfig
+        id: 13f2fc32-f442-49fb-b7cc-142a240bb8bc
+        name: PluginTlsOracleDatabaseConnectionConfig
+        description: null
+        metadata: {}
+        user:
+          $component_ref: 13f2fc32-f442-49fb-b7cc-142a240bb8bc.user
+        password:
+          $component_ref: 13f2fc32-f442-49fb-b7cc-142a240bb8bc.password
+        dsn:
+          $component_ref: 13f2fc32-f442-49fb-b7cc-142a240bb8bc.dsn
+        config_dir: null
+        component_plugin_name: DatastorePlugin
+        component_plugin_version: 26.1.0.dev0
+      component_plugin_name: DatastorePlugin
+      component_plugin_version: 26.1.0.dev0
+    query: SELECT title, description FROM products WHERE category = :product_category
+    RESULT: result
+    component_plugin_name: DatastorePlugin
+    component_plugin_version: 26.1.0.dev0
+  309c4bda-986e-4fd6-82b8-a83a91168d8d:
+    component_type: LlmNode
+    id: 309c4bda-986e-4fd6-82b8-a83a91168d8d
+    name: step_PromptExecutionStep_8f995292__auto
+    description: ''
+    metadata:
+      __metadata_info__: {}
+    inputs:
+    - description: '"products" input variable for the template'
+      type: string
+      title: products
+    outputs:
+    - description: the generated text
+      type: string
+      title: output
+    branches:
+    - next
+    llm_config:
+      component_type: VllmConfig
+      id: 115a6849-0e1b-4b1b-8bd2-be872c9bc64b
+      name: llm_41795d1f__auto
+      description: null
+      metadata:
+        __metadata_info__: {}
+      default_generation_parameters: null
+      url: LLAMA_API_URL
+      model_id: LLAMA_MODEL_ID
+      api_type: chat_completions
+      api_key: null
+    prompt_template: "You are an inventory assistant.\n\n    Your task:\n        -\
+      \ Summarize potential inconstencies across descriptions of products in the same\
+      \ category.\n          For example, identify typos and hightlight improvement\
+      \ opportunities\n    Important:\n        - Be helpful and concise in your messages\n\
+      \n    Here are the product description:\n    {{ products }}\n"
+  9eab48d6-a51c-412e-a459-a7fd05283e1a:
+    component_type: PluginOutputMessageNode
+    id: 9eab48d6-a51c-412e-a459-a7fd05283e1a
+    name: step_OutputMessageStep_2c68bdae__auto
+    description: ''
+    metadata:
+      __metadata_info__: {}
+    inputs:
+    - description: '"issues" input variable for the template'
+      type: string
+      title: issues
+    outputs:
+    - description: the message added to the messages list
+      type: string
+      title: output_message
+    branches:
+    - next
+    message: 'The following issues have been identified: {{ issues }}'
+    input_mapping: {}
+    output_mapping: {}
+    message_type: AGENT
+    rephrase: false
+    llm_config: null
+    expose_message_as_output: true
+    component_plugin_name: NodesPlugin
+    component_plugin_version: 26.1.0.dev0
+  9f7c1027-0ed4-480d-918b-22a74656a00f:
+    component_type: EndNode
+    id: 9f7c1027-0ed4-480d-918b-22a74656a00f
+    name: None End node
+    description: End node representing all transitions to None in the WayFlow flow
+    metadata: {}
+    inputs:
+    - type: array
+      items:
+        type: object
+        additionalProperties: {}
+        key_type:
+          type: string
+      title: result
+    - description: the generated text
+      type: string
+      title: output
+    - description: the message added to the messages list
+      type: string
+      title: output_message
+    outputs:
+    - type: array
+      items:
+        type: object
+        additionalProperties: {}
+        key_type:
+          type: string
+      title: result
+    - description: the generated text
+      type: string
+      title: output
+    - description: the message added to the messages list
+      type: string
+      title: output_message
+    branches: []
+    branch_name: next
+agentspec_version: 26.1.0

--- a/docs/wayflowcore/source/core/howtoguides/howto_datastores.rst
+++ b/docs/wayflowcore/source/core/howtoguides/howto_datastores.rst
@@ -10,11 +10,16 @@ How to Connect Assistants to Your Data
 
 .. grid:: 2
 
-    .. grid-item-card:: |python-icon| Download Python Script
-        :link: ../end_to_end_code_examples/howto_datastores.py
-        :link-alt: Datastores how-to script
+   .. grid-item-card:: |python-icon| Download In-Memory Script
+      :link: ../end_to_end_code_examples/howto_datastores.py
+      :link-alt: In-memory datastore how-to script
 
-        Python script/notebook for this guide.
+      Python script/notebook for the In-Memory Datastore example in this guide.
+   .. grid-item-card:: |python-icon| Download Oracle Database Script
+      :link: ../end_to_end_code_examples/howto_connect_to_oracle_database.py
+      :link-alt: Oracle Database datastore how-to script
+
+      Python script/notebook for Oracle Database Datastore  example in this guide.
 
 .. admonition:: Prerequisites
 
@@ -36,6 +41,8 @@ In this tutorial, you will:
 - **Use Datastores in Flows and Agents** to create two types of inventory management assistants.
 
 To ensure reproducibility of this tutorial, you will use an in-memory data source.
+Check out the section :ref:`Using Oracle Database Datastore <using-oracle-datastore>` to see how to configure an
+Oracle Database connection for persistent storage.
 
 Concepts shown in this guide
 ============================
@@ -51,10 +58,11 @@ Concepts shown in this guide
    robust and scalable persistence layer in Oracle Database.
 
    Note that there are a few key differences between an in-memory and a database ``Datastore``:
+
    - With database Datastores, all tables relevant to the assistant must already be created in the database prior to connecting to it.
    - You may choose to only model a subset of the tables available in the database via the :ref:`Entity <entity>` construct.
    - Database Datastores offer an additional ``query`` method (and the corresponding :ref:`DatastoreQueryStep <datastorequerystep>`),
-   that enables flexible execution of SQL queries that cannot be modelled by the ``list`` operation on the in-memory datastore
+      that enables flexible execution of SQL queries that cannot be modelled by the ``list`` operation on the in-memory datastore
 
 Datastores in Flows
 ===================
@@ -72,6 +80,8 @@ Import the required packages:
    :linenos:
    :start-after: .. start-##_Imports
    :end-before: .. end-##_Imports
+
+.. _llm-def:
 
 In this assistant, you need to use an LLM.
 WayFlow supports several LLM API providers.
@@ -203,13 +213,14 @@ Finally, create the inventory management agent by combining the LLM, the datasto
 .. literalinclude:: ../code_examples/howto_datastores.py
       :language: python
       :linenos:
-      :start-after: .. start-##_Create_agent
-      :end-before: .. end-##_Create_agent
+      :start-after: .. start-##_Create_the_agent
+      :end-before: .. end-##_Create_the_agent
 
 This agent can now respond to the user and perform actions on the data on their behalf.
 
 Refer to the :doc:`WayFlow Agents Tutorial <../tutorials/basic_agent>` to see how to run this Agent.
 
+.. _wayflow-export-load:
 
 Agent Spec Exporting/Loading
 ============================
@@ -265,6 +276,191 @@ You can then load the configuration back to an assistant using the ``AgentSpecLo
     See the list of available Agent Spec extension/plugin components in the :doc:`API Reference <../api/agentspec>`
 
 
+.. _using-oracle-datastore:
+
+Using Oracle Database Datastore
+===============================
+
+This guide mirrors the earlier **in-memory** demo, but leverages Oracle Database
+(Autonomous Database on OCI or an on-prem instance) for persistent storage.
+
+.. admonition:: Prerequisites
+   :class: tip
+
+   * An Oracle Database instance, reachable from your development machine
+   * Wallet files and/or database credentials for this instance
+   * A running LLM endpoint (the examples uses vLLM, but any provider works)
+
+Step 1. Configure the connection to the Database
+------------------------------------------------
+
+WayFlow supports two secure transport mechanisms for connecting to Oracle databases.
+
+When using **TLS** (one-way TLS) the database presents its certificate, the client verifies it,
+and the user authenticates with username and password.
+
+.. literalinclude:: ../code_examples/howto_connect_to_oracle_database.py
+   :language: python
+   :linenos:
+   :start-after: .. start-##_TLS_Connection
+   :end-before: .. end-##_TLS_Connection
+
+======================  =============================================================
+Parameter               Meaning
+----------------------  -------------------------------------------------------------
+``user``                Database username (e.g., ``ADMIN``).
+``password``            Password for ``user``.
+``dsn``                 Easy-connect string or TNS alias identifying the service.
+                        Example:
+                        ``adb.us-ashburn-1.oraclecloud.com:1522/xyz_high``
+======================  =============================================================
+
+When using **mTLS** (mutual TLS) both sides exchange certificates: the client proves its identity
+with a wallet (client cert + private key) in addition to the username and password.
+This gives stronger, certificate-based client authentication and is often required for
+Oracle Autonomous Database in "Require mTLS" mode.
+
+.. literalinclude:: ../code_examples/howto_connect_to_oracle_database.py
+   :language: python
+   :linenos:
+   :start-after: .. start-##_mTLS_Connection
+   :end-before: .. end-##_mTLS_Connection
+
+======================  =============================================================
+Parameter               Meaning
+----------------------  -------------------------------------------------------------
+``user``                Database username (e.g., ``ADMIN``).
+``password``            Password for ``user``.
+``dsn``                 Easy-connect string or TNS alias identifying the service.
+                        Example:
+                        ``adb.us-ashburn-1.oraclecloud.com:1522/xyz_high``
+``config_dir``          Directory containing ``sqlnet.ora`` / ``tnsnames.ora``.
+                        when you want to reference a
+                        TNS alias (e.g. ``<dbname>_high``) instead of a raw DSN.
+``wallet_location``     Path to the Oracle Wallet directory that contains
+                        ``cwallet.sso`` / ``ewallet.p12``.
+``wallet_password``     Password that protects the wallet’s private key.
+======================  =============================================================
+
+.. important::
+   Do **not** hard-code any database credentials or sensitive connection details directly in your code.
+   Please refer to our :doc:`Security Guidelines <../security>` for more information.
+
+Step 2. Define the data model and Datastore
+-------------------------------------------
+
+.. warning::
+   The following code snippet will create a new ``products`` table in the database.
+   Ensure you are using a throwaway schema with no other table named "products" when running this example.
+
+For this guide, we use the same data model from the in-memory example.
+It manages products in an inventory, so a single collection is sufficient.
+Datastores also support managing multiple database tables at the same time if needed.
+
+Entities map the relational schema to strongly-typed objects that Flows and
+Agents can validate at runtime.
+The key difference to the in-memory example is that we require the Entity of
+interest to be already defined as a table in the database.
+
+Note that, if you have some columns in the database that are not relevant to your assistant,
+you may simply omit them from the Entity definition (as is done in this example with the ``external_system_id``).
+However, it may not be possible for the datastore or assistant to create such entities if the omitted columns are required.
+
+.. literalinclude:: ../code_examples/howto_connect_to_oracle_database.py
+   :language: python
+   :linenos:
+   :start-after: .. start-##_Schema
+   :end-before:  .. end-##_Schema
+
+
+Step 3. Create datastore steps
+------------------------------
+
+Now that the Datastore is set up, create steps to perform different operations in the flow.
+In this guide, your assistant will identify inconsistencies in product descriptions of the same category.
+To do so, you will use the ``DatastoreQueryStep`` to fetch product information, and a ``PromptExecutionStep`` to identify the issues.
+
+In particular, the ``DatastoreQueryStep`` can be used with Database Datastores to execute developer-defined SQL queries.
+These queries can optionally be parametrized with bind variables.
+See the `bind variables guide on the python-oracledb documentation <https://python-oracledb.readthedocs.io/en/latest/user_guide/bind.html>`_ for more information.
+See also :ref:`the list of all available Datastore steps <datastoresteps>` for additional operations that can be performed with Oracle Database Datastores.
+
+
+.. literalinclude:: ../code_examples/howto_connect_to_oracle_database.py
+   :language: python
+   :linenos:
+   :start-after: .. start-##_Create_Datastore_step_and_flow
+   :end-before:  .. end-##_Create_Datastore_step_and_flow
+
+Finally, verify that the Flow works as expected:
+
+.. literalinclude:: ../code_examples/howto_connect_to_oracle_database.py
+      :language: python
+      :linenos:
+      :start-after: .. start-##_Execute_flow
+      :end-before: .. end-##_Execute_flow
+
+
+Agent Spec Exporting/Loading
+============================
+
+This flow can be exported to Agent Spec using the ``AgentSpecExporter`` as you have seen in the
+previous in-memory example, using the ``AgentSpecExporter``.
+
+.. literalinclude:: ../code_examples/howto_connect_to_oracle_database.py
+    :language: python
+    :start-after: .. start-##_Export_config_to_Agent_Spec
+    :end-before: .. end-##_Export_config_to_Agent_Spec
+
+
+Here is what the **Agent Spec representation will look like ↓**
+
+.. collapse:: Click here to see the assistant configuration.
+
+   .. tabs::
+
+      .. tab:: JSON
+
+         .. literalinclude:: ../config_examples/howto_connect_to_oracle_database.json
+            :language: json
+
+      .. tab:: YAML
+
+         .. literalinclude:: ../config_examples/howto_connect_to_oracle_database.yaml
+            :language: yaml
+
+
+.. warning::
+
+   The Oracle Database Connection Config objects contain several sensitive values
+   (like username, password, wallet location) that will not be serialized by the ``AgentSpecExporter``.
+   These will be serialized as references that must be resolved at loading time, by specifying the values
+   of these sensitive fields in the ``component_registry`` argument of the loader:
+
+   .. literalinclude:: ../code_examples/howto_connect_to_oracle_database.py
+      :language: python
+      :start-after: .. start-##_Provide_sensitive_information_when_loading_the_Agent_Spec_config
+      :end-before: .. end-##_Provide_sensitive_information_when_loading_the_Agent_Spec_config
+
+You can then load the configuration back to an assistant using the ``AgentSpecLoader``.
+
+.. literalinclude:: ../code_examples/howto_connect_to_oracle_database.py
+    :language: python
+    :start-after: .. start-##_Load_Agent_Spec_config
+    :end-before: .. end-##_Load_Agent_Spec_config
+
+.. note::
+
+    This guide uses the following extension/plugin Agent Spec components:
+
+    - ``PluginDatastoreQueryNode``
+    - ``PluginOracleDatabaseDatastore``
+    - ``PluginTlsOracleDatabaseConnectionConfig``
+    - ``PluginOutputMessageNode``
+
+    See the list of available Agent Spec extension/plugin components in the :doc:`API Reference <../api/agentspec>`
+
+
 Next steps
 ==========
 
@@ -277,8 +473,26 @@ Having learned how to connect WayFlow assistants to data sources, you may now pr
 Full code
 =========
 
-Click on the card at the :ref:`top of this page <top-howtodatastores>` to download the full code for this guide or copy the code below.
+In-memory datastore
+-------------------
 
-.. literalinclude:: ../end_to_end_code_examples/howto_datastores.py
-    :language: python
-    :linenos:
+Click on the card at the :ref:`top of this page <top-howtodatastores>`
+to download the full code for this guide or copy the code below.
+
+.. collapse:: Connecting Assistants to User Data (full code)
+
+    .. literalinclude:: ../end_to_end_code_examples/howto_datastores.py
+        :language: python
+        :linenos:
+
+Oracle Database datastore
+-------------------------
+
+Click on the card at the :ref:`top of this page <top-howtodatastores>`
+to download the full code for this guide, or copy the code below.
+
+.. collapse:: Connecting Assistants to Oracle Database (full code)
+
+    .. literalinclude:: ../end_to_end_code_examples/howto_connect_to_oracle_database.py
+        :language: python
+        :linenos:


### PR DESCRIPTION
This PR extends the Datastore how-to guide to include an example on how to use the Oracle Database Datastore, and highlights the key differences between in-memory and database datastores (e.g., query step and serialization of sensitive fields in Agent Spec).