### PR TITLE
Preserve RemoteTool IO descriptors in Agent Spec conversion

### DIFF
--- a/wayflowcore/src/wayflowcore/serialization/_builtins_deserialization_plugin.py
+++ b/wayflowcore/src/wayflowcore/serialization/_builtins_deserialization_plugin.py
@@ -135,9 +135,7 @@ from wayflowcore.agentspec.components import (
 from wayflowcore.agentspec.components import (
     PluginVllmEmbeddingConfig as AgentSpecPluginVllmEmbeddingConfig,
 )
-from wayflowcore.agentspec.components import (
-    all_deserialization_plugin,
-)
+from wayflowcore.agentspec.components import all_deserialization_plugin
 from wayflowcore.agentspec.components.agent import ExtendedAgent as AgentSpecExtendedAgent
 from wayflowcore.agentspec.components.contextprovider import (
     PluginConstantContextProvider as AgentSpecPluginConstantContextProvider,

--- a/wayflowcore/src/wayflowcore/serialization/_builtins_deserialization_plugin.py
+++ b/wayflowcore/src/wayflowcore/serialization/_builtins_deserialization_plugin.py
@@ -135,7 +135,9 @@ from wayflowcore.agentspec.components import (
 from wayflowcore.agentspec.components import (
     PluginVllmEmbeddingConfig as AgentSpecPluginVllmEmbeddingConfig,
 )
-from wayflowcore.agentspec.components import all_deserialization_plugin
+from wayflowcore.agentspec.components import (
+    all_deserialization_plugin,
+)
 from wayflowcore.agentspec.components.agent import ExtendedAgent as AgentSpecExtendedAgent
 from wayflowcore.agentspec.components.contextprovider import (
     PluginConstantContextProvider as AgentSpecPluginConstantContextProvider,
@@ -1541,6 +1543,14 @@ class WayflowBuiltinsDeserializationPlugin(WayflowDeserializationPlugin):
                     if agentspec_component.sensitive_headers
                     else None
                 ),
+                input_descriptors=[
+                    self._convert_property_to_runtime(input_property)
+                    for input_property in agentspec_component.inputs or []
+                ],
+                output_descriptors=[
+                    self._convert_property_to_runtime(output_property)
+                    for output_property in agentspec_component.outputs or []
+                ],
                 requires_confirmation=agentspec_component.requires_confirmation,
                 **self._get_component_arguments(agentspec_component),
             )

--- a/wayflowcore/src/wayflowcore/serialization/_builtins_serialization_plugin.py
+++ b/wayflowcore/src/wayflowcore/serialization/_builtins_serialization_plugin.py
@@ -134,7 +134,9 @@ from wayflowcore.agentspec.components import (
 from wayflowcore.agentspec.components import (
     PluginVllmEmbeddingConfig as AgentSpecPluginVllmEmbeddingConfig,
 )
-from wayflowcore.agentspec.components import all_serialization_plugin
+from wayflowcore.agentspec.components import (
+    all_serialization_plugin,
+)
 from wayflowcore.agentspec.components.agent import ExtendedAgent as AgentSpecExtendedAgent
 from wayflowcore.agentspec.components.contextprovider import (
     PluginConstantContextProvider as AgentSpecPluginConstantContextProvider,
@@ -377,7 +379,9 @@ from wayflowcore.models.ociclientconfig import (
 from wayflowcore.models.ociclientconfig import (
     OCIClientConfigWithUserAuthentication as RuntimeOCIClientConfigWithUserAuthentication,
 )
-from wayflowcore.models.openaicompatiblemodel import EMPTY_API_KEY
+from wayflowcore.models.openaicompatiblemodel import (
+    EMPTY_API_KEY,
+)
 from wayflowcore.models.openaicompatiblemodel import (
     OpenAICompatibleModel as RuntimeOpenAICompatibleModel,
 )
@@ -1361,6 +1365,14 @@ class WayflowBuiltinsSerializationPlugin(WayflowSerializationPlugin):
                 description=runtime_tool.description,
                 url=runtime_tool.url,
                 http_method=inner_api_step.method,
+                inputs=[
+                    _runtime_property_to_pyagentspec_property(input_)
+                    for input_ in runtime_tool.input_descriptors or []
+                ],
+                outputs=[
+                    _runtime_property_to_pyagentspec_property(output)
+                    for output in runtime_tool.output_descriptors or []
+                ],
                 data=data_param,
                 query_params=(
                     inner_api_step.params if isinstance(inner_api_step.params, dict) else dict()

--- a/wayflowcore/src/wayflowcore/serialization/_builtins_serialization_plugin.py
+++ b/wayflowcore/src/wayflowcore/serialization/_builtins_serialization_plugin.py
@@ -134,9 +134,7 @@ from wayflowcore.agentspec.components import (
 from wayflowcore.agentspec.components import (
     PluginVllmEmbeddingConfig as AgentSpecPluginVllmEmbeddingConfig,
 )
-from wayflowcore.agentspec.components import (
-    all_serialization_plugin,
-)
+from wayflowcore.agentspec.components import all_serialization_plugin
 from wayflowcore.agentspec.components.agent import ExtendedAgent as AgentSpecExtendedAgent
 from wayflowcore.agentspec.components.contextprovider import (
     PluginConstantContextProvider as AgentSpecPluginConstantContextProvider,
@@ -379,9 +377,7 @@ from wayflowcore.models.ociclientconfig import (
 from wayflowcore.models.ociclientconfig import (
     OCIClientConfigWithUserAuthentication as RuntimeOCIClientConfigWithUserAuthentication,
 )
-from wayflowcore.models.openaicompatiblemodel import (
-    EMPTY_API_KEY,
-)
+from wayflowcore.models.openaicompatiblemodel import EMPTY_API_KEY
 from wayflowcore.models.openaicompatiblemodel import (
     OpenAICompatibleModel as RuntimeOpenAICompatibleModel,
 )

--- a/wayflowcore/tests/agentspec/test_agentspec_to_core_conversion.py
+++ b/wayflowcore/tests/agentspec/test_agentspec_to_core_conversion.py
@@ -239,7 +239,6 @@ def test_toolnode_with_remote_tool_custom_output_can_be_loaded(
     tool_node = AgentSpecToolNode(
         name="search_tool",
         tool=agentspec_remote_tool_with_specified_io,
-        outputs=[AgentSpecStringProperty(title="search_results", type="string")],
     )
 
     loaded_step = AgentSpecLoader().load_component(tool_node)

--- a/wayflowcore/tests/agentspec/test_agentspec_to_core_conversion.py
+++ b/wayflowcore/tests/agentspec/test_agentspec_to_core_conversion.py
@@ -10,14 +10,19 @@ from typing import Any, Dict, Union, cast
 
 import pytest
 from pyagentspec.agent import Agent as AgentSpecAgent
+from pyagentspec.flows.nodes.toolnode import ToolNode as AgentSpecToolNode
 from pyagentspec.llms import VllmConfig
+from pyagentspec.property import StringProperty as AgentSpecStringProperty
 from pyagentspec.serialization import AgentSpecSerializer
+from pyagentspec.tools.remotetool import RemoteTool as AgentSpecRemoteTool
 
 from wayflowcore.agent import Agent as RuntimeAgent
 from wayflowcore.agent import CallerInputMode
 from wayflowcore.agentspec import AgentSpecLoader
 from wayflowcore.executors.executionstatus import ExecutionStatus, FinishedStatus
 from wayflowcore.flow import Flow as RuntimeFlow
+from wayflowcore.steps import ToolExecutionStep
+from wayflowcore.tools import RemoteTool as RuntimeRemoteTool
 from wayflowcore.tools.servertools import ServerTool
 
 from ..testhelpers.testhelpers import retry_test
@@ -31,6 +36,19 @@ from ..conftest import (  # isort:skip
 from ..mcptools.conftest import sse_mcp_server_http  # isort:skip
 
 CONFIGS_DIR = Path(os.path.dirname(__file__)) / "configs"
+
+
+@pytest.fixture
+def agentspec_search_remote_tool() -> AgentSpecRemoteTool:
+    return AgentSpecRemoteTool(
+        name="search_service",
+        description="Searches a remote service and returns structured results.",
+        url="https://example.com",
+        http_method="POST",
+        data={"payload": {"query": "{{query}}"}},
+        inputs=[AgentSpecStringProperty(title="query", type="string")],
+        outputs=[AgentSpecStringProperty(title="search_results", type="string")],
+    )
 
 
 @pytest.mark.parametrize(
@@ -201,6 +219,37 @@ def test_apinode_exposes_http_response_among_outputs_when_executed() -> None:
     status = conversation.execute()
     assert isinstance(status, FinishedStatus)
     assert "http_response" in status.output_values
+
+
+def test_agentspec_remote_tool_preserves_custom_io_descriptors_when_loaded(
+    agentspec_search_remote_tool: AgentSpecRemoteTool,
+) -> None:
+    loaded_remote_tool = AgentSpecLoader().load_component(agentspec_search_remote_tool)
+
+    assert isinstance(loaded_remote_tool, RuntimeRemoteTool)
+    assert [descriptor.name for descriptor in loaded_remote_tool.input_descriptors] == ["query"]
+    assert [descriptor.name for descriptor in loaded_remote_tool.output_descriptors] == [
+        "search_results"
+    ]
+
+
+def test_toolnode_with_remote_tool_custom_output_can_be_loaded(
+    agentspec_search_remote_tool: AgentSpecRemoteTool,
+) -> None:
+    tool_node = AgentSpecToolNode(
+        name="search_tool",
+        tool=agentspec_search_remote_tool,
+        inputs=[AgentSpecStringProperty(title="query", type="string")],
+        outputs=[AgentSpecStringProperty(title="search_results", type="string")],
+    )
+
+    loaded_step = AgentSpecLoader().load_component(tool_node)
+
+    assert isinstance(loaded_step, ToolExecutionStep)
+    assert [descriptor.name for descriptor in loaded_step.tool.output_descriptors] == [
+        "search_results"
+    ]
+    assert [descriptor.name for descriptor in loaded_step.output_descriptors] == ["search_results"]
 
 
 @pytest.mark.parametrize(

--- a/wayflowcore/tests/agentspec/test_agentspec_to_core_conversion.py
+++ b/wayflowcore/tests/agentspec/test_agentspec_to_core_conversion.py
@@ -39,7 +39,7 @@ CONFIGS_DIR = Path(os.path.dirname(__file__)) / "configs"
 
 
 @pytest.fixture
-def agentspec_search_remote_tool() -> AgentSpecRemoteTool:
+def agentspec_remote_tool_with_specified_io() -> AgentSpecRemoteTool:
     return AgentSpecRemoteTool(
         name="search_service",
         description="Searches a remote service and returns structured results.",
@@ -222,9 +222,9 @@ def test_apinode_exposes_http_response_among_outputs_when_executed() -> None:
 
 
 def test_agentspec_remote_tool_preserves_custom_io_descriptors_when_loaded(
-    agentspec_search_remote_tool: AgentSpecRemoteTool,
+    agentspec_remote_tool_with_specified_io: AgentSpecRemoteTool,
 ) -> None:
-    loaded_remote_tool = AgentSpecLoader().load_component(agentspec_search_remote_tool)
+    loaded_remote_tool = AgentSpecLoader().load_component(agentspec_remote_tool_with_specified_io)
 
     assert isinstance(loaded_remote_tool, RuntimeRemoteTool)
     assert [descriptor.name for descriptor in loaded_remote_tool.input_descriptors] == ["query"]
@@ -234,12 +234,11 @@ def test_agentspec_remote_tool_preserves_custom_io_descriptors_when_loaded(
 
 
 def test_toolnode_with_remote_tool_custom_output_can_be_loaded(
-    agentspec_search_remote_tool: AgentSpecRemoteTool,
+    agentspec_remote_tool_with_specified_io: AgentSpecRemoteTool,
 ) -> None:
     tool_node = AgentSpecToolNode(
         name="search_tool",
-        tool=agentspec_search_remote_tool,
-        inputs=[AgentSpecStringProperty(title="query", type="string")],
+        tool=agentspec_remote_tool_with_specified_io,
         outputs=[AgentSpecStringProperty(title="search_results", type="string")],
     )
 

--- a/wayflowcore/tests/agentspec/test_core_to_agentspec_conversion.py
+++ b/wayflowcore/tests/agentspec/test_core_to_agentspec_conversion.py
@@ -11,6 +11,7 @@ from typing import Dict, Union, cast
 
 import pytest
 import yaml
+from pyagentspec.tools.remotetool import RemoteTool as AgentSpecRemoteTool
 
 from wayflowcore.a2a.a2aagent import A2AAgent as RuntimeA2AAgent
 from wayflowcore.agent import Agent as RuntimeAgent
@@ -18,12 +19,27 @@ from wayflowcore.agent import CallerInputMode
 from wayflowcore.agentspec import AgentSpecExporter, AgentSpecLoader
 from wayflowcore.flow import Flow as RuntimeFlow
 from wayflowcore.ociagent import OciAgent as RuntimeOciAgent
+from wayflowcore.property import StringProperty as RuntimeStringProperty
+from wayflowcore.tools import RemoteTool as RuntimeRemoteTool
 from wayflowcore.tools.servertools import ServerTool
 
 from ..conftest import mock_llm
 from ..testhelpers.testhelpers import assert_agents_are_copies, assert_flows_are_copies
 
 CONFIGS_DIR = Path(os.path.dirname(__file__)) / "configs"
+
+
+@pytest.fixture
+def runtime_search_remote_tool() -> RuntimeRemoteTool:
+    return RuntimeRemoteTool(
+        tool_name="search_service",
+        tool_description="Searches a remote service and returns structured results.",
+        url="https://example.com",
+        method="POST",
+        data={"payload": {"query": "{{query}}"}},
+        input_descriptors=[RuntimeStringProperty(name="query")],
+        output_descriptors=[RuntimeStringProperty(name="search_results")],
+    )
 
 
 @pytest.mark.parametrize(
@@ -115,6 +131,18 @@ def test_agentspec_config_can_be_converted_to_core_then_back_to_agentspec(
     )
     assert '"inputs":' in agentspec_json
     assert '"outputs":' in agentspec_json
+
+
+def test_runtime_remote_tool_preserves_custom_io_descriptors_when_exported(
+    runtime_search_remote_tool: RuntimeRemoteTool,
+) -> None:
+    exported_remote_tool = AgentSpecExporter().to_component(runtime_search_remote_tool)
+
+    assert isinstance(exported_remote_tool, AgentSpecRemoteTool)
+    assert [descriptor.title for descriptor in exported_remote_tool.inputs or []] == ["query"]
+    assert [descriptor.title for descriptor in exported_remote_tool.outputs or []] == [
+        "search_results"
+    ]
 
 
 @pytest.mark.parametrize(

--- a/wayflowcore/tests/agentspec/test_core_to_agentspec_conversion.py
+++ b/wayflowcore/tests/agentspec/test_core_to_agentspec_conversion.py
@@ -30,7 +30,7 @@ CONFIGS_DIR = Path(os.path.dirname(__file__)) / "configs"
 
 
 @pytest.fixture
-def runtime_search_remote_tool() -> RuntimeRemoteTool:
+def runtime_remote_tool_with_specified_io() -> RuntimeRemoteTool:
     return RuntimeRemoteTool(
         tool_name="search_service",
         tool_description="Searches a remote service and returns structured results.",
@@ -134,15 +134,17 @@ def test_agentspec_config_can_be_converted_to_core_then_back_to_agentspec(
 
 
 def test_runtime_remote_tool_preserves_custom_io_descriptors_when_exported(
-    runtime_search_remote_tool: RuntimeRemoteTool,
+    runtime_remote_tool_with_specified_io: RuntimeRemoteTool,
 ) -> None:
-    exported_remote_tool = AgentSpecExporter().to_component(runtime_search_remote_tool)
+    exported_remote_tool = AgentSpecExporter().to_component(runtime_remote_tool_with_specified_io)
 
     assert isinstance(exported_remote_tool, AgentSpecRemoteTool)
-    assert [descriptor.title for descriptor in exported_remote_tool.inputs or []] == ["query"]
-    assert [descriptor.title for descriptor in exported_remote_tool.outputs or []] == [
-        "search_results"
-    ]
+    assert exported_remote_tool.inputs is not None and [
+        descriptor.title for descriptor in exported_remote_tool.inputs
+    ] == ["query"]
+    assert exported_remote_tool.outputs is not None and [
+        descriptor.title for descriptor in exported_remote_tool.outputs
+    ] == ["search_results"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- preserve explicit `RemoteTool` inputs and outputs when converting Agent Spec to WayFlow
- preserve explicit `RemoteTool` inputs and outputs when converting WayFlow back to Agent Spec
- add regression coverage in the existing Agent Spec conversion test files

## Bug
Custom `RemoteTool` IO descriptors were dropped during conversion, so runtime tools fell back to the default `http_response` output. That broke `ToolNode` validation when flows expected a declared custom output instead.

## Verification
- `pytest -q wayflowcore/tests/agentspec/test_agentspec_to_core_conversion.py -q -k "remote_tool_preserves_custom_io_descriptors_when_loaded or toolnode_with_remote_tool_custom_output_can_be_loaded"`
- `pytest -q wayflowcore/tests/agentspec/test_core_to_agentspec_conversion.py -q -k "runtime_remote_tool_preserves_custom_io_descriptors_when_exported"`
- `pytest -q wayflowcore/tests/agentspec/test_sensitive_fields.py -q`
- `pytest -q wayflowcore/tests/integration/tools/test_remote_tool.py -q -k "not agent_can_use"`
- `python test_remote_tool.py`