### PR TITLE
Fix: Use OciSessionAuth for OCI security token authentication.

### DIFF
--- a/wayflowcore/src/wayflowcore/models/ociclientconfig.py
+++ b/wayflowcore/src/wayflowcore/models/ociclientconfig.py
@@ -339,9 +339,9 @@ def _client_config_to_oci_client_kwargs(client_config: OCIClientConfig) -> Dict[
 
 def _client_config_to_oci_openai_client_auth(client_config: OCIClientConfig) -> Any:
     from oci_openai import (  # type: ignore
-        OciSessionAuth,
         OciInstancePrincipalAuth,
         OciResourcePrincipalAuth,
+        OciSessionAuth,
         OciUserPrincipalAuth,
     )
 
@@ -355,7 +355,9 @@ def _client_config_to_oci_openai_client_auth(client_config: OCIClientConfig) -> 
             profile_name=client_config.auth_profile,
         )
     elif isinstance(client_config, OCIClientConfigWithSecurityToken):
-        return OciSessionAuth(config_file=client_config.auth_file_location, profile_name=client_config.auth_profile)
+        return OciSessionAuth(
+            config_file=client_config.auth_file_location, profile_name=client_config.auth_profile
+        )
     elif isinstance(client_config, OCIClientConfigWithInstancePrincipal):
         return OciInstancePrincipalAuth()
     elif isinstance(client_config, OCIClientConfigWithResourcePrincipal):


### PR DESCRIPTION
The current implementation of using `HttpxOciAuth` is causing an error as it is an abstract class.
```
TypeError: Can't instantiate abstract class HttpxOciAuth without an implementation for abstract method '_refresh_signer'
```

This PR fixes the issue by using the `OciSessionAuth` class provided by `oci_openai`, as documented by the example [here](https://github.com/oracle-samples/oci-openai?tab=readme-ov-file#using-the-oci-openai-synchronous-client).
