### PR TITLE
docs: add markdown to docs and example mcp server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,4 +206,4 @@ wayflowcore/dev_scripts/*/data
 
 # environment variables such as private keys
 *env/
-examples/*
+.docs_cache

--- a/docs/wayflowcore/Makefile
+++ b/docs/wayflowcore/Makefile
@@ -1,26 +1,60 @@
 # Minimal Makefile for Sphinx documentation
-#
-
 SPHINXOPTS    ?= -W --keep-going
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
-BUILDDIR      = build/html
+
+BUILDDIR_HTML = build/html
+BUILDDIR_MD   = build/markdown
+ARTIFACTS_DIR = build/html
+
+MD_TREE_FILE  = $(ARTIFACTS_DIR)/markdown_tree.txt
+MD_ZIP_FILE   = $(ARTIFACTS_DIR)/markdown_bundle.zip
+
 TAG           = external
 
-# Put it first so that "make" without argument is like "make help".
 help:
 	@echo "Please use 'make <target>' where <target> is one of:"
-	@echo "  html    to make HTML documentation"
-	@echo "  clean   to clean up build directory"
+	@echo "  html       to make HTML documentation (and overlay generated markdown)"
+	@echo "  html-only  to make HTML documentation only"
+	@echo "  md         to make Markdown documentation only"
+	@echo "  clean      to clean up build directories"
 
-.PHONY: help html clean
+.PHONY: help html html-only md overlay-md clean
 
-# Build HTML
-html:
-	@$(SPHINXBUILD) -t $(TAG) -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
-	@echo
-	@echo "Build finished. The HTML pages are in $(BUILDDIR)."
+# Build markdown docs only
+md:
+	@$(SPHINXBUILD) -t $(TAG) -b markdown "$(SOURCEDIR)" "$(BUILDDIR_MD)" $(SPHINXOPTS)
+	@rm -rf "$(BUILDDIR_MD)/.doctrees" "$(BUILDDIR_MD)/_sphinx_design_static"
+	@echo "Build finished. The Markdown pages are in $(BUILDDIR_MD)."
 
-# Clean up build directory
+# Build html docs only
+html-only:
+	@$(SPHINXBUILD) -t $(TAG) -b html "$(SOURCEDIR)" "$(BUILDDIR_HTML)" $(SPHINXOPTS)
+	@echo "Build finished. The HTML pages are in $(BUILDDIR_HTML)."
+
+# Build markdown, build html, overlay .md next to html, then remove markdown build dir
+html: md-artifacts html-only overlay-md
+	@echo "Removing temporary Markdown build directory $(BUILDDIR_MD)..."
+	@rm -rf "$(BUILDDIR_MD)"
+	@echo "Artifacts written to $(ARTIFACTS_DIR)."
+
+# Overlay markdown files into the html build tree (preserving relative paths)
+overlay-md:
+	@echo "Overlaying Markdown files from $(BUILDDIR_MD) onto $(BUILDDIR_HTML)..."
+	@cd "$(BUILDDIR_MD)" && \
+	find . -type f -name '*.md' | while read file; do \
+		target="../../$(BUILDDIR_HTML)/$$file"; \
+		mkdir -p "$$(dirname "$$target")"; \
+		cp -f "$$file" "$$target"; \
+	done
+
+# Produce a simple folder tree + a zip of the markdown build.
+md-artifacts: md
+	@echo "Writing markdown tree to $(MD_TREE_FILE)..."
+	@mkdir -p "$(ARTIFACTS_DIR)"
+	@python create_tree.py "$(BUILDDIR_MD)" --max-depth 6 --ext .md --output "$(MD_TREE_FILE)"
+	@echo "Creating markdown zip bundle at $(MD_ZIP_FILE)..."
+	@cd "$(BUILDDIR_MD)" && zip -qr "../../$(MD_ZIP_FILE)" .
+
 clean:
-	- rm -rf "$(BUILDDIR)"
+	- rm -rf "$(BUILDDIR_HTML)" "$(BUILDDIR_MD)" "$(ARTIFACTS_DIR)"

--- a/docs/wayflowcore/create_tree.py
+++ b/docs/wayflowcore/create_tree.py
@@ -1,0 +1,95 @@
+# Copyright © 2025 Oracle and/or its affiliates.
+#
+# This software is under the Apache License 2.0
+# (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
+# (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+
+@dataclass(frozen=True)
+class TreeNode:
+    name: str
+    is_dir: bool
+    children: List["TreeNode"]
+
+
+def _iter_children(path: Path) -> Iterable[Path]:
+    try:
+        return sorted(path.iterdir(), key=lambda p: (not p.is_dir(), p.name.lower()))
+    except FileNotFoundError:
+        return []
+
+
+def build_tree(root: Path, *, max_depth: int) -> TreeNode:
+    root = root.resolve()
+
+    def rec(current: Path, depth: int) -> TreeNode:
+        if depth > max_depth:
+            return TreeNode(name=current.name, is_dir=current.is_dir(), children=[])
+
+        if current.is_dir():
+            children: List[TreeNode] = []
+            for child in _iter_children(current):
+                # Skip hidden and underscore-prefixed directories (Sphinx internals like _static).
+                if child.name.startswith("."):
+                    continue
+                if child.is_dir() and child.name.startswith("_"):
+                    continue
+                children.append(rec(child, depth + 1))
+            return TreeNode(name=current.name, is_dir=True, children=children)
+
+        # Files are ignored for the simplified navigation tree.
+        return TreeNode(name=current.name, is_dir=False, children=[])
+
+    return rec(root, 0)
+
+
+def render_tree(node: TreeNode, *, indent: str = "  ") -> str:
+    # If the root has a single child directory, show that as the top-level.
+    start = node
+    top_dirs = [c for c in node.children if c.is_dir]
+    if node.is_dir and len(top_dirs) == 1:
+        start = top_dirs[0]
+
+    lines: List[str] = [start.name]
+
+    def rec(n: TreeNode, level: int) -> None:
+        for child in n.children:
+            if not child.is_dir:
+                continue
+            prefix = indent * level + "- "
+            lines.append(f"{prefix}{child.name} ({len(child.children)} items)")
+            rec(child, level + 1)
+
+    rec(start, 1)
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Create a simplified docs tree.")
+    parser.add_argument("root", type=Path, help="Root folder to scan")
+    parser.add_argument("--max-depth", type=int, default=4)
+    parser.add_argument("--ext", action="append", default=[".md"], help="Include extension")
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    root = args.root
+    tree = build_tree(root, max_depth=args.max_depth)
+    rendered = render_tree(tree)
+
+    if rendered.strip() == root.resolve().name:
+        raise SystemExit(f"No directory structure found under: {root}")
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(rendered, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/wayflowcore/requirements-docs.txt
+++ b/docs/wayflowcore/requirements-docs.txt
@@ -1,15 +1,16 @@
-sphinx==6.1
+sphinx==8.1.3
 sphinx-substitution-extensions==2022.2.16
 sphinx-tabs==3.4.5
 sphinx-copybutton==0.5.2
 pydata-sphinx-theme==0.16.1
 sphinx-argparse==0.5.2
-# These are added as newer versions require sphinx>5.0, and pip doesn't resolve to older versions correctly
-sphinxcontrib-applehelp<1.0.8
-sphinxcontrib-devhelp<1.0.6
-sphinxcontrib-htmlhelp<2.0.5
-sphinxcontrib.serializinghtml<1.1.10
-sphinxcontrib.qthelp<1.0.7
-sphinx_toolbox<=3.8.0
+sphinxcontrib-applehelp==2.0.0
+sphinxcontrib-devhelp==2.0.0
+sphinxcontrib-htmlhelp==2.1.0
+sphinxcontrib.serializinghtml==2.0.0
+sphinxcontrib.qthelp==2.0.0
+sphinx_toolbox==4.1.2
+sphinx_design==0.6.1
+sphinx-markdown-builder==0.6.9
 
 -e ../../wayflowcore[oci]

--- a/docs/wayflowcore/source/_ext/markdown_translator_ext.py
+++ b/docs/wayflowcore/source/_ext/markdown_translator_ext.py
@@ -1,0 +1,201 @@
+# Copyright © 2025 Oracle and/or its affiliates.
+#
+# This software is under the Apache License 2.0
+# (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
+# (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
+# mypy: ignore-errors
+
+from __future__ import annotations
+
+from docutils import nodes
+from sphinx_markdown_builder.contexts import SubContext, SubContextParams, TableContext
+from sphinx_markdown_builder.translator import MarkdownTranslator, pushing_context
+
+
+class MarkdownTranslatorPlus(MarkdownTranslator):
+    def astext(self):
+        text = super().astext()
+        return (
+            text.replace("<br/>\n", "\n")
+            .replace("<br/>", "\n")
+            .replace("<br/>", "\n")
+            .replace("<!-- :orphan: -->", "")
+            .replace("<!-- :no-search: -->", "")
+        )
+
+    # -------------------------
+    # Admonitions
+    # -------------------------
+    @pushing_context
+    def visit_admonition(self, node: nodes.admonition) -> None:
+        title = _get_admonition_title(node, "ADMONITION")
+        self._push_box(title)
+
+    # Specific admonition directives in RST map to specific node types
+    @pushing_context
+    def visit_tip(self, node: nodes.tip) -> None:
+        self._push_box(_get_admonition_title(node, "TIP"))
+
+    @pushing_context
+    def visit_danger(self, node: nodes.danger) -> None:
+        self._push_box(_get_admonition_title(node, "DANGER"))
+
+    @pushing_context
+    def visit_caution(self, node: nodes.caution) -> None:
+        self._push_box(_get_admonition_title(node, "CAUTION"))
+
+    def visit_title(self, node: nodes.title) -> None:
+        if isinstance(node.parent, nodes.admonition):
+            # skip the actual title child inside admonition to avoid duplicating it
+            raise nodes.SkipNode
+        return super().visit_title(node)
+
+    # -------------------------
+    # option_list (RST options)
+    # -------------------------
+    @pushing_context
+    def visit_option_list(self, node: nodes.option_list) -> None:
+        # simplest Markdown representation: a bullet list
+        self._start_list("*")
+
+    def depart_option_list(self, node: nodes.option_list) -> None:
+        self._end_list(node)
+
+    @pushing_context
+    def visit_option_list_item(self, node: nodes.option_list_item) -> None:
+        self._start_list_item(node)
+
+    def depart_option_list_item(self, node: nodes.option_list_item) -> None:
+        self._end_list_item(node)
+
+    def visit_option_group(self, node: nodes.option_group) -> None:
+        # Render like `-h, --help` (inline)
+        # Let children (option / option_string) render
+        pass
+
+    def visit_option(self, node: nodes.option) -> None:
+        pass
+
+    def visit_option_string(self, node: nodes.option_string) -> None:
+        self._push_status(escape_text=False)
+        self.add("`")
+
+    def depart_option_string(self, node: nodes.option_string) -> None:
+        self.add("`")
+        self._pop_status()
+
+    def visit_description(self, node: nodes.description) -> None:
+        # " - description" on same list item
+        self.add(" — ")
+
+    # -------------------------
+    # abbreviation
+    # -------------------------
+    def visit_abbreviation(self, node: nodes.abbreviation) -> None:
+        # Markdown has no native abbreviation syntax; simplest is to emit text.
+        title = node.get("explanation")
+        if title:
+            self.add(f'<abbr title="{title}">')
+        # allow children/text to render
+
+    def depart_abbreviation(self, node: nodes.abbreviation) -> None:
+        if node.get("explanation"):
+            self.add("</abbr>")
+
+    # -------------------------
+    # sphinx_toolbox.collapse: CollapseNode
+    # -------------------------
+    @pushing_context
+    def visit_CollapseNode(self, node) -> None:
+        summary = getattr(node, "summary", None) or node.get("summary", None) or "Details"
+
+        self.add("<details>", prefix_eol=2, suffix_eol=1)
+        self.add(f"<summary>{summary}</summary>", prefix_eol=1, suffix_eol=2)
+
+        self._push_context(SubContext(SubContextParams(prefix_eol=1, suffix_eol=2)))
+
+    def depart_CollapseNode(self, node) -> None:
+        self._pop_context()
+        self.add("</details>", prefix_eol=1, suffix_eol=2)
+
+    # -------------------------
+    # PassthroughTextElement
+    # -------------------------
+    def visit_PassthroughTextElement(self, node) -> None:
+        # Letting traversal continue to process children (image + text)
+        pass
+
+    def depart_PassthroughTextElement(self, node) -> None:
+        pass
+
+    # -------------------------
+    # Table fix
+    # -------------------------
+    def _find_table_ctx(self):
+        # Walk up the context stack from innermost to outermost
+        for c in reversed(self._ctx_queue):
+            if isinstance(c, TableContext):
+                return c
+        return None
+
+    def visit_table(self, node):
+        # Always push a TableContext for any table node
+        self._push_context(TableContext(params=SubContextParams(2, 1)))
+
+    def visit_thead(self, node: nodes.thead):
+        table_ctx = self._find_table_ctx()
+        if table_ctx is None:
+            raise nodes.SkipNode
+        table_ctx.enter_head()
+
+    def depart_thead(self, node):
+        table_ctx = self._find_table_ctx()
+        if table_ctx is not None:
+            table_ctx.exit_head()
+
+    def visit_tbody(self, node):
+        table_ctx = self._find_table_ctx()
+        if table_ctx is None:
+            raise nodes.SkipNode
+        table_ctx.enter_body()
+
+    def depart_tbody(self, node):
+        table_ctx = self._find_table_ctx()
+        if table_ctx is not None:
+            table_ctx.exit_body()
+
+    def visit_row(self, node):
+        table_ctx = self._find_table_ctx()
+        if table_ctx is None:
+            raise nodes.SkipNode
+        table_ctx.enter_row()
+
+    def depart_row(self, node):
+        table_ctx = self._find_table_ctx()
+        if table_ctx is not None:
+            table_ctx.exit_row()
+
+    def visit_entry(self, node):
+        table_ctx = self._find_table_ctx()
+        if table_ctx is None:
+            raise nodes.SkipNode
+        table_ctx.enter_entry()
+
+    def depart_entry(self, node):
+        table_ctx = self._find_table_ctx()
+        if table_ctx is not None:
+            table_ctx.exit_entry()
+
+
+def _get_admonition_title(node: nodes.Node, default: str) -> str:
+    # If it's a generic ".. admonition:: My Title", docutils adds a title node as first child.
+    for child in node.children:
+        if isinstance(child, nodes.title):
+            return child.astext()
+    return default
+
+
+def setup(app):
+    # Register for the "markdown" builder to override the translator used by sphinx_markdown_builder.
+    app.set_translator("markdown", MarkdownTranslatorPlus, override=True)
+    return {"version": "0.1", "parallel_read_safe": True, "parallel_write_safe": True}

--- a/docs/wayflowcore/source/conf.py
+++ b/docs/wayflowcore/source/conf.py
@@ -92,6 +92,7 @@ logging.getLogger("sphinx").addFilter(SphinxWarningFilter())
 # ones.
 extensions = [
     "sphinx.ext.napoleon",
+    "sphinx.ext.autodoc",
     "sphinx.ext.mathjax",
     "sphinx_substitution_extensions",
     "sphinx.ext.extlinks",
@@ -102,6 +103,8 @@ extensions = [
     "sphinx_design",
     "sphinxarg.ext",
     "sphinx_autodoc_typehints",
+    "sphinx_markdown_builder",
+    "markdown_translator_ext",
 ]
 
 # Set the variables that should be replaced in the substitution-extensions directives
@@ -184,6 +187,14 @@ html_theme_options = {
         "image_light": "logo-light.svg",
         "image_dark": "logo-dark.svg",
     },
+    "announcement": (
+        "<span>"
+        "<strong>New:</strong> The Docs MCP server lets assistants browse WayFlow docs and examples. "
+        "See Resources → Docs MCP Server."
+        "</span>"
+        '<button id="close-announcement" aria-label="Close announcement" '
+        'style="margin-left:auto;background:none;border:none;color:inherit;cursor:pointer;font-size:1.15em;line-height:1">×</button>'
+    ),
 }
 
 html_sidebars = {"**": ["sidebar-nav-bs"], "core/changelog": []}
@@ -222,6 +233,16 @@ nitpick_ignore_regex = [
     ("py:.*", r"starlette\..*"),
     ("py:.*", r"collections\..*"),
     ("py:.*", r"contextlib\..*"),
+    # Pydantic-specific issues
+    ("py:.*", r"pydantic\..*"),
+    ("py:class", r"func=.*"),
+    ("py:class", r"return_type=.*"),
+    ("py:class", r"when_used=.*"),
+    ("py:class", r"PydanticUndefined"),
+    ("py:class", r"FieldInfo"),
+    ("py:class", r"annotation=.*"),
+    ("py:class", r"required=.*"),
+    ("py:class", r"discriminator=.*"),
     # `...`
     ("py:data", r"Ellipsis"),
     # Coming from typing

--- a/docs/wayflowcore/source/core/changelog.rst
+++ b/docs/wayflowcore/source/core/changelog.rst
@@ -20,8 +20,16 @@ New features
   You can now declare your agents with summarization transforms and summary caching in Agent Spec and run them in WayFlow.
 
 
-Improvements
-^^^^^^^^^^^^
+Documentation
+^^^^^^^^^^^^^
+
+* **Added a new MCP server to browse the WayFlow documentation:**
+
+  Added a new MCP server in ``examples/mcp/docs_mcp.py`` to let assistants
+  browse the WayFlow documentation.
+
+  For more information, see the :doc:`Docs MCP Server guide <misc/docs_mcp_server>`.
+
 
 * **OpenAI-compatible embeddings now support API keys:**
 

--- a/docs/wayflowcore/source/core/index.rst
+++ b/docs/wayflowcore/source/core/index.rst
@@ -121,3 +121,4 @@ Look through our :doc:`Frequently Asked Questions <faqs>`.
    Security Considerations <security>
    For Contributors <contributing>
    Frequently Asked Questions <faqs>
+   Docs MCP Server <misc/docs_mcp_server>

--- a/docs/wayflowcore/source/core/misc/docs_mcp_server.rst
+++ b/docs/wayflowcore/source/core/misc/docs_mcp_server.rst
@@ -1,0 +1,306 @@
+.. _docs_mcp_server:
+
+===============
+Docs MCP Server
+===============
+
+WayFlow includes a documentation-focused MCP server in ``examples/mcp/docs_mcp.py``.
+It exposes a single tool, ``get_docs``, that lets coding assistants safely navigate
+the published WayFlow Markdown docs bundle and the generated end-to-end example files.
+
+This is useful when you want an assistant to answer questions grounded in the current
+WayFlow documentation, inspect example code before writing new code, or locate the
+right guide/API page without giving the assistant unrestricted shell access.
+
+
+What the server does
+====================
+
+The ``get_docs`` tool accepts a constrained shell-like command and runs it against the
+downloaded docs bundle. Supported commands are:
+
+* ``ls [PATH]`` or ``ls -la [PATH]``
+* ``rg --files [-g/--glob PATTERN] [PATH]``
+* ``sed -n 'START,ENDp' FILE``
+* ``head FILE`` or ``head -n N FILE``
+* ``tail FILE`` or ``tail -n N FILE``
+* exactly one pipe from a supported producer into ``head``, ``tail``, or filtering ``rg``
+
+The server is intentionally narrow in scope:
+
+* it refreshes the Markdown bundle at startup from the base docs URL;
+* it only allows navigation inside that bundle;
+* it supports exactly one pipe and still blocks redirects, command chaining, and subshell syntax.
+
+The intended workflow is:
+
+1. discover folders with ``ls``;
+2. locate the relevant page or example with ``rg --files`` or ``| rg`` filtering;
+3. read or trim excerpts with ``sed -n``, ``head``, or ``tail``.
+
+Typical pipeline examples include:
+
+* ``rg --files core/howtoguides | rg mcp``
+* ``rg --files -g '*.md' core | head -n 20``
+* ``sed -n '1,220p' core/howtoguides/howto_mcp.md | rg StdioTransport``
+
+
+Adding the server to Codex
+==========================
+
+The example file includes the minimal Codex setup instructions at the top.
+
+From the ``examples/mcp`` directory:
+
+.. code-block:: bash
+
+   codex mcp add wayflow_docs -- python docs_mcp.py --base-docs-url https://oracle.github.io/wayflow/development
+
+If you prefer to edit the Codex configuration manually:
+
+.. code-block:: toml
+
+   [mcp_servers.wayflow_docs]
+   command = "python"
+   args = ["docs_mcp.py", "--base-docs-url", "https://oracle.github.io/wayflow/development"]
+
+
+If you launch Codex from the repository root instead, use
+``examples/mcp/docs_mcp.py`` as the script path.
+
+If you prefer a ``uv``-based setup that does not require a local checkout of the
+WayFlow repository, you can run the server directly from GitHub:
+
+.. code-block:: bash
+
+   codex mcp add wayflow_docs -- uv run --with mcp -- https://raw.githubusercontent.com/oracle/wayflow/refs/heads/main/examples/mcp/docs_mcp.py --base-docs-url https://oracle.github.io/wayflow/development
+
+Equivalent Codex configuration:
+
+.. code-block:: toml
+
+   [mcp_servers.wayflow_docs]
+   command = "uv"
+   args = [
+       "run", "--with", "mcp",
+       "--",
+       "https://raw.githubusercontent.com/oracle/wayflow/refs/heads/main/examples/mcp/docs_mcp.py",
+       "--base-docs-url",
+       "https://oracle.github.io/wayflow/development",
+   ]
+   startup_timeout_sec = 10
+
+   #[mcp_servers.wayflow_docs.env]
+   #HTTPS_PROXY = "YOUR_PROXY_URL"
+
+
+Using it from a WayFlow Agent
+=============================
+
+The docs MCP server can also be consumed from WayFlow through :ref:`MCPTool <mcptool>`
+and the :ref:`StdioTransport <stdiotransport>`.
+
+The example below starts the docs MCP server as a local subprocess, connects a
+single ``get_docs`` tool to an :ref:`Agent <agent>`, and lets the agent inspect the
+docs before answering.
+
+.. code-block:: python
+
+   from wayflowcore.agent import Agent
+   from wayflowcore.executors.executionstatus import UserMessageRequestStatus
+   from wayflowcore.mcp import MCPTool, StdioTransport, enable_mcp_without_auth
+   from wayflowcore.models import VllmModel
+
+   llm = VllmModel(
+       model_id="LLAMA_MODEL_ID",
+       host_port="LLAMA_API_URL",
+   )
+
+   enable_mcp_without_auth()
+   docs_transport = StdioTransport(
+       command="python",
+       args=[
+           "examples/mcp/docs_mcp.py",
+           "--base-docs-url",
+           "https://oracle.github.io/wayflow/development",
+       ],
+       cwd="/path/to/wayflow",
+   )
+
+   docs_tool = MCPTool(
+       name="get_docs",
+       client_transport=docs_transport,
+   )
+
+   assistant = Agent(
+       llm=llm,
+       tools=[docs_tool],
+       custom_instruction=(
+           "Use the get_docs tool to inspect the WayFlow docs and examples before "
+           "answering. Prefer ls, rg --files, head, tail, and short sed excerpts. "
+           "You may use a single pipe into head, tail, or filtering rg when helpful."
+       ),
+   )
+
+   conversation = assistant.start_conversation()
+   conversation.append_user_message(
+       "Find the MCP how-to and write a minimal stdio example for a WayFlow agent."
+   )
+   status = conversation.execute()
+
+   if isinstance(status, UserMessageRequestStatus):
+       print(conversation.get_last_message().content)
+
+.. note::
+
+   As with the rest of the :doc:`MCP guide <../howtoguides/howto_mcp>`,
+   ``enable_mcp_without_auth()`` is for local and test usage only.
+
+
+Example assistant queries
+=========================
+
+Below are representative queries you can send to a code assistant equipped with the
+``wayflow_docs.get_docs`` tool. The tool calls were exercised against the docs bundle
+to illustrate the expected workflow and response style.
+
+
+Example 1: Find the MCP guide and the recommended local transport
+-----------------------------------------------------------------
+
+**User query**
+
+"Where is the MCP guide, and which transport should I use for a local subprocess server?"
+
+**Example tool calls**
+
+.. code-block:: text
+
+   wayflow_docs.get_docs("rg --files core/howtoguides | rg mcp")
+   wayflow_docs.get_docs("head -n 40 core/howtoguides/howto_mcp.md")
+   wayflow_docs.get_docs("sed -n '740,820p' core/api/tools.md | rg StdioTransport")
+
+**Result the assistant would give**
+
+The MCP guide is in ``core/howtoguides/howto_mcp.md``. For a locally launched MCP
+server, the docs recommend :ref:`StdioTransport <stdiotransport>`, which is intended
+for subprocess-based communication on the same machine. The same guide also points to
+the :doc:`Tools API <../api/tools>` for the transport details.
+
+
+Example 2: Locate an end-to-end MCP example
+-------------------------------------------
+
+**User query**
+
+"Show me an existing WayFlow example that connects an agent to an MCP server."
+
+**Example tool calls**
+
+.. code-block:: text
+
+   wayflow_docs.get_docs("ls core/end_to_end_code_examples | rg howto_mcp")
+   wayflow_docs.get_docs("head -n 40 core/end_to_end_code_examples/howto_mcp.py")
+
+**Result the assistant would give**
+
+There is an end-to-end example in ``core/end_to_end_code_examples/howto_mcp.py``.
+The relevant section shows a WayFlow ``Agent`` configured with MCP access, including
+the transport setup, the MCP tool wiring, and a simple execution loop.
+
+
+Example 3: Discover what documentation areas are available
+----------------------------------------------------------
+
+**User query**
+
+"What can you browse in the WayFlow docs bundle?"
+
+**Example tool call**
+
+.. code-block:: text
+
+   wayflow_docs.get_docs("ls core | head -n 10")
+
+**Result the assistant would give**
+
+The bundle includes the main documentation areas such as ``api``, ``howtoguides``,
+``tutorials``, ``misc``, and ``end_to_end_code_examples``, plus top-level pages like
+``installation.md``, ``security.md``, and ``faqs.md``. A good next step is to narrow
+the search to one area with ``rg --files`` and then read a short excerpt with ``sed``.
+
+
+Example 4: Pull a glossary definition before writing code
+---------------------------------------------------------
+
+**User query**
+
+"Before you write code, remind me what WayFlow means by an Agent."
+
+**Example tool call**
+
+.. code-block:: text
+
+   wayflow_docs.get_docs("head -n 40 core/misc/glossary.md")
+
+**Result the assistant would give**
+
+According to the glossary, an Agent is a conversational WayFlow assistant that can
+interact with users, use tools, and collaborate with other WayFlow assistants to solve
+requests. It is the right building block when you want an assistant to plan tool usage
+flexibly instead of following a fixed flow.
+
+
+Example 5: Ask the assistant to synthesize a stdio MCP snippet
+--------------------------------------------------------------
+
+**User query**
+
+"Use the docs to write a minimal Agent example that talks to an MCP server over stdio."
+
+**Example tool calls**
+
+.. code-block:: text
+
+   wayflow_docs.get_docs("head -n 80 core/howtoguides/howto_mcp.md")
+   wayflow_docs.get_docs("sed -n '740,820p' core/api/tools.md | rg StdioTransport")
+   wayflow_docs.get_docs("head -n 40 core/end_to_end_code_examples/howto_mcp.py")
+
+**Result the assistant would give**
+
+Here is a minimal example based on the MCP how-to and the ``StdioTransport`` API:
+
+.. code-block:: python
+
+   from wayflowcore.agent import Agent
+   from wayflowcore.executors.executionstatus import UserMessageRequestStatus
+   from wayflowcore.mcp import MCPTool, StdioTransport, enable_mcp_without_auth
+   from wayflowcore.models import VllmModel
+
+   llm = VllmModel(
+       model_id="LLAMA_MODEL_ID",
+       host_port="LLAMA_API_URL",
+   )
+
+   enable_mcp_without_auth()
+   docs_transport = StdioTransport(
+       command="python",
+       args=[
+           "examples/mcp/docs_mcp.py",
+           "--base-docs-url",
+           "https://oracle.github.io/wayflow/development",
+       ],
+       cwd="/path/to/wayflow",
+   )
+
+   docs_tool = MCPTool(
+       name="get_docs",
+       client_transport=docs_transport,
+   )
+
+   assistant = Agent(
+       llm=llm,
+       tools=[docs_tool],
+   )
+
+   ...

--- a/examples/mcp/docs_mcp.py
+++ b/examples/mcp/docs_mcp.py
@@ -1,0 +1,841 @@
+# Copyright © 2025 Oracle and/or its affiliates.
+#
+# This software is under the Apache License 2.0
+# (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
+# (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
+
+"""
+
+MCP Server Example - WayFlow Docs MCP
+-------------------------------------
+
+This module defines a MCP Server to easily fetch context about the WayFlow documentation.
+
+
+How to use
+^^^^^^^^^^
+
+This MCP server can be used in coding assistants, e.g., Codex:
+
+```bash
+codex mcp add wayflow_docs -- python docs_mcp.py --base-docs-url https://oracle.github.io/wayflow/development
+```
+
+Or add to your config.toml
+
+[mcp_servers.wayflow_docs]
+command = "python"
+args = ["docs_mcp.py", "--base-docs-url", "https://oracle.github.io/wayflow/development"]
+
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import logging
+import os
+import re
+import shlex
+import urllib.request
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Sequence, cast
+
+from mcp.server.fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
+
+
+class _CommandError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class _CommandResult:
+    stdout: str
+    stderr: str
+    exit_code: int
+
+
+_SED_RANGE_RE = re.compile(r"^(?P<start>\d+),(?P<end>\d+)p$")
+_HEAD_TAIL_N_RE = re.compile(r"^\d+$")
+_MAX_HEAD_TAIL_LINES = 500
+
+
+def _is_within_root(root: Path, path: Path) -> bool:
+    root = root.resolve()
+    path = path.resolve()
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _validate_no_shell_metacharacters(raw: str) -> None:
+    forbidden = [";", "&&", "||", ">", "<", "`", "$("]
+    for token in forbidden:
+        if token in raw:
+            raise _CommandError(f"Unsupported shell syntax: {token}")
+
+    if raw.count("|") > 1:
+        raise _CommandError("Only a single pipe is supported")
+
+
+def _run_supported_command(
+    command: str,
+    *,
+    root_dir: str | Path = ".",
+    cwd: str | Path | None = None,
+    max_output_bytes: int = 200_000,
+    timeout_seconds: int = 5,
+) -> _CommandResult:
+    """Run a constrained subset of shell-like commands.
+
+    Supported:
+    - rg --files [--glob/-g ...] [<path>]
+    - ls [path] or ls -la [path]
+    - sed -n 'START,ENDp' <file>
+    - head [-n N] <file>
+    - tail [-n N] <file>
+    - <producer> | head [-n N]
+    - <producer> | tail [-n N]
+    - <producer> | rg [-i] [-F] [-v] [-n] PATTERN
+
+    Notes:
+    - Exactly one pipe is supported.
+    - All paths must remain within root_dir.
+    """
+
+    _validate_no_shell_metacharacters(command)
+    root = Path(root_dir).resolve()
+    working_dir = Path(cwd).resolve() if cwd is not None else root
+    if not _is_within_root(root, working_dir):
+        raise _CommandError("cwd must be within root_dir")
+
+    if "|" in command:
+        left_raw, right_raw = [part.strip() for part in command.split("|", maxsplit=1)]
+        if not left_raw or not right_raw:
+            raise _CommandError("Invalid pipe syntax")
+        producer_result = _run_non_pipeline_command(
+            left_raw,
+            root=root,
+            cwd=working_dir,
+            max_output_bytes=max_output_bytes,
+            timeout_seconds=timeout_seconds,
+        )
+        if producer_result.exit_code != 0:
+            return producer_result
+        return _run_pipeline_consumer(
+            right_raw,
+            input_text=producer_result.stdout,
+            max_output_bytes=max_output_bytes,
+        )
+
+    return _run_non_pipeline_command(
+        command,
+        root=root,
+        cwd=working_dir,
+        max_output_bytes=max_output_bytes,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def _run_non_pipeline_command(
+    command: str,
+    *,
+    root: Path,
+    cwd: Path,
+    max_output_bytes: int,
+    timeout_seconds: int,
+) -> _CommandResult:
+    args = shlex.split(command)
+    if not args:
+        raise _CommandError("Empty command")
+
+    prog = args[0]
+    if prog == "rg":
+        return _run_rg_files(
+            args,
+            root=root,
+            cwd=cwd,
+            max_output_bytes=max_output_bytes,
+            timeout_seconds=timeout_seconds,
+        )
+    if prog == "ls":
+        return _run_ls(
+            args,
+            root=root,
+            cwd=cwd,
+            max_output_bytes=max_output_bytes,
+            timeout_seconds=timeout_seconds,
+        )
+    if prog == "sed":
+        return _run_sed(
+            args,
+            root=root,
+            cwd=cwd,
+            max_output_bytes=max_output_bytes,
+        )
+    if prog == "head":
+        return _run_head_tail(
+            args,
+            root=root,
+            cwd=cwd,
+            max_output_bytes=max_output_bytes,
+            mode="head",
+        )
+    if prog == "tail":
+        return _run_head_tail(
+            args,
+            root=root,
+            cwd=cwd,
+            max_output_bytes=max_output_bytes,
+            mode="tail",
+        )
+
+    raise _CommandError(f"Unsupported command: {prog}")
+
+
+def _run_pipeline_consumer(
+    command: str,
+    *,
+    input_text: str,
+    max_output_bytes: int,
+) -> _CommandResult:
+    args = shlex.split(command)
+    if not args:
+        raise _CommandError("Empty pipeline consumer")
+
+    prog = args[0]
+    if prog == "head":
+        return _run_head_tail_on_text(
+            args, input_text=input_text, max_output_bytes=max_output_bytes, mode="head"
+        )
+    if prog == "tail":
+        return _run_head_tail_on_text(
+            args, input_text=input_text, max_output_bytes=max_output_bytes, mode="tail"
+        )
+    if prog == "rg":
+        return _run_rg_filter(args, input_text=input_text, max_output_bytes=max_output_bytes)
+
+    raise _CommandError(f"Unsupported pipe target: {prog}")
+
+
+def _run_rg_files(
+    args: List[str],
+    *,
+    root: Path,
+    cwd: Path,
+    timeout_seconds: int,
+    max_output_bytes: int,
+) -> _CommandResult:
+    # Allowed forms:
+    #   rg --files [--glob/-g PATTERN]... [PATH]
+    if "--files" not in args:
+        raise _CommandError("Only 'rg --files' is supported")
+
+    allowed_flags_with_value = {"--glob", "-g"}
+    allowed_flags = {"--files"}
+
+    parsed: List[str] = ["rg"]
+    idx = 1
+    path_arg: Optional[str] = None
+    while idx < len(args):
+        arg_ = args[idx]
+        if arg_ in allowed_flags:
+            parsed.append(arg_)
+            idx += 1
+            continue
+        if arg_ in allowed_flags_with_value:
+            if idx + 1 >= len(args):
+                raise _CommandError(f"Missing value for {arg_}")
+            parsed.extend([arg_, args[idx + 1]])
+            idx += 2
+            continue
+        if arg_.startswith("-"):
+            raise _CommandError(f"Unsupported rg flag: {arg_}")
+        if path_arg is not None:
+            raise _CommandError("Too many path arguments")
+        path_arg = arg_
+        idx += 1
+
+    if path_arg is not None:
+        candidate = (cwd / path_arg).resolve()
+        if not _is_within_root(root, candidate):
+            raise _CommandError("Path escapes root_dir")
+        # Keep the user's relative path for rg.
+        parsed.append(path_arg)
+
+    return _rg_files_inprocess(
+        parsed,
+        root=root,
+        cwd=cwd,
+        timeout_seconds=timeout_seconds,
+        max_output_bytes=max_output_bytes,
+    )
+
+
+def _run_ls(
+    args: List[str],
+    *,
+    root: Path,
+    cwd: Path,
+    timeout_seconds: int,
+    max_output_bytes: int,
+) -> _CommandResult:
+    # Allowed forms:
+    #   ls
+    #   ls PATH
+    #   ls -la [PATH]
+    flags: List[str] = []
+    paths: List[str] = []
+    for arg_ in args[1:]:
+        if arg_.startswith("-"):
+            if arg_ != "-la":
+                raise _CommandError(f"Unsupported ls flag: {arg_}")
+            flags.append(arg_)
+        else:
+            paths.append(arg_)
+
+    if len(paths) > 1:
+        raise _CommandError("Only one path argument is supported")
+    if len(flags) > 1:
+        raise _CommandError("Duplicate flags")
+
+    argv = ["ls", *flags]
+    if paths:
+        candidate = (cwd / paths[0]).resolve()
+        if not _is_within_root(root, candidate):
+            raise _CommandError("Path escapes root_dir")
+        argv.append(paths[0])
+
+    return _ls_inprocess(
+        argv,
+        root=root,
+        cwd=cwd,
+        timeout_seconds=timeout_seconds,
+        max_output_bytes=max_output_bytes,
+    )
+
+
+def _run_sed(
+    args: List[str],
+    *,
+    root: Path,
+    cwd: Path,
+    max_output_bytes: int,
+) -> _CommandResult:
+    # Allowed form:
+    #   sed -n 'START,ENDp' FILE
+    if len(args) != 4:
+        raise _CommandError("Only 'sed -n START,ENDp FILE' is supported")
+    if args[1] != "-n":
+        raise _CommandError("Only 'sed -n' is supported")
+
+    range_expression = args[2]
+    match = _SED_RANGE_RE.match(range_expression)
+    if not match:
+        raise _CommandError("sed range must be like '10,50p'")
+    start_idx = int(match.group("start"))
+    end_idx = int(match.group("end"))
+    if start_idx < 1 or end_idx < 1 or end_idx < start_idx:
+        raise _CommandError("Invalid sed range")
+    if (end_idx - start_idx) > 5000:
+        raise _CommandError("sed range too large")
+
+    file_arg = args[3]
+    candidate = (cwd / file_arg).resolve()
+    if not _is_within_root(root, candidate):
+        raise _CommandError("Path escapes root_dir")
+    if not candidate.exists() or not candidate.is_file():
+        raise _CommandError("File not found")
+
+    return _sed_inprocess(
+        start=start_idx,
+        end=end_idx,
+        file_path=candidate,
+        max_output_bytes=max_output_bytes,
+    )
+
+
+def _parse_head_tail_args(
+    args: List[str], *, allow_file: bool, mode: str
+) -> tuple[int, Optional[str]]:
+    count = 10
+    file_arg: Optional[str] = None
+    idx = 1
+    while idx < len(args):
+        arg_ = args[idx]
+        if arg_ == "-n":
+            if idx + 1 >= len(args):
+                raise _CommandError(f"Missing value for {mode} -n")
+            value = args[idx + 1]
+            if not _HEAD_TAIL_N_RE.match(value):
+                raise _CommandError(f"{mode} -n expects a positive integer")
+            count = int(value)
+            idx += 2
+            continue
+        if arg_.startswith("-"):
+            raise _CommandError(f"Unsupported {mode} flag: {arg_}")
+        if not allow_file:
+            raise _CommandError(f"{mode} does not accept a file after a pipe")
+        if file_arg is not None:
+            raise _CommandError(f"Only one file argument is supported for {mode}")
+        file_arg = arg_
+        idx += 1
+
+    if count < 1:
+        raise _CommandError(f"{mode} -n expects a positive integer")
+    if count > _MAX_HEAD_TAIL_LINES:
+        raise _CommandError(f"{mode} -n too large")
+    if allow_file and file_arg is None:
+        raise _CommandError(f"{mode} requires a file path")
+    return count, file_arg
+
+
+def _run_head_tail(
+    args: List[str],
+    *,
+    root: Path,
+    cwd: Path,
+    max_output_bytes: int,
+    mode: str,
+) -> _CommandResult:
+    count, file_arg = _parse_head_tail_args(args, allow_file=True, mode=mode)
+    if file_arg is None:
+        raise _CommandError(f"Parsed file arg is None, from {args=}")
+    candidate = (cwd / file_arg).resolve()
+    if not _is_within_root(root, candidate):
+        raise _CommandError("Path escapes root_dir")
+    if not candidate.exists() or not candidate.is_file():
+        raise _CommandError("File not found")
+
+    return _head_tail_file_inprocess(
+        file_path=candidate,
+        count=count,
+        mode=mode,
+        max_output_bytes=max_output_bytes,
+    )
+
+
+def _run_head_tail_on_text(
+    args: List[str],
+    *,
+    input_text: str,
+    max_output_bytes: int,
+    mode: str,
+) -> _CommandResult:
+    count, _ = _parse_head_tail_args(args, allow_file=False, mode=mode)
+    return _head_tail_text_inprocess(
+        input_text=input_text,
+        count=count,
+        mode=mode,
+        max_output_bytes=max_output_bytes,
+    )
+
+
+def _run_rg_filter(
+    args: List[str],
+    *,
+    input_text: str,
+    max_output_bytes: int,
+) -> _CommandResult:
+    if "--files" in args:
+        raise _CommandError("The piped rg form is only a line filter, not 'rg --files'")
+
+    ignore_case = False
+    fixed_strings = False
+    invert_match = False
+    show_line_numbers = False
+    pattern: Optional[str] = None
+
+    for arg_ in args[1:]:
+        if arg_ == "-i":
+            ignore_case = True
+        elif arg_ == "-F":
+            fixed_strings = True
+        elif arg_ == "-v":
+            invert_match = True
+        elif arg_ == "-n":
+            show_line_numbers = True
+        elif arg_.startswith("-"):
+            raise _CommandError(f"Unsupported piped rg flag: {arg_}")
+        elif pattern is None:
+            pattern = arg_
+        else:
+            raise _CommandError("Piped rg supports exactly one pattern and no path arguments")
+
+    if pattern is None:
+        raise _CommandError("Piped rg requires a pattern")
+
+    return _rg_filter_inprocess(
+        input_text=input_text,
+        pattern=pattern,
+        ignore_case=ignore_case,
+        fixed_strings=fixed_strings,
+        invert_match=invert_match,
+        show_line_numbers=show_line_numbers,
+        max_output_bytes=max_output_bytes,
+    )
+
+
+def _check_output_size(stdout: str, stderr: str, max_output_bytes: int) -> None:
+    if (len(stdout.encode("utf-8")) + len(stderr.encode("utf-8"))) > max_output_bytes:
+        raise _CommandError("Command output exceeded max_output_bytes")
+
+
+def _ls_inprocess(
+    argv: Sequence[str],
+    *,
+    root: Path,
+    cwd: Path,
+    timeout_seconds: int,
+    max_output_bytes: int,
+) -> _CommandResult:
+    # argv is like: ["ls"] or ["ls", "-la"] or ["ls", "-la", "path"]
+    _ = timeout_seconds  # no-op; kept for signature parity
+    show_long = "-la" in argv
+    target = cwd
+    if len(argv) >= 2 and argv[-1] != "-la":
+        candidate = (cwd / argv[-1]).resolve()
+        if not _is_within_root(root, candidate):
+            raise _CommandError("Path escapes root_dir")
+        target = candidate
+
+    if not target.exists():
+        return _CommandResult(stdout="", stderr="No such file or directory\n", exit_code=2)
+
+    if target.is_file():
+        entries = [target]
+    else:
+        entries = sorted(target.iterdir(), key=lambda p: p.name)
+
+    lines: List[str] = []
+    for entry in entries:
+        name = entry.name
+        if not show_long:
+            lines.append(name)
+            continue
+        st = entry.lstat()
+        # Minimal long-ish format: mode links user group size mtime name
+        mode = _format_mode(st.st_mode)
+        nlink = getattr(st, "st_nlink", 1)
+        uid = getattr(st, "st_uid", 0)
+        gid = getattr(st, "st_gid", 0)
+        size = st.st_size
+        mtime = int(st.st_mtime)
+        lines.append(f"{mode} {nlink:3d} {uid:5d} {gid:5d} {size:9d} {mtime:10d} {name}")
+
+    stdout = "\n".join(lines) + ("\n" if lines else "")
+    stderr = ""
+    _check_output_size(stdout, stderr, max_output_bytes)
+    return _CommandResult(stdout=stdout, stderr=stderr, exit_code=0)
+
+
+def _format_mode(st_mode: int) -> str:
+    import stat
+
+    is_dir = "d" if stat.S_ISDIR(st_mode) else "-"
+    perms = []
+    for rbit, wbit, xbit in (
+        (stat.S_IRUSR, stat.S_IWUSR, stat.S_IXUSR),
+        (stat.S_IRGRP, stat.S_IWGRP, stat.S_IXGRP),
+        (stat.S_IROTH, stat.S_IWOTH, stat.S_IXOTH),
+    ):
+        perms.append("r" if (st_mode & rbit) else "-")
+        perms.append("w" if (st_mode & wbit) else "-")
+        perms.append("x" if (st_mode & xbit) else "-")
+    return is_dir + "".join(perms)
+
+
+def _rg_files_inprocess(
+    argv: Sequence[str],
+    *,
+    root: Path,
+    cwd: Path,
+    timeout_seconds: int,
+    max_output_bytes: int,
+) -> _CommandResult:
+    # Implements a subset of `rg --files` with `--glob/-g` include patterns.
+    # argv is like: ["rg", "--files", "-g", "*.md", "core"]
+    import fnmatch
+    import time
+
+    start_time = time.time()
+    globs: List[str] = []
+    search_root = cwd
+
+    idx = 1
+    while idx < len(argv):
+        arg_ = argv[idx]
+        if arg_ == "--files":
+            idx += 1
+            continue
+        if arg_ in {"-g", "--glob"}:
+            globs.append(argv[idx + 1])
+            idx += 2
+            continue
+        # path
+        candidate = (cwd / arg_).resolve()
+        if not _is_within_root(root, candidate):
+            raise _CommandError("Path escapes root_dir")
+        search_root = candidate
+        idx += 1
+
+    if not search_root.exists():
+        return _CommandResult(stdout="", stderr="Path not found\n", exit_code=2)
+
+    files: List[str] = []
+    for dirpath, dirnames, filenames in os.walk(search_root):
+        if (time.time() - start_time) > timeout_seconds:
+            raise _CommandError("Command timed out")
+        # Keep traversal within root (defense-in-depth)
+        if not _is_within_root(root, Path(dirpath)):
+            continue
+        dirnames.sort()
+        filenames.sort()
+        for filename_ in filenames:
+            full_path = Path(dirpath) / filename_
+            rel = full_path.relative_to(cwd)
+            rel_str = rel.as_posix()
+            if globs and not any(
+                fnmatch.fnmatch(rel_str, g) or fnmatch.fnmatch(filename_, g) for g in globs
+            ):
+                continue
+            files.append(rel_str)
+
+    stdout = "\n".join(files) + ("\n" if files else "")
+    stderr = ""
+    _check_output_size(stdout, stderr, max_output_bytes)
+    return _CommandResult(stdout=stdout, stderr=stderr, exit_code=0)
+
+
+def _sed_inprocess(
+    *, start: int, end: int, file_path: Path, max_output_bytes: int
+) -> _CommandResult:
+    # Print inclusive 1-based line range.
+    lines: List[str] = []
+    with file_path.open("r", encoding="utf-8", errors="replace") as f:
+        for lineno, line in enumerate(f, start=1):
+            if lineno < start:
+                continue
+            if lineno > end:
+                break
+            lines.append(line)
+
+    stdout = "".join(lines)
+    stderr = ""
+    _check_output_size(stdout, stderr, max_output_bytes)
+    return _CommandResult(stdout=stdout, stderr=stderr, exit_code=0)
+
+
+def _head_tail_file_inprocess(
+    *, file_path: Path, count: int, mode: str, max_output_bytes: int
+) -> _CommandResult:
+    with file_path.open("r", encoding="utf-8", errors="replace") as f:
+        input_text = f.read()
+    return _head_tail_text_inprocess(
+        input_text=input_text,
+        count=count,
+        mode=mode,
+        max_output_bytes=max_output_bytes,
+    )
+
+
+def _head_tail_text_inprocess(
+    *, input_text: str, count: int, mode: str, max_output_bytes: int
+) -> _CommandResult:
+    lines = input_text.splitlines(keepends=True)
+    if mode == "head":
+        selected = lines[:count]
+    elif mode == "tail":
+        selected = lines[-count:]
+    else:
+        raise _CommandError(f"Unsupported mode: {mode}")
+
+    stdout = "".join(selected)
+    stderr = ""
+    _check_output_size(stdout, stderr, max_output_bytes)
+    return _CommandResult(stdout=stdout, stderr=stderr, exit_code=0)
+
+
+def _rg_filter_inprocess(
+    *,
+    input_text: str,
+    pattern: str,
+    ignore_case: bool,
+    fixed_strings: bool,
+    invert_match: bool,
+    show_line_numbers: bool,
+    max_output_bytes: int,
+) -> _CommandResult:
+    try:
+        matcher = (
+            None if fixed_strings else re.compile(pattern, re.IGNORECASE if ignore_case else 0)
+        )
+    except re.error as exc:
+        raise _CommandError(f"Invalid rg pattern: {exc}") from exc
+
+    lines = input_text.splitlines(keepends=True)
+    matched_lines: List[str] = []
+    for lineno, line in enumerate(lines, start=1):
+        haystack = line.rstrip("\n")
+        if fixed_strings:
+            needle = pattern.lower() if ignore_case else pattern
+            subject = haystack.lower() if ignore_case else haystack
+            is_match = needle in subject
+        else:
+            if matcher is None:
+                raise _CommandError("Internal error")
+            is_match = matcher.search(haystack) is not None
+        if invert_match:
+            is_match = not is_match
+        if not is_match:
+            continue
+        prefix = f"{lineno}:" if show_line_numbers else ""
+        matched_lines.append(f"{prefix}{line}")
+
+    stdout = "".join(matched_lines)
+    stderr = ""
+    _check_output_size(stdout, stderr, max_output_bytes)
+    return _CommandResult(stdout=stdout, stderr=stderr, exit_code=0)
+
+
+_TOOL_DESCRIPTION_TEMPLATE = """Fetch context from the project Markdown documentation.
+
+Use this tool to navigate a Markdown docs bundle and read parts of the docs.
+It accepts a constrained subset of shell-like commands for predictable retrieval.
+
+Typical workflow
+1) Discover folders:
+   - ls
+   - ls folder_name
+2) Enumerate Markdown files:
+   - rg --files -g '*.md'
+   - rg --files -g '*.md' folder_name
+   - rg --files path/to/folder | rg mcp
+   - rg --files path/to/folder | head -n 20
+3) Read a specific excerpt from a page:
+   - sed -n '1,80p' index.md
+   - sed -n '120,170p' path/to/index.md
+   - head -n 40 path/to/howto_do_x.md
+   - sed -n '1,220p' path/to/howto_x.md | rg SomeClass
+
+Supported commands
+- ls [PATH] | ls -la [PATH]
+- rg --files [-g/--glob PATTERN] [PATH]
+- sed -n 'START,ENDp' FILE
+- head FILE | head -n N FILE
+- tail FILE | tail -n N FILE
+- <producer> | head [-n N]
+- <producer> | tail [-n N]
+- <producer> | rg [-i] [-F] [-v] [-n] PATTERN
+
+Where <producer> is one of:
+- ls [PATH] | ls -la [PATH]
+- rg --files [-g/--glob PATTERN] [PATH]
+- sed -n 'START,ENDp' FILE
+
+Safety rules
+- Exactly one pipe is supported.
+- Redirects, chaining, and subshell syntax are not supported.
+- Paths are restricted to the downloaded docs root.
+- Output is size-capped; traversal is time-bounded.
+
+Docs tree (folders only)
+{doc_tree}
+"""
+
+
+def _fetch_url(url: str, *, timeout_seconds: int = 20) -> bytes:
+    req = urllib.request.Request(url, headers={"User-Agent": "mcp-docs-context/1.0"})
+    with urllib.request.urlopen(req, timeout=timeout_seconds) as resp:  # nosec: B310
+        return cast(bytes, resp.read())
+
+
+def _read_text_url(url: str) -> str:
+    return _fetch_url(url).decode("utf-8", errors="replace")
+
+
+def _derive_artifact_urls(base_url: str) -> tuple[str, str]:
+    base = base_url.rstrip("/")
+    return (
+        f"{base}/markdown_bundle.zip",
+        f"{base}/markdown_tree.txt",
+    )
+
+
+def _build_server(*, base_url: str, cache_dir: Path) -> FastMCP:
+    zip_url, tree_url = _derive_artifact_urls(base_url)
+
+    logger.info("Fetching docs tree from %s", tree_url)
+    doc_tree = _read_text_url(tree_url)
+
+    logger.info("Fetching markdown bundle from %s", zip_url)
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    docs_root = cache_dir / "markdown"
+    # Always refresh on startup for 'latest' behavior.
+    if docs_root.exists():
+        for path in docs_root.iterdir():
+            if path.is_dir():
+                import shutil
+
+                shutil.rmtree(path)
+            else:
+                path.unlink()
+    docs_root.mkdir(parents=True, exist_ok=True)
+
+    blob = _fetch_url(zip_url)
+    with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+        for member in zf.infolist():
+            member_path = Path(member.filename)
+            if member_path.is_absolute() or ".." in member_path.parts:
+                raise RuntimeError("Refusing to extract unsafe zip entry")
+        zf.extractall(docs_root)
+
+    tool_description = _TOOL_DESCRIPTION_TEMPLATE.format(doc_tree=doc_tree.rstrip())
+    server = FastMCP(
+        name="Docs Context MCP Server",
+        instructions="Provides safe navigation and excerpt retrieval for Markdown docs.",
+    )
+
+    @server.tool(description=tool_description)
+    def get_docs(command: str) -> str:
+        result = _run_supported_command(command, root_dir=docs_root, cwd=docs_root)
+        if result.exit_code != 0:
+            raise _CommandError(result.stderr.strip() or f"Command failed: {result.exit_code}")
+        return result.stdout
+
+    return server
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO)
+
+    parser = argparse.ArgumentParser(description="MCP server for Markdown docs context.")
+    parser.add_argument(
+        "--base-docs-url",
+        required=True,
+        help=(
+            "Base URL hosting markdown artifacts (expects markdown_bundle.zip and markdown_tree.txt)"
+        ),
+    )
+    parser.add_argument(
+        "--cache-dir",
+        default=".docs_cache",
+        help="Local folder where markdown bundle is extracted",
+    )
+    args = parser.parse_args()
+
+    server = _build_server(base_url=args.base_docs_url, cache_dir=Path(args.cache_dir))
+    server.run(transport="stdio")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,20 +14,20 @@ flake8-copyright==0.2.4
 pyflakes==2.5.0
 
 # For docs
-sphinx==6.1
+sphinx==8.1.3 # latest version supporting python3.10
 sphinx-substitution-extensions==2022.2.16
 sphinx-tabs==3.4.5
 sphinx-copybutton==0.5.2
 pydata-sphinx-theme==0.16.1
 sphinx-argparse==0.5.2
-# These are added as newer versions require sphinx>5.0, and pip doesn't resolve to older versions correctly
-sphinxcontrib-applehelp<1.0.8
-sphinxcontrib-devhelp<1.0.6
-sphinxcontrib-htmlhelp<2.0.5
-sphinxcontrib.serializinghtml<1.1.10
-sphinxcontrib.qthelp<1.0.7
-sphinx_toolbox<=3.8.0
+sphinxcontrib-applehelp==2.0.0
+sphinxcontrib-devhelp==2.0.0
+sphinxcontrib-htmlhelp==2.1.0
+sphinxcontrib.serializinghtml==2.0.0
+sphinxcontrib.qthelp==2.0.0
+sphinx_toolbox==4.1.2
 sphinx_design==0.6.1
+sphinx-markdown-builder==0.6.9
 
 # To detect available memory when running tests and skip if not enough
 psutil

--- a/wayflowcore/requirements-dev.txt
+++ b/wayflowcore/requirements-dev.txt
@@ -1,18 +1,18 @@
 # For docs
-sphinx==6.1
+sphinx==8.1.3
 sphinx-substitution-extensions==2022.2.16
 sphinx-tabs==3.4.5
 sphinx-copybutton==0.5.2
 pydata-sphinx-theme==0.16.1
 sphinx-argparse==0.5.2
-# These are added as newer versions require sphinx>5.0, and pip doesn't resolve to older versions correctly
-sphinxcontrib-applehelp<1.0.8
-sphinxcontrib-devhelp<1.0.6
-sphinxcontrib-htmlhelp<2.0.5
-sphinxcontrib.serializinghtml<1.1.10
-sphinxcontrib.qthelp<1.0.7
-sphinx_toolbox<=3.8.0
+sphinxcontrib-applehelp==2.0.0
+sphinxcontrib-devhelp==2.0.0
+sphinxcontrib-htmlhelp==2.1.0
+sphinxcontrib.serializinghtml==2.0.0
+sphinxcontrib.qthelp==2.0.0
+sphinx_toolbox==4.1.2
 sphinx_design==0.6.1
+sphinx-markdown-builder==0.6.9
 
 # To detect available memory when running tests and skip if not enough
 psutil


### PR DESCRIPTION
This PR adds:

* .md extension for every html file in the docs, to have a LLM-friendly documentation
* a MCP server (stdio) that can be used with code assistants (e.g., Codex) to query the WayFlow documentation