### PR TITLE
Fix summarization transform serialization and multi-agent wiring

### DIFF
--- a/docs/wayflowcore/source/core/changelog.rst
+++ b/docs/wayflowcore/source/core/changelog.rst
@@ -98,6 +98,16 @@ Possibly Breaking Changes
 Bug fixes
 ^^^^^^^^^
 
+* **Fix summarization transform persistence and multi-agent integration**
+
+  ``MessageSummarizationTransform`` and ``ConversationSummarizationTransform`` now serialize the configuration required to deserialize
+  prompt templates and resume serialized conversations correctly. ``Swarm`` and ``ManagerWorkers`` also now apply their component-level
+  ``transforms`` during execution, making it possible to attach summarization transforms directly to these multi-agent components.
+
+  See the guide on :ref:`using Swarm <swarm_transform_ordering>` and :ref:`ManagerWorkers <managerworkers_transform_ordering>` to learn
+  more about how component-level transforms are combined with prompt template transforms during execution.
+
+
 * Fix: conversations no longer replay already-materialized tool results when resuming manager-worker executions,
   which could previously duplicate internal `send_message` results and break continued execution after serialization.
 

--- a/docs/wayflowcore/source/core/code_examples/howto_managerworkers.py
+++ b/docs/wayflowcore/source/core/code_examples/howto_managerworkers.py
@@ -284,6 +284,23 @@ group = ManagerWorkers(
 )
 # .. end-##_Managerworkers_pattern
 
