### PR TITLE
[fix]: use a single line in the nosec_ignore file per nosec

### DIFF
--- a/wayflowcore/nosec_ignore.csv
+++ b/wayflowcore/nosec_ignore.csv
@@ -3,3 +3,6 @@ nosec0001,B105,the reported issue by pybandit that variables should not be named
 nosec0002,B105,the reported issue by pybandit that variables should not be named token is hard to comply with in this context as the variable refers to the token-based authentication method for the OCI service
 nosec0003,B110,finalizers must not raise; we ignore normal cleanup errors during shutdown/garbage collection on purpose
 nosec0004,B311,the reported issue by pybandit indicates use of non-cryptographic randomness; this randomness is only used to return a demo weather condition for tests
+nosec0005,B311,the reported issue by pybandit indicates use of non-cryptographic randomness; this randomness is only used to return a demo weather condition for tests
+nosec0006,B311,the reported issue by pybandit indicates use of non-cryptographic randomness; this randomness is only used to return a demo weather condition for tests
+nosec0007,B311,the reported issue by pybandit indicates use of non-cryptographic randomness; this randomness is only used to return a demo weather condition for tests

--- a/wayflowcore/tests/integration/steps/test_tool_execution_step.py
+++ b/wayflowcore/tests/integration/steps/test_tool_execution_step.py
@@ -61,7 +61,7 @@ def create_weather_server_tool():
         """
         return random.choice(
             ["sunny", "rainy"]
-        )  # nosec0004 # the reported issue by pybandit indicates use of non-cryptographic randomness; this randomness is only used to return a demo weather condition for tests
+        )  # nosec0007 # the reported issue by pybandit indicates use of non-cryptographic randomness; this randomness is only used to return a demo weather condition for tests
 
     return get_weather
 

--- a/wayflowcore/tests/integration/test_assistanttester.py
+++ b/wayflowcore/tests/integration/test_assistanttester.py
@@ -58,7 +58,7 @@ def get_weather_assistant(
             return "wintry"
         return random.choice(
             ["sunny", "cloudy", "windy"]
-        )  # nosec0004 # the reported issue by pybandit indicates use of non-cryptographic randomness; this randomness is only used to return a demo weather condition for tests
+        )  # nosec0005 # the reported issue by pybandit indicates use of non-cryptographic randomness; this randomness is only used to return a demo weather condition for tests
 
     @tool(description_mode="only_docstring")
     def get_largest_city(country: str) -> str:

--- a/wayflowcore/tests/integration/test_descriptors.py
+++ b/wayflowcore/tests/integration/test_descriptors.py
@@ -61,7 +61,7 @@ def get_weather(location: Annotated[str, "The location to get the weather from"]
     """Returns the weather in the provided location"""
     return random.choice(
         ["sunny", "rainy"]
-    )  # nosec0004 # the reported issue by pybandit indicates use of non-cryptographic randomness; this randomness is only used to return a demo weather condition for tests
+    )  # nosec0006 # the reported issue by pybandit indicates use of non-cryptographic randomness; this randomness is only used to return a demo weather condition for tests
 
 
 @pytest.fixture


### PR DESCRIPTION
Use a single line in the nosec_ignore file per nosec in the codebase