### PR TITLE
Fix agent ignoring tools backport

### DIFF
--- a/docs/wayflowcore/source/core/changelog.rst
+++ b/docs/wayflowcore/source/core/changelog.rst
@@ -21,6 +21,7 @@ Bug fixes
 
 * Fix: Gemini models with the OpenAiCompatible model now support native tool calling (#77)
 * Fix: MCP session persistence no longer collides when multiple MCP client transports (different servers/connections) are used within the same conversation.
+* Fix: Agent no longer ignores tool calls when the LLM attempts to both invoke a tool and respond directly to the user.
 
 
 WayFlow 26.1.0

--- a/wayflowcore/src/wayflowcore/executors/_agentexecutor.py
+++ b/wayflowcore/src/wayflowcore/executors/_agentexecutor.py
@@ -66,6 +66,12 @@ _SUBMIT_TOOL_NAME = "submit_result"
 _TALK_TO_USER_TOOL_NAME = "talk_to_user"
 _TALK_TO_USER_INPUT_PARAM = "text"
 
+# some tools cannot be handled at the same time as other tools
+# therefore are dropped if present in parallel tool calls
+_NON_PARALLEL_TOOL_NAMES = [
+    _TALK_TO_USER_TOOL_NAME,  # user should only be notified after all the tools have been run
+]
+
 EXIT_CONVERSATION_TOOL_NAME = "end_conversation"
 EXIT_CONVERSATION_TOOL_MESSAGE = "Conversation has been ended by the agent."
 EXIT_CONVERSATION_CONFIRMATION_MESSAGE = "You attempted to end the conversation. If the user indeed asked to exit, please call this tool again and do not reply anything else. You are a helpful assistant; do not annoy the user; do not ask them to confirm."
@@ -336,15 +342,14 @@ class AgentConversationExecutor(ConversationExecutor):
         if new_message.tool_requests is None or len(new_message.tool_requests) == 0:
             return True
 
-        # fix
-        talk_to_user_request = next(
-            (tr for tr in new_message.tool_requests if tr.name == _TALK_TO_USER_TOOL_NAME), None
-        )
-        if talk_to_user_request:
-            logger.debug(
-                "Parallel tool calling is disabled when using %s tool", _TALK_TO_USER_TOOL_NAME
-            )
-            new_message.tool_requests = [talk_to_user_request]
+        tool_requests = new_message.tool_requests
+
+        if len(tool_requests) > 1 and any(
+            tr.name in _NON_PARALLEL_TOOL_NAMES for tr in tool_requests
+        ):
+            new_message.tool_requests = [
+                tr for tr in new_message.tool_requests if tr.name not in _NON_PARALLEL_TOOL_NAMES
+            ]
 
         state.tool_call_queue.extend(new_message.tool_requests)
         return False

--- a/wayflowcore/tests/integration/test_agent.py
+++ b/wayflowcore/tests/integration/test_agent.py
@@ -20,7 +20,11 @@ from wayflowcore.contextproviders import ContextProvider, ToolContextProvider
 from wayflowcore.contextproviders.constantcontextprovider import ConstantContextProvider
 from wayflowcore.controlconnection import ControlFlowEdge
 from wayflowcore.dataconnection import DataFlowEdge
-from wayflowcore.executors._agentexecutor import _SUBMIT_TOOL_NAME
+from wayflowcore.executors._agentexecutor import (
+    _SUBMIT_TOOL_NAME,
+    _TALK_TO_USER_INPUT_PARAM,
+    _TALK_TO_USER_TOOL_NAME,
+)
 from wayflowcore.executors.executionstatus import (
     FinishedStatus,
     ToolExecutionConfirmationStatus,
@@ -2327,3 +2331,44 @@ def test_agent_does_not_loop_until_max_iterations(remotely_hosted_llm):
     status = conv.execute()
     # it should not have exited because of max_iter
     assert conv.state.curr_iter != agent.max_iterations
+
+
+def test_agent_outputs_both_talk_user_and_normal_tool(remotely_hosted_llm):
+
+    tool = ClientTool(
+        name="some_tool",
+        description="",
+        input_descriptors=[],
+        output_descriptors=[],
+    )
+
+    agent = Agent(
+        llm=remotely_hosted_llm,
+        tools=[tool],
+    )
+    conv = agent.start_conversation(messages="do something")
+
+    with patch_llm(
+        remotely_hosted_llm,
+        outputs=[
+            [
+                ToolRequest(name="some_tool", args={}, tool_request_id="id100"),
+                ToolRequest(
+                    name=_TALK_TO_USER_TOOL_NAME,
+                    args={_TALK_TO_USER_INPUT_PARAM: "something"},
+                    tool_request_id="id3",
+                ),
+            ],
+            "something else",
+        ],
+    ):
+        status = conv.execute()
+        assert isinstance(status, ToolRequestStatus)
+        status.submit_tool_result(
+            tool_result=ToolResult(
+                tool_request_id=status.tool_requests[0].tool_request_id, content={}
+            )
+        )
+        status = conv.execute()
+        assert isinstance(status, UserMessageRequestStatus)
+        assert status.message.content == "something else"


### PR DESCRIPTION
Currently, the LLM is not executing tools that are present in a parallel tool calling turn along with a talk_to_user call. We should do the opposite, rather drop the talk_to_user call to force the LLM running all the tool calls before returning to the user