+# .. start-##_Managerworkers_pattern_with_transforms
+from wayflowcore.transforms import ConversationSummarizationTransform
+
+summarization_transform = ConversationSummarizationTransform(
+    llm=llm,
+    max_num_messages=30,
+    min_num_messages=10,
+    datastore=None,
+)
+
+group_with_summarization = ManagerWorkers(
+    group_manager=customer_service_manager,
+    workers=[refund_specialist_agent, surveyor_agent],
+    transforms=[summarization_transform],
+)
+# .. end-##_Managerworkers_pattern_with_transforms
+
 # .. start-##_Managerworkers_answers_without_expert
 main_conversation = group.start_conversation(
     inputs={

--- a/docs/wayflowcore/source/core/code_examples/howto_swarm.py
+++ b/docs/wayflowcore/source/core/code_examples/howto_swarm.py
@@ -212,6 +212,28 @@ assistant = Swarm(
 )
 # .. end-##_Creating_the_Swarm
 
+# .. start-##_Creating_the_Swarm_With_Transforms
+from wayflowcore.transforms import ConversationSummarizationTransform
+
+summarization_transform = ConversationSummarizationTransform(
+    llm=llm,
+    max_num_messages=30,
+    min_num_messages=10,
+    datastore=None,
+)
+
+assistant_with_summarization = Swarm(
+    name="SwarmWithSummarization",
+    first_agent=general_practitioner,
+    relationships=[
+        (general_practitioner, pharmacist),
+        (general_practitioner, dermatologist),
+        (dermatologist, pharmacist),
+    ],
+    transforms=[summarization_transform],
+)
+# .. end-##_Creating_the_Swarm_With_Transforms
+
 # .. start-##_Running_the_Swarm
 # With a linear conversation
 conversation = assistant.start_conversation()

--- a/docs/wayflowcore/source/core/howtoguides/howto_long_context.rst
+++ b/docs/wayflowcore/source/core/howtoguides/howto_long_context.rst
@@ -40,6 +40,8 @@ This guide demonstrates three methods for reducing context size using built-in t
 
 
 This guide shows how to use built-in :ref:`MessageTransform <messagetransform>` objects to reduce the context size in agents.
+The same transforms can also be attached directly to :ref:`Swarm <swarm>` and :ref:`ManagerWorkers <managerworkers>`
+through their ``transforms`` constructor argument when you need long-context handling in multi-agent patterns.
 
 Introduction
 ============
@@ -51,6 +53,10 @@ A :ref:`MessageTransform <MessageTransform>` is a transformation applied to a li
 more about them in the :doc:`Advanced Prompting Techniques <howto_prompttemplate>` guide.
 
 In this guide, we use built-in message transforms to adjust the agent's chat history by passing them directly to the :ref:`Agent <agent>` constructor.
+For :ref:`Swarm <swarm>` and :ref:`ManagerWorkers <managerworkers>`, the ``transforms`` constructor argument behaves the same way:
+component-level transforms are prepended to any transforms already defined on the prompt template, so user-provided transforms run first.
+For ``Swarm``, when the active agent also defines ``Agent(..., transforms=[...])``, those agent-level transforms run before
+the swarm-level transforms. See :ref:`Swarm transform ordering <swarm_transform_ordering>` for the full ordering.
 
 LLM Setup
 ~~~~~~~~~
@@ -82,6 +88,10 @@ We use the built-in :ref:`MessageSummarizationTransform <messagesummarizationtra
 .. note::
    When creating :ref:`MessageSummarizationTransform <messagesummarizationtransform>` without specifying a ``datastore``, it will initialize a default :ref:`InMemoryDatastore <inmemorydatastore>` for caching, which is only suitable for prototyping. This will raise a user warning indicating that in-memory datastores are not recommended for production systems.
    For production systems, you can use :ref:`OracleDatabaseDatastore <oracledatabasedatastore>` or :ref:`PostgresDatabaseDatastore <postgresdatabasedatastore>`.
+
+.. important::
+   If you serialize and later deserialize a conversation or prompt template that uses summarization transforms, the transform configuration is restored, including the summarization LLM settings and datastore configuration.
+   However, an :ref:`InMemoryDatastore <inmemorydatastore>` does not preserve cached summary rows across process restarts. If you need summary cache reuse after deserialization in a persistent application, use a database-backed datastore such as :ref:`OracleDatabaseDatastore <oracledatabasedatastore>` or :ref:`PostgresDatabaseDatastore <postgresdatabasedatastore>`.
 
 Let's integrate the :ref:`MessageSummarizationTransform <messagesummarizationtransform>` into the :ref:`Agent <agent>`:
 

--- a/docs/wayflowcore/source/core/howtoguides/howto_managerworkers.rst
+++ b/docs/wayflowcore/source/core/howtoguides/howto_managerworkers.rst
@@ -218,6 +218,35 @@ The ManagerWorkers has two main parameters:
   - Worker agents cannot interact with the end user directly.
   - When invoked, each worker can leverage its equipped tools to complete the assigned task and report the result back to the group manager.
 
+``ManagerWorkers`` also accepts a ``transforms`` parameter. This is the recommended way to apply message transforms such as
+:ref:`MessageSummarizationTransform <messagesummarizationtransform>` or :ref:`ConversationSummarizationTransform <conversationsummarizationtransform>`
+to the manager's rendered prompt in a multi-agent setup.
+These component-level transforms are prepended to any transforms already present on the ``managerworkers_template``.
+If ``group_manager`` is itself an ``Agent`` with its own ``transforms``, those manager-agent transforms are also preserved during execution.
+
+.. literalinclude:: ../code_examples/howto_managerworkers.py
+    :language: python
+    :start-after: .. start-##_Managerworkers_pattern_with_transforms
+    :end-before: .. end-##_Managerworkers_pattern_with_transforms
+
+.. _managerworkers_transform_ordering:
+
+.. note::
+   **How ``transforms`` and ``managerworkers_template`` work together**
+
+   During execution, WayFlow builds the manager agent's effective runtime template from the configured ``managerworkers_template``.
+   If ``group_manager`` is an ``Agent`` with its own pre-rendering transforms, those run first, then ``managerworkers.transforms``, and finally any pre-rendering transforms already attached directly to ``managerworkers_template``.
+   The effective order is therefore:
+
+   1. ``group_manager.transforms`` for the group manager, when ``group_manager`` is an ``Agent``
+   2. ``managerworkers.transforms`` in the order you passed them
+   3. ``managerworkers_template.pre_rendering_transforms``
+
+   This means the most specific transforms run first: manager-agent before manager-workers, and manager-workers before template-level transforms.
+
+When a ``ManagerWorkers`` conversation is serialized and later deserialized, the summarization transform configuration is restored.
+Use a persistent datastore if you also need the summary cache contents to survive application restarts.
+
 Executing the ManagerWorkers
 ----------------------------
 

--- a/docs/wayflowcore/source/core/howtoguides/howto_serialize_conversations.rst
+++ b/docs/wayflowcore/source/core/howtoguides/howto_serialize_conversations.rst
@@ -193,6 +193,8 @@ Important considerations:
 - Flows can be serialized while waiting for user input
 - The loaded Flow conversation resumes exactly where it left off
 - User input can be provided to the loaded conversation to continue execution
+- If your component uses :ref:`MessageSummarizationTransform <messagesummarizationtransform>` or :ref:`ConversationSummarizationTransform <conversationsummarizationtransform>`, their configuration is serialized with the component and restored on deserialization
+- If those transforms use an :ref:`InMemoryDatastore <inmemorydatastore>` for caching, cached summary rows are not preserved across restarts; use a persistent datastore if cache continuity matters
 
 Building persistent applications
 ================================

--- a/docs/wayflowcore/source/core/howtoguides/howto_swarm.rst
+++ b/docs/wayflowcore/source/core/howtoguides/howto_swarm.rst
@@ -225,6 +225,39 @@ The Dermatologist can also delegate with the Pharmacist.
 When invoked, each agent can either respond to its caller (a human user or another agent) or choose to initiate a discussion with
 another agent if they are given the capability to do so.
 
+You can also attach message transforms directly on the ``Swarm`` with the ``transforms`` parameter. This is useful for patterns such as
+:ref:`MessageSummarizationTransform <messagesummarizationtransform>` and :ref:`ConversationSummarizationTransform <conversationsummarizationtransform>`,
+where you want long-context handling to apply to the active agent's effective runtime prompt inside the swarm.
+These swarm-level transforms are prepended ahead of any transforms already configured on the ``swarm_template``.
+
+.. literalinclude:: ../code_examples/howto_swarm.py
+    :language: python
+    :start-after: .. start-##_Creating_the_Swarm_With_Transforms
+    :end-before: .. end-##_Creating_the_Swarm_With_Transforms
+
+.. _swarm_transform_ordering:
+
+.. note::
+   **How ``transforms`` and ``swarm_template`` work together**
+
+   During execution, WayFlow always renders prompts from the configured ``swarm_template``, and applies that prompt surface to the active agent.
+   The active agent's own pre-rendering transforms are prepended first, then ``swarm.transforms``,
+   and finally any pre-rendering transforms already configured directly on ``swarm_template``.
+   The effective pre-rendering order is therefore:
+
+   1. ``active_agent.transforms``
+   2. ``swarm.transforms``
+   3. ``swarm_template.pre_rendering_transforms``
+
+   This means the most specific transforms run first: agent-level before swarm-level, and swarm-level before
+   template-level transforms.
+
+   If you use ``_DEFAULT_SWARM_CHAT_TEMPLATE``, note that its built-in formatting transforms are
+   ``post_rendering_transforms``. They run after the pre-rendering order above and after the template has been rendered.
+
+If you serialize and later deserialize a swarm conversation, the summarization transform configuration is restored as part of the prompt template and component configuration.
+For persistent deployments, prefer a database-backed datastore for the summary cache so previously computed summaries remain available after restarts.
+
 Executing the Swarm
 -------------------
 

--- a/wayflowcore/src/wayflowcore/executors/_managerworkersexecutor.py
+++ b/wayflowcore/src/wayflowcore/executors/_managerworkersexecutor.py
@@ -119,7 +119,9 @@ class ManagerWorkersRunner(ConversationExecutor):
                 # Manager agent should have tool to talk to user
                 mutated_agent_tools.append(_make_talk_to_user_tool())
 
-        mutated_agent_template = managerworkers_config.managerworkers_template.with_partial(
+        mutated_agent_template = managerworkers_config._compose_runtime_manager_agent_template(
+            current_agent
+        ).with_partial(
             {
                 "name": current_agent.name,
                 "description": current_agent.description,

--- a/wayflowcore/src/wayflowcore/executors/_swarmexecutor.py
+++ b/wayflowcore/src/wayflowcore/executors/_swarmexecutor.py
@@ -176,7 +176,9 @@ class SwarmRunner(ConversationExecutor):
                 ]
             mutated_agent_tools = list(current_agent.tools) + communication_tools
 
-            mutated_agent_template = swarm_config.swarm_template.with_partial(
+            mutated_agent_template = swarm_config._compose_runtime_agent_template(
+                current_agent
+            ).with_partial(
                 {
                     "name": current_agent.name,
                     "description": current_agent.description,

--- a/wayflowcore/src/wayflowcore/managerworkers.py
+++ b/wayflowcore/src/wayflowcore/managerworkers.py
@@ -19,6 +19,7 @@ from wayflowcore.serialization.serializer import SerializableDataclassMixin, Ser
 from wayflowcore.templates import PromptTemplate
 from wayflowcore.templates._managerworkerstemplate import _DEFAULT_MANAGERWORKERS_CHAT_TEMPLATE
 from wayflowcore.tools import Tool
+from wayflowcore.transforms import MessageTransform
 
 if TYPE_CHECKING:
     from wayflowcore.executors._managerworkersconversation import ManagerWorkersConversation
@@ -32,6 +33,7 @@ class ManagerWorkers(ConversationalComponent, SerializableDataclassMixin, Serial
     group_manager: Union[LlmModel, Agent]
     workers: List[Union[Agent, "ManagerWorkers"]]
     caller_input_mode: CallerInputMode
+    transforms: List[MessageTransform]
     managerworkers_template: "PromptTemplate"
     input_descriptors: List["Property"]
     output_descriptors: List["Property"]
@@ -45,6 +47,7 @@ class ManagerWorkers(ConversationalComponent, SerializableDataclassMixin, Serial
         group_manager: Union[LlmModel, Agent],
         workers: List[Union[Agent, "ManagerWorkers"]],
         caller_input_mode: CallerInputMode = CallerInputMode.ALWAYS,
+        transforms: Optional[List[MessageTransform]] = None,
         managerworkers_template: Optional["PromptTemplate"] = None,
         input_descriptors: Optional[List["Property"]] = None,
         output_descriptors: Optional[List["Property"]] = None,
@@ -69,6 +72,11 @@ class ManagerWorkers(ConversationalComponent, SerializableDataclassMixin, Serial
         caller_input_mode:
             Whether the manager can ask the user for additional information or needs to handle the task internally within the team.
             This overrides manager agent's ``caller_input_mode``.
+        transforms:
+            Message transforms configured on the manager-workers component. These transforms are prepended to
+            the manager-workers template pre-rendering transforms during execution, so user-provided transforms
+            run first. When ``group_manager`` is an ``Agent`` with ``Agent(..., transforms=[...])``,
+            those manager-level transforms are prepended before the manager-workers-level transforms.
         input_descriptors:
             Input descriptors of the ManagerWorkers. ``None`` means the ManagerWorks will resolve the input descriptors automatically in a best effort manner.
 
@@ -124,6 +132,7 @@ class ManagerWorkers(ConversationalComponent, SerializableDataclassMixin, Serial
         self.manager_agent = _create_manager_agent(self.group_manager)
 
         self.workers = workers
+        self.transforms = transforms or []
 
         self._agent_by_name: Dict[str, Union["Agent", "ManagerWorkers"]] = _validate_agent_unicity(
             self.workers + [self.manager_agent]
@@ -134,6 +143,9 @@ class ManagerWorkers(ConversationalComponent, SerializableDataclassMixin, Serial
 
         self.managerworkers_template = (
             managerworkers_template or _DEFAULT_MANAGERWORKERS_CHAT_TEMPLATE
+        )
+        self._runtime_managerworkers_template: PromptTemplate = (
+            self._compose_runtime_managerworkers_template()
         )
 
         self.caller_input_mode = caller_input_mode
@@ -148,6 +160,61 @@ class ManagerWorkers(ConversationalComponent, SerializableDataclassMixin, Serial
             conversation_class=ManagerWorkersConversation,
             __metadata_info__=__metadata_info__,
         )
+
+    def _compose_runtime_managerworkers_template(self) -> PromptTemplate:
+        runtime_managerworkers_template = self.managerworkers_template
+        template_transform_names = [
+            t.__class__.__name__
+            for t in runtime_managerworkers_template.pre_rendering_transforms or []
+        ]
+        if template_transform_names:
+            managerworkers_transform_names = [t.__class__.__name__ for t in self.transforms]
+            logger.info(
+                "ManagerWorkers-level transforms %s will be prepended to template transforms %s.",
+                managerworkers_transform_names,
+                template_transform_names,
+            )
+
+        for transform in self.transforms[::-1]:
+            runtime_managerworkers_template = (
+                runtime_managerworkers_template.with_additional_pre_rendering_transform(
+                    transform, append_last=False
+                )
+            )
+        return runtime_managerworkers_template
+
+    def _compose_runtime_manager_agent_template(self, agent: Agent) -> PromptTemplate:
+        """
+        Compose the prompt template used when the manager agent executes inside the pattern.
+
+        ManagerWorkers execution always uses the manager-workers prompt surface, but if the group
+        manager is itself an Agent, that agent's own pre-rendering transforms still need to run.
+        We therefore prepend the manager agent's template transforms to the already composed
+        manager-workers runtime template.
+        """
+        runtime_manager_agent_template = self._runtime_managerworkers_template
+        agent_template_transforms = agent.agent_template.pre_rendering_transforms or []
+
+        if agent_template_transforms:
+            agent_transform_names = [t.__class__.__name__ for t in agent_template_transforms]
+            managerworkers_transform_names = [
+                t.__class__.__name__
+                for t in runtime_manager_agent_template.pre_rendering_transforms or []
+            ]
+            logger.info(
+                "Manager agent transforms %s will be prepended to manager-workers transforms %s for agent '%s'.",
+                agent_transform_names,
+                managerworkers_transform_names,
+                agent.name,
+            )
+
+        for transform in agent_template_transforms[::-1]:
+            runtime_manager_agent_template = (
+                runtime_manager_agent_template.with_additional_pre_rendering_transform(
+                    transform, append_last=False
+                )
+            )
+        return runtime_manager_agent_template
 
     def start_conversation(
         self,
@@ -238,5 +305,13 @@ class ManagerWorkers(ConversationalComponent, SerializableDataclassMixin, Serial
         return all_tools
 
     def _update_internal_state(self) -> None:
-        # This method would need to be implemented if needed
-        pass
+        from wayflowcore.executors._agenticpattern_helpers import _create_communication_tools
+        from wayflowcore.executors._managerworkersexecutor import (
+            _create_manager_agent,
+            _validate_agent_unicity,
+        )
+
+        self.manager_agent = _create_manager_agent(self.group_manager)
+        self._agent_by_name = _validate_agent_unicity(self.workers + [self.manager_agent])
+        self._manager_communication_tools = _create_communication_tools()
+        self._runtime_managerworkers_template = self._compose_runtime_managerworkers_template()

--- a/wayflowcore/src/wayflowcore/serialization/_builtins_serialization_plugin.py
+++ b/wayflowcore/src/wayflowcore/serialization/_builtins_serialization_plugin.py
@@ -1764,7 +1764,9 @@ class WayflowBuiltinsSerializationPlugin(WayflowSerializationPlugin):
             )
         elif isinstance(runtime_messagetransform, RuntimeMessageSummarizationTransform):
             return AgentSpecMessageSummarizationTransform(
+                id=runtime_messagetransform.id,
                 name=runtime_messagetransform.name or "message-summarizer",
+                description=runtime_messagetransform.description,
                 llm=self._llm_convert_to_agentspec(
                     conversion_context, runtime_messagetransform.llm, referenced_objects
                 ),
@@ -1774,6 +1776,15 @@ class WayflowBuiltinsSerializationPlugin(WayflowSerializationPlugin):
                 max_cache_size=runtime_messagetransform.max_cache_size,
                 max_cache_lifetime=runtime_messagetransform.max_cache_lifetime,
                 cache_collection_name=runtime_messagetransform.cache_collection_name,
+                datastore=(
+                    self._datastore_convert_to_agentspec(
+                        conversion_context,
+                        runtime_messagetransform.cache.datastore,
+                        referenced_objects,
+                    )
+                    if runtime_messagetransform.cache is not None
+                    else None
+                ),
                 metadata=_create_agentspec_metadata_from_runtime_component(
                     runtime_messagetransform
                 ),
@@ -1781,7 +1792,9 @@ class WayflowBuiltinsSerializationPlugin(WayflowSerializationPlugin):
 
         elif isinstance(runtime_messagetransform, RuntimeConversationSummarizationTransform):
             return AgentSpecConversationSummarizationTransform(
+                id=runtime_messagetransform.id,
                 name=runtime_messagetransform.name or "conversation-summarizer",
+                description=runtime_messagetransform.description,
                 llm=self._llm_convert_to_agentspec(
                     conversion_context, runtime_messagetransform.llm, referenced_objects
                 ),
@@ -1793,6 +1806,15 @@ class WayflowBuiltinsSerializationPlugin(WayflowSerializationPlugin):
                 max_cache_size=runtime_messagetransform.max_cache_size,
                 max_cache_lifetime=runtime_messagetransform.max_cache_lifetime,
                 cache_collection_name=runtime_messagetransform.cache_collection_name,
+                datastore=(
+                    self._datastore_convert_to_agentspec(
+                        conversion_context,
+                        runtime_messagetransform.cache.datastore,
+                        referenced_objects,
+                    )
+                    if runtime_messagetransform.cache is not None
+                    else None
+                ),
                 metadata=_create_agentspec_metadata_from_runtime_component(
                     runtime_messagetransform
                 ),

--- a/wayflowcore/src/wayflowcore/swarm.py
+++ b/wayflowcore/src/wayflowcore/swarm.py
@@ -20,6 +20,7 @@ from wayflowcore.serialization.serializer import SerializableDataclassMixin, Ser
 from wayflowcore.templates import PromptTemplate
 from wayflowcore.templates._swarmtemplate import _DEFAULT_SWARM_CHAT_TEMPLATE
 from wayflowcore.tools import ClientTool, Tool
+from wayflowcore.transforms import MessageTransform
 
 if TYPE_CHECKING:
     from wayflowcore.conversation import Conversation
@@ -82,6 +83,7 @@ class Swarm(ConversationalComponent, SerializableDataclassMixin, SerializableObj
     relationships: List[Tuple[Agent, Agent]]
     handoff: Union[HandoffMode, bool]
     caller_input_mode: CallerInputMode
+    transforms: List[MessageTransform]
     swarm_template: "PromptTemplate"
     input_descriptors: List["Property"]
     output_descriptors: List["Property"]
@@ -96,6 +98,7 @@ class Swarm(ConversationalComponent, SerializableDataclassMixin, SerializableObj
         relationships: List[Tuple[Agent, Agent]],
         handoff: Union[HandoffMode, bool] = HandoffMode.OPTIONAL,
         caller_input_mode: CallerInputMode = CallerInputMode.ALWAYS,
+        transforms: Optional[List[MessageTransform]] = None,
         swarm_template: Optional[PromptTemplate] = None,
         input_descriptors: Optional[List["Property"]] = None,
         output_descriptors: Optional[List["Property"]] = None,
@@ -150,6 +153,12 @@ class Swarm(ConversationalComponent, SerializableDataclassMixin, SerializableObj
             Output descriptors of the swarm. ``None`` means the swarm will resolve them automatically in a best effort manner.
         caller_input_mode:
             Whether the agent in swarm can ask the user for additional information or needs to handle the task internally within the swarm.
+        transforms:
+            Message transforms configured on the swarm. During execution, the active agent runs with an
+            effective runtime template derived from the swarm prompt surface, and these transforms are
+            prepended ahead of ``swarm_template.pre_rendering_transforms`` in that runtime template.
+            When the active agent also defines ``Agent(..., transforms=[...])``, those agent-level transforms
+            are prepended before the swarm-level transforms.
         name:
             name of the swarm, used for composition
         description:
@@ -217,13 +226,15 @@ class Swarm(ConversationalComponent, SerializableDataclassMixin, SerializableObj
                 logger.debug("Agent '%s' does not have any recipient", agent_name)
                 continue
 
-            send_message_tools = _create_communication_tools(self.handoff)
+            send_message_tools = _create_communication_tools(self._get_handoff_mode())
             self._communication_tools[agent_name].extend(send_message_tools)
 
         self.first_agent = first_agent
         self.relationships = relationships or []
         self.swarm_template = swarm_template or _DEFAULT_SWARM_CHAT_TEMPLATE
         self.caller_input_mode = caller_input_mode
+        self.transforms = transforms or []
+        self._runtime_swarm_template: PromptTemplate = self._compose_runtime_swarm_template()
 
         super().__init__(
             name=IdGenerator.get_or_generate_name(name, prefix="swarm_", length=8),
@@ -235,6 +246,65 @@ class Swarm(ConversationalComponent, SerializableDataclassMixin, SerializableObj
             conversation_class=SwarmConversation,
             __metadata_info__=__metadata_info__,
         )
+
+    def _compose_runtime_swarm_template(self) -> PromptTemplate:
+        runtime_swarm_template = self.swarm_template
+        template_transform_names = [
+            t.__class__.__name__ for t in runtime_swarm_template.pre_rendering_transforms or []
+        ]
+        if template_transform_names:
+            swarm_transform_names = [t.__class__.__name__ for t in self.transforms]
+            logger.info(
+                "Swarm-level transforms %s will be prepended to template transforms %s.",
+                swarm_transform_names,
+                template_transform_names,
+            )
+
+        for transform in self.transforms[::-1]:
+            runtime_swarm_template = runtime_swarm_template.with_additional_pre_rendering_transform(
+                transform, append_last=False
+            )
+        return runtime_swarm_template
+
+    def _get_handoff_mode(self) -> HandoffMode:
+        """
+        Return the normalized runtime handoff mode.
+
+        ``self.handoff`` is normalized to ``HandoffMode`` in ``__init__``, but this helper keeps
+        the contract explicit for type checkers and refresh paths.
+        """
+        if isinstance(self.handoff, HandoffMode):
+            return self.handoff
+        return HandoffMode.OPTIONAL if self.handoff else HandoffMode.NEVER
+
+    def _compose_runtime_agent_template(self, agent: Agent) -> PromptTemplate:
+        """
+        Compose the prompt template used when a specific agent executes inside the swarm.
+
+        Swarm execution always uses the swarm prompt surface, but the active agent's own
+        pre-rendering transforms still need to run. We therefore prepend the agent template's
+        pre-rendering transforms to the already composed swarm runtime template.
+        """
+        runtime_agent_template = self._runtime_swarm_template
+        agent_template_transforms = agent.agent_template.pre_rendering_transforms or []
+
+        if agent_template_transforms:
+            agent_transform_names = [t.__class__.__name__ for t in agent_template_transforms]
+            swarm_transform_names = [
+                t.__class__.__name__ for t in runtime_agent_template.pre_rendering_transforms or []
+            ]
+            logger.info(
+                "Agent-level transforms %s will be prepended to swarm transforms %s for agent '%s'.",
+                agent_transform_names,
+                swarm_transform_names,
+                agent.name,
+            )
+
+        for transform in agent_template_transforms[::-1]:
+            runtime_agent_template = runtime_agent_template.with_additional_pre_rendering_transform(
+                transform, append_last=False
+            )
+        return runtime_agent_template
 
     def start_conversation(
         self,
@@ -305,5 +375,25 @@ class Swarm(ConversationalComponent, SerializableDataclassMixin, SerializableObj
         return all_tools
 
     def _update_internal_state(self) -> None:
-        # This method would need to be implemented if needed
-        pass
+        from wayflowcore.executors._agenticpattern_helpers import _create_communication_tools
+        from wayflowcore.executors._swarmexecutor import (
+            _get_all_recipients_for_agent,
+            _validate_agent_unicity,
+            _validate_relationships_unicity,
+        )
+
+        self._agent_by_name = _validate_agent_unicity(self.first_agent, self.relationships)
+        _validate_relationships_unicity(self.relationships)
+
+        self._communication_tools = {}
+        for agent_name, agent in self._agent_by_name.items():
+            self._communication_tools[agent_name] = []
+            agent_recipients = _get_all_recipients_for_agent(self.relationships, agent)
+            if not agent_recipients:
+                logger.debug("Agent '%s' does not have any recipient", agent_name)
+                continue
+
+            send_message_tools = _create_communication_tools(self._get_handoff_mode())
+            self._communication_tools[agent_name].extend(send_message_tools)
+
+        self._runtime_swarm_template = self._compose_runtime_swarm_template()

--- a/wayflowcore/src/wayflowcore/transforms/summarization.py
+++ b/wayflowcore/src/wayflowcore/transforms/summarization.py
@@ -20,6 +20,12 @@ from wayflowcore.messagelist import ImageContent, Message, MessageContent, TextC
 from wayflowcore.models.llmmodel import Prompt
 from wayflowcore.models.tokenusagehelpers import CountTokensHeuristics
 from wayflowcore.property import FloatProperty, IntegerProperty, StringProperty
+from wayflowcore.serialization.context import DeserializationContext, SerializationContext
+from wayflowcore.serialization.serializer import (
+    autodeserialize_from_dict,
+    deserialize_any_from_dict,
+    serialize_to_dict,
+)
 from wayflowcore.tools.tools import ToolResult
 from wayflowcore.transforms.transforms import MessageTransform
 
@@ -407,6 +413,63 @@ class MessageSummarizationTransform(MessageTransform):
     ) -> str:
         return conversation_id + "_" + str(message_idx) + "_" + _type
 
+    def _serialize_to_dict(self, serialization_context: SerializationContext) -> Dict[str, Any]:
+        return {
+            "llm": serialize_to_dict(self.llm, serialization_context),
+            "max_message_size": self.max_message_size,
+            "summarization_instructions": self.summarization_instructions,
+            "summarized_message_template": self.summarized_message_template,
+            "datastore": (
+                serialize_to_dict(self.cache.datastore, serialization_context)
+                if self.cache is not None
+                else None
+            ),
+            "cache_collection_name": self.cache_collection_name,
+            "max_cache_size": self.max_cache_size,
+            "max_cache_lifetime": self.max_cache_lifetime,
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+        }
+
+    @classmethod
+    def _deserialize_from_dict(
+        cls, input_dict: Dict[str, Any], deserialization_context: DeserializationContext
+    ) -> "MessageSummarizationTransform":
+        from wayflowcore.models import LlmModel
+
+        datastore = (
+            cast(
+                "Datastore",
+                autodeserialize_from_dict(input_dict["datastore"], deserialization_context),
+            )
+            if input_dict.get("datastore") is not None
+            else None
+        )
+
+        return cls(
+            llm=deserialize_any_from_dict(input_dict["llm"], LlmModel, deserialization_context),
+            max_message_size=input_dict.get("max_message_size", 20_000),
+            summarization_instructions=input_dict.get(
+                "summarization_instructions",
+                "Please make a summary of this message. Include relevant information and keep it short. "
+                "Your response will replace the message, so just output the summary directly, no introduction needed.",
+            ),
+            summarized_message_template=input_dict.get(
+                "summarized_message_template", "Summarized message: {{summary}}"
+            ),
+            datastore=datastore,
+            cache_collection_name=input_dict.get(
+                "cache_collection_name", cls.DEFAULT_CACHE_COLLECTION_NAME
+            ),
+            max_cache_size=input_dict.get("max_cache_size", 10_000),
+            max_cache_lifetime=input_dict.get("max_cache_lifetime", 4 * 3600),
+            id=input_dict.get("id"),
+            name=input_dict.get("name"),
+            description=input_dict.get("description"),
+            __metadata_info__=input_dict.get("__metadata_info__", {}),
+        )
+
 
 class ConversationSummarizationTransform(MessageTransform):
     """
@@ -663,4 +726,63 @@ class ConversationSummarizationTransform(MessageTransform):
                 "created_at": FloatProperty(),
                 "last_used_at": FloatProperty(),
             }
+        )
+
+    def _serialize_to_dict(self, serialization_context: SerializationContext) -> Dict[str, Any]:
+        return {
+            "llm": serialize_to_dict(self.llm, serialization_context),
+            "max_num_messages": self.max_num_messages,
+            "min_num_messages": self.min_num_messages,
+            "summarization_instructions": self.summarization_instructions,
+            "summarized_conversation_template": self.summarized_conversation_template,
+            "datastore": (
+                serialize_to_dict(self.cache.datastore, serialization_context)
+                if self.cache is not None
+                else None
+            ),
+            "max_cache_size": self.max_cache_size,
+            "max_cache_lifetime": self.max_cache_lifetime,
+            "cache_collection_name": self.cache_collection_name,
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+        }
+
+    @classmethod
+    def _deserialize_from_dict(
+        cls, input_dict: Dict[str, Any], deserialization_context: DeserializationContext
+    ) -> "ConversationSummarizationTransform":
+        from wayflowcore.models import LlmModel
+
+        datastore = (
+            cast(
+                "Datastore",
+                autodeserialize_from_dict(input_dict["datastore"], deserialization_context),
+            )
+            if input_dict.get("datastore") is not None
+            else None
+        )
+
+        return cls(
+            llm=deserialize_any_from_dict(input_dict["llm"], LlmModel, deserialization_context),
+            max_num_messages=input_dict.get("max_num_messages", 50),
+            min_num_messages=input_dict.get("min_num_messages", 10),
+            summarization_instructions=input_dict.get(
+                "summarization_instructions",
+                "Please make a summary of this conversation. Include relevant information and keep it short. "
+                "Your response will replace the messages, so just output the summary directly, no introduction needed.",
+            ),
+            summarized_conversation_template=input_dict.get(
+                "summarized_conversation_template", "Summarized conversation: {{summary}}"
+            ),
+            datastore=datastore,
+            max_cache_size=input_dict.get("max_cache_size", 10_000),
+            max_cache_lifetime=input_dict.get("max_cache_lifetime", 4 * 3600),
+            cache_collection_name=input_dict.get(
+                "cache_collection_name", cls.DEFAULT_CACHE_COLLECTION_NAME
+            ),
+            id=input_dict.get("id"),
+            name=input_dict.get("name"),
+            description=input_dict.get("description"),
+            __metadata_info__=input_dict.get("__metadata_info__", {}),
         )

--- a/wayflowcore/tests/agentspec/test_transforms.py
+++ b/wayflowcore/tests/agentspec/test_transforms.py
@@ -38,6 +38,12 @@ filter_in_memory_datastore_warnings = pytest.mark.filterwarnings(
 )
 
 
+def _get_datastore_schema(datastore):
+    return (
+        datastore.datastore_schema if hasattr(datastore, "datastore_schema") else datastore.schema
+    )
+
+
 def _testing_message_summarization_transforms():
     """Create both wayflow and agent-spec transforms with non-default values."""
     # Non-default values for comprehensive testing
@@ -70,6 +76,7 @@ def _testing_message_summarization_transforms():
         name="vllm", model_id=MOCK_LLM_CONFIG["model_id"], url=MOCK_LLM_CONFIG["host_port"]
     )
     agent_spec_datastore = InMemoryCollectionDatastore(
+        id=datastore.id,
         name="custom-inmemory-datastore",
         datastore_schema={
             custom_cache_collection_name: AgentSpecMessageSummarizationTransform.get_entity_definition()
@@ -130,6 +137,7 @@ def _testing_conversation_summarization_transforms(
         name="vllm", model_id=MOCK_LLM_CONFIG["model_id"], url=MOCK_LLM_CONFIG["host_port"]
     )
     agent_spec_datastore = InMemoryCollectionDatastore(
+        id=datastore.id,
         name="custom-inmemory-datastore-conversations",
         datastore_schema={
             custom_cache_collection_name: AgentSpecConversationSummarizationTransform.get_entity_definition()
@@ -211,6 +219,16 @@ def test_agentspec_summarization_conversation_transform_can_be_converted_to_wayf
 
 
 def assert_message_summarization_transforms_are_equal(converted_transform, expected_transform):
+    converted_datastore = (
+        converted_transform.datastore
+        if hasattr(converted_transform, "datastore")
+        else converted_transform.cache.datastore if converted_transform.cache is not None else None
+    )
+    expected_datastore = (
+        expected_transform.datastore
+        if hasattr(expected_transform, "datastore")
+        else expected_transform.cache.datastore if expected_transform.cache is not None else None
+    )
     # Check that the parameters match the ground truth from agent-spec
     assert converted_transform.max_message_size == expected_transform.max_message_size
     assert (
@@ -224,6 +242,14 @@ def assert_message_summarization_transforms_are_equal(converted_transform, expec
     assert converted_transform.max_cache_size == expected_transform.max_cache_size
     assert converted_transform.max_cache_lifetime == expected_transform.max_cache_lifetime
     assert converted_transform.cache_collection_name == expected_transform.cache_collection_name
+    assert (converted_datastore is None) == (expected_datastore is None)
+    if expected_datastore is not None:
+        assert converted_datastore is not None
+        assert converted_datastore.id == expected_datastore.id
+        assert (
+            _get_datastore_schema(converted_datastore).keys()
+            == _get_datastore_schema(expected_datastore).keys()
+        )
     # For llm, check equivalent fields
     if isinstance(expected_transform, AgentSpecMessageSummarizationTransform):
         assert converted_transform.llm.url == expected_transform.llm.url
@@ -237,6 +263,16 @@ def assert_message_summarization_transforms_are_equal(converted_transform, expec
 
 
 def assert_conversation_summarization_transforms_are_equal(converted_transform, expected_transform):
+    converted_datastore = (
+        converted_transform.datastore
+        if hasattr(converted_transform, "datastore")
+        else converted_transform.cache.datastore if converted_transform.cache is not None else None
+    )
+    expected_datastore = (
+        expected_transform.datastore
+        if hasattr(expected_transform, "datastore")
+        else expected_transform.cache.datastore if expected_transform.cache is not None else None
+    )
     # Check that the parameters match the ground truth from agent-spec
     assert converted_transform.max_num_messages == expected_transform.max_num_messages
     assert converted_transform.max_num_characters == expected_transform.max_num_characters
@@ -252,6 +288,14 @@ def assert_conversation_summarization_transforms_are_equal(converted_transform, 
     assert converted_transform.max_cache_size == expected_transform.max_cache_size
     assert converted_transform.max_cache_lifetime == expected_transform.max_cache_lifetime
     assert converted_transform.cache_collection_name == expected_transform.cache_collection_name
+    assert (converted_datastore is None) == (expected_datastore is None)
+    if expected_datastore is not None:
+        assert converted_datastore is not None
+        assert converted_datastore.id == expected_datastore.id
+        assert (
+            _get_datastore_schema(converted_datastore).keys()
+            == _get_datastore_schema(expected_datastore).keys()
+        )
     # For llm, check equivalent fields
     if isinstance(expected_transform, AgentSpecConversationSummarizationTransform):
         assert converted_transform.llm.url == expected_transform.llm.url

--- a/wayflowcore/tests/serialization/test_managerworkers_serialization.py
+++ b/wayflowcore/tests/serialization/test_managerworkers_serialization.py
@@ -22,6 +22,7 @@ from wayflowcore.models.llmmodelfactory import LlmModelFactory
 from wayflowcore.serialization import deserialize, serialize, serialize_to_dict
 from wayflowcore.steps.agentexecutionstep import AgentExecutionStep
 from wayflowcore.tools import ToolRequest
+from wayflowcore.transforms import RemoveEmptyNonUserMessageTransform
 
 from ..conftest import GEMMA_CONFIG, VLLM_MODEL_CONFIG, _assert_config_are_equal
 from ..test_managerworkers import simple_math_agents_example  # noqa
@@ -97,6 +98,10 @@ def assert_managerworkers_are_equal(old_instance: ManagerWorkers, new_instance: 
         assert_llms_are_equal(old_instance.group_manager, new_instance.group_manager)
     assert_managerworkers_agents_are_equal(old_instance.manager_agent, new_instance.manager_agent)
 
+    assert len(old_instance.transforms) == len(new_instance.transforms)
+    for old_transform, new_transform in zip(old_instance.transforms, new_instance.transforms):
+        assert type(old_transform) is type(new_transform)
+
     assert len(old_instance.workers) == len(new_instance.workers)
     for old_worker, new_worker in zip(old_instance.workers, new_instance.workers):
         if isinstance(old_worker, ManagerWorkers) and isinstance(new_worker, ManagerWorkers):
@@ -155,6 +160,23 @@ def test_can_deserialize_simple_managerworkers(simple_managerworkers: ManagerWor
     )
 
     assert_managerworkers_are_equal(simple_managerworkers, new_managerworkers)
+
+
+def test_managerworkers_transforms_are_serialized(simple_math_agents_example) -> None:
+    addition_agent, multiplication_agent = simple_math_agents_example
+    group = ManagerWorkers(
+        workers=[addition_agent, multiplication_agent],
+        group_manager=addition_agent.llm,
+        transforms=[RemoveEmptyNonUserMessageTransform()],
+    )
+
+    deserialized_group = deserialize(ManagerWorkers, serialize(group))
+
+    assert len(deserialized_group.transforms) == 1
+    assert isinstance(
+        deserialized_group.transforms[0],
+        RemoveEmptyNonUserMessageTransform,
+    )
 
 
 def test_can_serialize_simple_state(simple_state: ManagerWorkersConversationExecutionState):

--- a/wayflowcore/tests/serialization/test_summarization_transform_serialization.py
+++ b/wayflowcore/tests/serialization/test_summarization_transform_serialization.py
@@ -1,0 +1,162 @@
+# Copyright © 2025 Oracle and/or its affiliates.
+#
+# This software is under the Apache License 2.0
+# (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
+# (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from wayflowcore.agent import Agent
+from wayflowcore.datastore import InMemoryDatastore
+from wayflowcore.executors._swarmconversation import SwarmConversation
+from wayflowcore.messagelist import Message
+from wayflowcore.models import LlmCompletion
+from wayflowcore.serialization import autodeserialize, deserialize, serialize
+from wayflowcore.swarm import Swarm
+from wayflowcore.templates import PromptTemplate
+from wayflowcore.templates._swarmtemplate import _DEFAULT_SWARM_CHAT_TEMPLATE
+from wayflowcore.transforms import ConversationSummarizationTransform, MessageSummarizationTransform
+
+from ..conftest import mock_llm
+from ..testhelpers.patching import patch_llm
+
+
+def test_template_with_conversation_summarization_transform_can_roundtrip():
+    template = PromptTemplate(
+        messages=[
+            {"role": "system", "content": "Be concise."},
+            PromptTemplate.CHAT_HISTORY_PLACEHOLDER,
+        ],
+        pre_rendering_transforms=[
+            ConversationSummarizationTransform(
+                llm=mock_llm(),
+                max_num_messages=4,
+                min_num_messages=1,
+                datastore=None,
+            )
+        ],
+    )
+
+    deserialized_template = autodeserialize(serialize(template))
+
+    assert isinstance(deserialized_template, PromptTemplate)
+    assert deserialized_template.pre_rendering_transforms is not None
+    assert len(deserialized_template.pre_rendering_transforms) == 1
+
+    transform = deserialized_template.pre_rendering_transforms[0]
+    assert isinstance(transform, ConversationSummarizationTransform)
+    assert transform.max_num_messages == 4
+    assert transform.min_num_messages == 1
+
+
+def test_template_with_message_summarization_transform_can_roundtrip():
+    template = PromptTemplate(
+        messages=[
+            {"role": "system", "content": "Be concise."},
+            PromptTemplate.CHAT_HISTORY_PLACEHOLDER,
+        ],
+        pre_rendering_transforms=[
+            MessageSummarizationTransform(
+                llm=mock_llm(),
+                max_message_size=1234,
+                datastore=None,
+            )
+        ],
+    )
+
+    deserialized_template = autodeserialize(serialize(template))
+
+    assert isinstance(deserialized_template, PromptTemplate)
+    assert deserialized_template.pre_rendering_transforms is not None
+    assert len(deserialized_template.pre_rendering_transforms) == 1
+
+    transform = deserialized_template.pre_rendering_transforms[0]
+    assert isinstance(transform, MessageSummarizationTransform)
+    assert transform.max_message_size == 1234
+
+
+@pytest.mark.filterwarnings(
+    "ignore:InMemoryDatastore is for DEVELOPMENT and PROOF-OF-CONCEPT ONLY!:UserWarning"
+)
+def test_deserialized_swarm_conversation_with_conversation_summarization_can_continue():
+    cache_collection_name = "test_swarm_conversation_summary_cache"
+    summary_datastore = InMemoryDatastore(
+        {
+            cache_collection_name: ConversationSummarizationTransform.get_entity_definition(),
+        }
+    )
+    summary_llm = mock_llm()
+    router_llm = mock_llm()
+    specialist_llm = mock_llm()
+
+    summarization_transform = ConversationSummarizationTransform(
+        llm=summary_llm,
+        max_num_messages=3,
+        min_num_messages=1,
+        datastore=summary_datastore,
+        cache_collection_name=cache_collection_name,
+    )
+    swarm_template = _DEFAULT_SWARM_CHAT_TEMPLATE.with_additional_pre_rendering_transform(
+        summarization_transform,
+        append_last=False,
+    )
+
+    router = Agent(
+        name="Router",
+        description="Front desk router.",
+        llm=router_llm,
+        custom_instruction="Reply in one short sentence and do not delegate.",
+    )
+    specialist = Agent(
+        name="Specialist",
+        description="Backup specialist.",
+        llm=specialist_llm,
+        custom_instruction="Reply in one short sentence.",
+    )
+    swarm = Swarm(
+        first_agent=router,
+        relationships=[(router, specialist)],
+        swarm_template=swarm_template,
+    )
+
+    conversation = swarm.start_conversation()
+    summary = "Summarized previous swarm conversation."
+    # Patch the summarization model separately from the router model:
+    # the transform calls its own llm.generate_async(), while the Swarm turn execution
+    # goes through the router agent's llm.
+    summarize_completion = AsyncMock(
+        side_effect=lambda prompt: LlmCompletion(Message(summary), None)
+    )
+
+    with patch.object(summary_llm, "generate_async", summarize_completion):
+        with patch_llm(router_llm, outputs=["Reply 1", "Reply 2", "Reply 3"]):
+            conversation.append_user_message("Message 1")
+            conversation.execute()
+            conversation.append_user_message("Message 2")
+            conversation.execute()
+            conversation.append_user_message("Message 3")
+            conversation.execute()
+
+    assert summarize_completion.call_count > 0
+    assert len(summary_datastore.list(cache_collection_name)) > 0
+
+    deserialized_conversation = deserialize(SwarmConversation, serialize(conversation))
+    deserialized_transform = (
+        deserialized_conversation.component.swarm_template.pre_rendering_transforms[0]
+    )
+    assert isinstance(deserialized_transform, ConversationSummarizationTransform)
+
+    with patch.object(
+        deserialized_transform.llm,
+        "generate_async",
+        AsyncMock(side_effect=lambda prompt: LlmCompletion(Message(summary), None)),
+    ) as deserialized_summary_generate:
+        with patch_llm(deserialized_conversation.component.first_agent.llm, outputs=["Reply 4"]):
+            deserialized_conversation.append_user_message("Message 4")
+            deserialized_conversation.execute()
+
+    assert deserialized_summary_generate.call_count > 0
+    assert deserialized_conversation.get_last_message() is not None
+    assert deserialized_conversation.get_last_message().content == "Reply 4"

--- a/wayflowcore/tests/serialization/test_swarm_serialization.py
+++ b/wayflowcore/tests/serialization/test_swarm_serialization.py
@@ -17,6 +17,7 @@ from wayflowcore.executors._swarmconversation import (
 )
 from wayflowcore.serialization import deserialize, serialize, serialize_to_dict
 from wayflowcore.swarm import Swarm
+from wayflowcore.transforms import RemoveEmptyNonUserMessageTransform
 
 from ..conftest import _assert_config_are_equal
 from ..test_swarm import example_medical_agents  # noqa
@@ -111,6 +112,10 @@ def assert_swarms_are_equal(old_swarm: Swarm, new_swarm: Swarm):
         assert_swarm_agents_are_equal(old_caller_agent, new_caller_agent)
         assert_swarm_agents_are_equal(old_recipient_agent, new_recipient_agent)
 
+    assert len(old_swarm.transforms) == len(new_swarm.transforms)
+    for old_transform, new_transform in zip(old_swarm.transforms, new_swarm.transforms):
+        assert type(old_transform) is type(new_transform)
+
     assert old_swarm.__metadata_info__ == new_swarm.__metadata_info__
     assert old_swarm.id == new_swarm.id
 
@@ -192,6 +197,20 @@ def test_can_deserialize_a_serialized_swarm(simple_swarm: Swarm) -> None:
         serialize_to_dict(new_swarm),
     )
     assert_swarms_are_equal(simple_swarm, new_swarm)
+
+
+def test_swarm_transforms_are_serialized(example_medical_agents) -> None:
+    gp_doctor, neurologist_doctor, _ = example_medical_agents
+    swarm = Swarm(
+        first_agent=gp_doctor,
+        relationships=[(gp_doctor, neurologist_doctor)],
+        transforms=[RemoveEmptyNonUserMessageTransform()],
+    )
+
+    deserialized_swarm = deserialize(Swarm, serialize(swarm))
+
+    assert len(deserialized_swarm.transforms) == 1
+    assert isinstance(deserialized_swarm.transforms[0], RemoveEmptyNonUserMessageTransform)
 
 
 def test_can_serialize_simple_conversation(simple_conversation: SwarmConversation) -> None:

--- a/wayflowcore/tests/transforms/test_summarization_transforms.py
+++ b/wayflowcore/tests/transforms/test_summarization_transforms.py
@@ -13,10 +13,18 @@ import pytest
 from tests.testhelpers.testhelpers import retry_test
 from wayflowcore.agent import Agent
 from wayflowcore.datastore.inmemory import _INMEMORY_USER_WARNING, InMemoryDatastore
+from wayflowcore.managerworkers import ManagerWorkers
 from wayflowcore.messagelist import ImageContent, Message, MessageType, TextContent
 from wayflowcore.models.llmmodel import LlmCompletion, LlmModel
+from wayflowcore.swarm import HandoffMode, Swarm
+from wayflowcore.templates._managerworkerstemplate import _DEFAULT_MANAGERWORKERS_CHAT_TEMPLATE
+from wayflowcore.templates._swarmtemplate import _DEFAULT_SWARM_CHAT_TEMPLATE
 from wayflowcore.tools import ToolRequest, ToolResult, tool
-from wayflowcore.transforms import ConversationSummarizationTransform, MessageSummarizationTransform
+from wayflowcore.transforms import (
+    ConversationSummarizationTransform,
+    MessageSummarizationTransform,
+    MessageTransform,
+)
 from wayflowcore.transforms.summarization import _SUMMARIZATION_WARNING_MESSAGE
 
 from ..conftest import mock_llm, patch_streaming_llm
@@ -296,6 +304,28 @@ filter_in_memory_datastore_warnings = pytest.mark.filterwarnings(
 filter_summarization_transform_with_default_in_memory_datastore_warnings = (
     pytest.mark.filterwarnings(f"ignore:{_SUMMARIZATION_WARNING_MESSAGE}:UserWarning")
 )
+
+
+class _RecordingConversationSummarizationTransform(ConversationSummarizationTransform):
+    def __init__(self, *, recorded_calls, label, **kwargs):
+        super().__init__(**kwargs)
+        self.recorded_calls = recorded_calls
+        self.label = label
+
+    async def call_async(self, messages):
+        self.recorded_calls.append(self.label)
+        return await super().call_async(messages)
+
+
+class _RecordingMessageTransform(MessageTransform):
+    def __init__(self, *, recorded_calls, label):
+        super().__init__()
+        self.recorded_calls = recorded_calls
+        self.label = label
+
+    def __call__(self, messages):
+        self.recorded_calls.append(self.label)
+        return messages
 
 
 def message_summarization_transform_setup(llm: LlmModel):
@@ -855,6 +885,487 @@ def test_summarization_transform_updates_tool_result_content(toolres_message_con
                 assert len(transformed_messages[2].content) < toolres_len
             else:
                 assert transformed_messages[2].contents == toolres_message_contents
+
+
+@pytest.mark.filterwarnings(f"ignore:{_SUMMARIZATION_WARNING_MESSAGE}:UserWarning")
+def test_swarm_template_message_summarization_transform_summarizes_large_tool_results():
+    max_message_size = 200
+    large_tool_output = "Very long tool result. " * 100
+    summarized_tool_output = "Summarized swarm tool result"
+
+    summarization_llm = mock_llm()
+    router_llm = mock_llm()
+    specialist_llm = mock_llm()
+
+    transform = MessageSummarizationTransform(
+        llm=summarization_llm,
+        max_message_size=max_message_size,
+    )
+    swarm_template = _DEFAULT_SWARM_CHAT_TEMPLATE.with_additional_pre_rendering_transform(
+        transform,
+        append_last=False,
+    )
+
+    router = Agent(
+        name="Router",
+        description="Agent that uses tools.",
+        llm=router_llm,
+        custom_instruction="Use tools when needed and answer in one sentence.",
+    )
+    specialist = Agent(
+        name="Specialist",
+        description="Unused backup agent.",
+        llm=specialist_llm,
+        custom_instruction="Answer in one sentence.",
+    )
+    swarm = Swarm(
+        first_agent=router,
+        relationships=[(router, specialist)],
+        swarm_template=swarm_template,
+    )
+
+    conv = swarm.start_conversation(
+        messages=[
+            Message(message_type=MessageType.USER, content="Please use your tool."),
+            Message(
+                contents=[],
+                message_type=MessageType.TOOL_REQUEST,
+                tool_requests=[
+                    ToolRequest(
+                        name="retrieve_facts",
+                        args={"subject": "dolphins"},
+                        tool_request_id="tool_1",
+                    )
+                ],
+            ),
+            Message(
+                contents=[],
+                message_type=MessageType.TOOL_RESULT,
+                tool_result=ToolResult(content=large_tool_output, tool_request_id="tool_1"),
+            ),
+            Message(message_type=MessageType.USER, content="Now process that tool result."),
+        ]
+    )
+
+    mock_generate_summary = AsyncMock(
+        side_effect=lambda prompt: LlmCompletion(Message(summarized_tool_output), None)
+    )
+
+    with patch.object(summarization_llm, "generate_async", mock_generate_summary):
+        with patch_streaming_llm(router_llm, "Processed tool result") as patched_router_llm:
+            conv.execute()
+
+            transformed_messages = [
+                message
+                for prompts, _ in patched_router_llm.call_args_list
+                for prompt in prompts
+                for message in prompt.messages
+            ]
+
+    assert mock_generate_summary.call_count > 0
+    assert any(
+        summarized_tool_output in message.content and "--- TOOL RESULT:" in message.content
+        for message in transformed_messages
+    )
+    assert all(large_tool_output not in message.content for message in transformed_messages)
+
+
+@filter_in_memory_datastore_warnings
+@pytest.mark.parametrize(
+    ("scenario", "expected_transform_label"),
+    [
+        ("main_thread", "router"),
+        ("send_message", "specialist"),
+        ("handoff", "specialist"),
+    ],
+)
+def test_swarm_applies_agent_level_conversation_summarization_transforms(
+    scenario, expected_transform_label
+):
+    """
+    Agent-level conversation transforms should still run when an agent executes inside a Swarm.
+
+    Expected behavior by scenario:
+    - ``main_thread``: a transform attached to the router should summarize the main thread once
+      the router's own conversation exceeds the configured threshold.
+    - ``send_message``: a transform attached to the specialist should summarize the delegated
+      sub-conversation when repeated ``send_message`` calls grow that thread past the threshold.
+    - ``handoff``: a transform attached to the specialist should summarize the main thread after
+      ownership is transferred and subsequent turns continue under the specialist.
+
+    This regression test is intentionally written against the desired behavior. It fails when
+    Swarm execution rebuilds prompts exclusively from ``swarm_template`` and drops transforms that
+    were attached through ``Agent(transforms=[...])``.
+    """
+    recorded_calls = []
+    summary_llm = mock_llm()
+    router_llm = mock_llm()
+    specialist_llm = mock_llm()
+
+    def make_transform(label, max_num_messages):
+        cache_collection_name = f"test_swarm_agent_transform_{scenario}_{label}_cache"
+        summary_datastore = InMemoryDatastore(
+            {
+                cache_collection_name: ConversationSummarizationTransform.get_entity_definition(),
+            }
+        )
+        return _RecordingConversationSummarizationTransform(
+            recorded_calls=recorded_calls,
+            label=label,
+            llm=summary_llm,
+            max_num_messages=max_num_messages,
+            min_num_messages=1,
+            datastore=summary_datastore,
+            cache_collection_name=cache_collection_name,
+        )
+
+    router_transforms = []
+    specialist_transforms = []
+    handoff_mode = HandoffMode.NEVER
+    router_outputs = []
+    specialist_outputs = []
+    user_messages = []
+
+    if scenario == "main_thread":
+        router_transforms = [make_transform("router", max_num_messages=3)]
+        router_outputs = ["Reply 1", "Reply 2", "Reply 3"]
+        user_messages = ["Message 1", "Message 2", "Message 3"]
+    elif scenario == "send_message":
+        specialist_transforms = [make_transform("specialist", max_num_messages=2)]
+        router_outputs = [
+            [
+                ToolRequest(
+                    name="send_message",
+                    args={"recipient": "Specialist", "message": "Delegated task 1."},
+                    tool_request_id="send_1",
+                )
+            ],
+            "Router answer after delegated task 1.",
+            [
+                ToolRequest(
+                    name="send_message",
+                    args={"recipient": "Specialist", "message": "Delegated task 2."},
+                    tool_request_id="send_2",
+                )
+            ],
+            "Router answer after delegated task 2.",
+        ]
+        specialist_outputs = ["Specialist reply 1.", "Specialist reply 2."]
+        user_messages = ["Please delegate round 1.", "Please delegate round 2."]
+    elif scenario == "handoff":
+        specialist_transforms = [make_transform("specialist", max_num_messages=4)]
+        handoff_mode = HandoffMode.ALWAYS
+        router_outputs = [
+            [
+                ToolRequest(
+                    name="handoff_conversation",
+                    args={"recipient": "Specialist"},
+                    tool_request_id="handoff_1",
+                )
+            ],
+        ]
+        specialist_outputs = [
+            "Specialist answer after handoff turn 1.",
+            "Specialist answer after handoff turn 2.",
+        ]
+        user_messages = ["Take over this conversation.", "Now continue after the handoff."]
+    else:
+        raise AssertionError(f"Unsupported scenario: {scenario}")
+
+    router = Agent(
+        name="Router",
+        description="Router agent for swarm transform regression coverage.",
+        llm=router_llm,
+        custom_instruction=(
+            "Always use send_message to delegate work to Specialist, then answer the user."
+            if scenario == "send_message"
+            else (
+                "Always hand off the conversation to Specialist."
+                if scenario == "handoff"
+                else "Reply in one short sentence and do not delegate."
+            )
+        ),
+        transforms=router_transforms,
+    )
+    specialist = Agent(
+        name="Specialist",
+        description="Specialist agent for swarm transform regression coverage.",
+        llm=specialist_llm,
+        custom_instruction=(
+            "Continue the user conversation after the handoff."
+            if scenario == "handoff"
+            else "Answer the delegated request."
+        ),
+        transforms=specialist_transforms,
+    )
+    swarm = Swarm(
+        first_agent=router,
+        relationships=[(router, specialist)],
+        handoff=handoff_mode,
+    )
+    conversation = swarm.start_conversation()
+
+    summarize_completion = AsyncMock(
+        side_effect=lambda prompt: LlmCompletion(Message("Summarized conversation."), None)
+    )
+
+    with patch.object(summary_llm, "generate_async", summarize_completion):
+        with patch_llm(router_llm, outputs=router_outputs):
+            with patch_llm(specialist_llm, outputs=specialist_outputs):
+                for user_message in user_messages:
+                    conversation.append_user_message(user_message)
+                    conversation.execute()
+
+    assert summarize_completion.call_count > 0
+    assert expected_transform_label in recorded_calls
+
+
+@filter_in_memory_datastore_warnings
+def test_swarm_transforms_apply_conversation_summarization_during_execution():
+    cache_collection_name = "test_swarm_transforms_summary_cache"
+    summary_datastore = InMemoryDatastore(
+        {
+            cache_collection_name: ConversationSummarizationTransform.get_entity_definition(),
+        }
+    )
+    summary_llm = mock_llm()
+    router_llm = mock_llm()
+    specialist_llm = mock_llm()
+
+    transform = ConversationSummarizationTransform(
+        llm=summary_llm,
+        max_num_messages=3,
+        min_num_messages=1,
+        datastore=summary_datastore,
+        cache_collection_name=cache_collection_name,
+    )
+    router = Agent(
+        name="Router",
+        description="Front desk router.",
+        llm=router_llm,
+        custom_instruction="Reply in one short sentence and do not delegate.",
+    )
+    specialist = Agent(
+        name="Specialist",
+        description="Backup specialist.",
+        llm=specialist_llm,
+        custom_instruction="Reply in one short sentence.",
+    )
+    swarm = Swarm(
+        first_agent=router,
+        relationships=[(router, specialist)],
+        transforms=[transform],
+    )
+
+    conversation = swarm.start_conversation()
+    summary = "Summarized previous swarm conversation."
+    summarize_completion = AsyncMock(
+        side_effect=lambda prompt: LlmCompletion(Message(summary), None)
+    )
+
+    with patch.object(summary_llm, "generate_async", summarize_completion):
+        with patch_llm(router_llm, outputs=["Reply 1", "Reply 2", "Reply 3"]):
+            conversation.append_user_message("Message 1")
+            conversation.execute()
+            conversation.append_user_message("Message 2")
+            conversation.execute()
+            conversation.append_user_message("Message 3")
+            conversation.execute()
+
+    assert summarize_completion.call_count > 0
+    assert len(summary_datastore.list(cache_collection_name)) > 0
+
+
+def test_swarm_applies_agent_swarm_and_template_transforms_in_order():
+    recorded_calls = []
+    router_llm = mock_llm()
+    specialist_llm = mock_llm()
+
+    agent_transform = _RecordingMessageTransform(recorded_calls=recorded_calls, label="agent")
+    swarm_transform = _RecordingMessageTransform(recorded_calls=recorded_calls, label="swarm")
+    template_transform = _RecordingMessageTransform(recorded_calls=recorded_calls, label="template")
+
+    router = Agent(
+        name="Router",
+        description="Router agent for transform ordering coverage.",
+        llm=router_llm,
+        custom_instruction="Reply in one short sentence and do not delegate.",
+        transforms=[agent_transform],
+    )
+    specialist = Agent(
+        name="Specialist",
+        description="Backup specialist.",
+        llm=specialist_llm,
+        custom_instruction="Reply in one short sentence.",
+    )
+    swarm = Swarm(
+        first_agent=router,
+        relationships=[(router, specialist)],
+        transforms=[swarm_transform],
+        swarm_template=_DEFAULT_SWARM_CHAT_TEMPLATE.with_additional_pre_rendering_transform(
+            template_transform
+        ),
+    )
+
+    conversation = swarm.start_conversation()
+
+    with patch_llm(router_llm, outputs=["Reply 1"]):
+        conversation.append_user_message("Message 1")
+        conversation.execute()
+
+    assert recorded_calls == ["agent", "swarm", "template"]
+
+
+def test_managerworkers_applies_manager_group_and_template_transforms_in_order():
+    recorded_calls = []
+    manager_llm = mock_llm()
+    worker_llm = mock_llm()
+
+    manager_transform = _RecordingMessageTransform(recorded_calls=recorded_calls, label="manager")
+    managerworkers_transform = _RecordingMessageTransform(
+        recorded_calls=recorded_calls, label="managerworkers"
+    )
+    template_transform = _RecordingMessageTransform(recorded_calls=recorded_calls, label="template")
+
+    manager_agent = Agent(
+        name="Manager",
+        description="Manager agent for transform ordering coverage.",
+        llm=manager_llm,
+        custom_instruction="Reply in one short sentence and do not delegate.",
+        transforms=[manager_transform],
+    )
+    worker = Agent(
+        name="Worker",
+        description="Backup worker.",
+        llm=worker_llm,
+        custom_instruction="Reply in one short sentence.",
+    )
+    managerworkers = ManagerWorkers(
+        workers=[worker],
+        group_manager=manager_agent,
+        transforms=[managerworkers_transform],
+        managerworkers_template=_DEFAULT_MANAGERWORKERS_CHAT_TEMPLATE.with_additional_pre_rendering_transform(
+            template_transform
+        ),
+    )
+
+    conversation = managerworkers.start_conversation()
+
+    with patch_llm(manager_llm, outputs=["Reply 1"]):
+        conversation.append_user_message("Message 1")
+        conversation.execute()
+
+    assert recorded_calls == ["manager", "managerworkers", "template"]
+
+
+@filter_in_memory_datastore_warnings
+def test_managerworkers_applies_manager_agent_conversation_summarization_transforms():
+    recorded_calls = []
+    cache_collection_name = "test_managerworkers_manager_agent_transform_summary_cache"
+    summary_datastore = InMemoryDatastore(
+        {
+            cache_collection_name: ConversationSummarizationTransform.get_entity_definition(),
+        }
+    )
+    summary_llm = mock_llm()
+    manager_llm = mock_llm()
+    worker_llm = mock_llm()
+
+    manager_transform = _RecordingConversationSummarizationTransform(
+        recorded_calls=recorded_calls,
+        label="manager",
+        llm=summary_llm,
+        max_num_messages=3,
+        min_num_messages=1,
+        datastore=summary_datastore,
+        cache_collection_name=cache_collection_name,
+    )
+    manager_agent = Agent(
+        name="Manager",
+        description="Manager agent for manager transform regression coverage.",
+        llm=manager_llm,
+        custom_instruction="Reply in one short sentence and do not delegate.",
+        transforms=[manager_transform],
+    )
+    worker = Agent(
+        name="Worker",
+        description="Backup worker.",
+        llm=worker_llm,
+        custom_instruction="Reply in one short sentence.",
+    )
+    managerworkers = ManagerWorkers(
+        workers=[worker],
+        group_manager=manager_agent,
+    )
+
+    conversation = managerworkers.start_conversation()
+    summary = "Summarized previous manager conversation."
+    summarize_completion = AsyncMock(
+        side_effect=lambda prompt: LlmCompletion(Message(summary), None)
+    )
+
+    with patch.object(summary_llm, "generate_async", summarize_completion):
+        with patch_llm(manager_llm, outputs=["Reply 1", "Reply 2", "Reply 3"]):
+            conversation.append_user_message("Message 1")
+            conversation.execute()
+            conversation.append_user_message("Message 2")
+            conversation.execute()
+            conversation.append_user_message("Message 3")
+            conversation.execute()
+
+    assert summarize_completion.call_count > 0
+    assert "manager" in recorded_calls
+    assert len(summary_datastore.list(cache_collection_name)) > 0
+
+
+@filter_in_memory_datastore_warnings
+def test_managerworkers_transforms_apply_conversation_summarization_during_execution():
+    cache_collection_name = "test_managerworkers_transforms_summary_cache"
+    summary_datastore = InMemoryDatastore(
+        {
+            cache_collection_name: ConversationSummarizationTransform.get_entity_definition(),
+        }
+    )
+    summary_llm = mock_llm()
+    manager_llm = mock_llm()
+    worker_llm = mock_llm()
+
+    transform = ConversationSummarizationTransform(
+        llm=summary_llm,
+        max_num_messages=3,
+        min_num_messages=1,
+        datastore=summary_datastore,
+        cache_collection_name=cache_collection_name,
+    )
+    worker = Agent(
+        name="Worker",
+        description="Backup worker.",
+        llm=worker_llm,
+        custom_instruction="Reply in one short sentence.",
+    )
+    managerworkers = ManagerWorkers(
+        workers=[worker],
+        group_manager=manager_llm,
+        transforms=[transform],
+    )
+
+    conversation = managerworkers.start_conversation()
+    summary = "Summarized previous manager-workers conversation."
+    summarize_completion = AsyncMock(
+        side_effect=lambda prompt: LlmCompletion(Message(summary), None)
+    )
+
+    with patch.object(summary_llm, "generate_async", summarize_completion):
+        with patch_llm(manager_llm, outputs=["Reply 1", "Reply 2", "Reply 3"]):
+            conversation.append_user_message("Message 1")
+            conversation.execute()
+            conversation.append_user_message("Message 2")
+            conversation.execute()
+            conversation.append_user_message("Message 3")
+            conversation.execute()
+
+    assert summarize_completion.call_count > 0
+    assert len(summary_datastore.list(cache_collection_name)) > 0
 
 
 @filter_summarization_transform_with_default_in_memory_datastore_warnings


### PR DESCRIPTION
## Summary

This PR fixes serialization/deserialization for `MessageSummarizationTransform` and
`ConversationSummarizationTransform`, so prompt templates and serialized conversations can roundtrip
correctly with their required runtime config.

It also wires the `transforms` parameter on `Swarm` and `ManagerWorkers` into execution, and fixes
Swarm so transforms attached through `Agent(transforms=[...])` are preserved when an agent runs
inside the Swarm prompt pipeline instead of being dropped.

For Swarm, the effective pre-rendering order is now:

1. active `Agent(..., transforms=[...])`
2. `Swarm(..., transforms=[...])`
3. `swarm_template.pre_rendering_transforms`

Fixes #130 and #131.

## What changed

- Added explicit serde for summarization transforms, including `llm` and datastore config
- Applied `Swarm.transforms` and `ManagerWorkers.transforms` at runtime
- Fixed Swarm execution so agent-level transforms are preserved when the active agent is executed
through the Swarm template
- Added regression tests for:
- summarization transform roundtrip
- serialized swarm continuation with conversation summarization
- swarm / managerworkers transform serialization
- swarm tool-result summarization
- direct runtime use of transforms on `Swarm` and `ManagerWorkers`
- agent-level conversation summarization in Swarm `main_thread`, `send_message`, and `handoff`
flows
- transform ordering across agent-level, swarm-level, and template-level pre-rendering transforms
- Updated docs and changelog, including notes on transform ordering with prompt templates
