### PR TITLE
Fix assistant tool result canonicalization

### DIFF
--- a/docs/wayflowcore/source/core/changelog.rst
+++ b/docs/wayflowcore/source/core/changelog.rst
@@ -107,6 +107,7 @@ Bug fixes
   See the guide on :ref:`using Swarm <swarm_transform_ordering>` and :ref:`ManagerWorkers <managerworkers_transform_ordering>` to learn
   more about how component-level transforms are combined with prompt template transforms during execution.
 
+* Fix: `CanonicalizationMessageTransform` now correctly handles assistant-role tool-result messages from runtime conversation history, which fixes parallel tool-calling turns for native tool-calling prompts such as OCI Google models.
 
 * Fix: conversations no longer replay already-materialized tool results when resuming manager-worker executions,
   which could previously duplicate internal `send_message` results and break continued execution after serialization.

--- a/docs/wayflowcore/source/core/changelog.rst
+++ b/docs/wayflowcore/source/core/changelog.rst
@@ -98,6 +98,8 @@ Possibly Breaking Changes
 Bug fixes
 ^^^^^^^^^
 
+* Fix: `CanonicalizationMessageTransform` now correctly handles assistant-role tool-result messages from runtime conversation history, which fixes parallel tool-calling turns for native tool-calling prompts such as OCI Google models.
+
 * **Fix summarization transform persistence and multi-agent integration**
 
   ``MessageSummarizationTransform`` and ``ConversationSummarizationTransform`` now serialize the configuration required to deserialize
@@ -106,8 +108,6 @@ Bug fixes
 
   See the guide on :ref:`using Swarm <swarm_transform_ordering>` and :ref:`ManagerWorkers <managerworkers_transform_ordering>` to learn
   more about how component-level transforms are combined with prompt template transforms during execution.
-
-* Fix: `CanonicalizationMessageTransform` now correctly handles assistant-role tool-result messages from runtime conversation history, which fixes parallel tool-calling turns for native tool-calling prompts such as OCI Google models.
 
 * Fix: conversations no longer replay already-materialized tool results when resuming manager-worker executions,
   which could previously duplicate internal `send_message` results and break continued execution after serialization.

--- a/wayflowcore/src/wayflowcore/transforms/canonicalizationtransform.py
+++ b/wayflowcore/src/wayflowcore/transforms/canonicalizationtransform.py
@@ -119,7 +119,15 @@ class CanonicalizationMessageTransform(MessageTransform, SerializableObject):
         for msg in messages:
             role = msg.role
 
-            if role == "system":
+            # Tool results can be persisted as assistant-role messages in the runtime conversation
+            # history, but canonicalization must treat them as user-side responses so they can be
+            # interleaved with queued tool requests.
+            if msg.tool_result is not None:
+                if role != "user":
+                    msg = msg.copy(role="user")
+                    modified = True
+                append_user_or_merge(msg)
+            elif role == "system":
                 if system_msg is None:
                     system_msg = msg
                 else:

--- a/wayflowcore/tests/integration/test_agent.py
+++ b/wayflowcore/tests/integration/test_agent.py
@@ -2238,20 +2238,16 @@ def test_exception_during_parallel_tool_calls(remotely_hosted_llm):
 
 
 def test_agent_handles_parallel_tool_calls_with_canonicalized_native_template():
-    class CanonicalizedDummyModel(DummyModel):
-        @property
-        def default_agent_template(self) -> PromptTemplate:
-            return NATIVE_AGENT_TEMPLATE.with_additional_post_rendering_transform(
-                CanonicalizationMessageTransform()
-            )
-
-    llm = CanonicalizedDummyModel()
+    llm = DummyModel()
     agent = Agent(
         tools=[success_tool],
         llm=llm,
         custom_instruction="some instructions",
         can_finish_conversation=False,
         max_iterations=40,
+        agent_template=NATIVE_AGENT_TEMPLATE.with_additional_post_rendering_transform(
+            CanonicalizationMessageTransform()
+        ),
     )
 
     conversation = agent.start_conversation(messages="do something")

--- a/wayflowcore/tests/integration/test_agent.py
+++ b/wayflowcore/tests/integration/test_agent.py
@@ -45,8 +45,9 @@ from wayflowcore.steps import (
     ToolExecutionStep,
 )
 from wayflowcore.steps.step import Step
-from wayflowcore.templates import PromptTemplate
+from wayflowcore.templates import NATIVE_AGENT_TEMPLATE, PromptTemplate
 from wayflowcore.tools import ClientTool, DescribedFlow, ServerTool, ToolRequest, ToolResult, tool
+from wayflowcore.transforms import CanonicalizationMessageTransform
 
 from ..conftest import VLLM_MODEL_CONFIG, with_all_llm_configs
 from ..testhelpers.dummy import DummyModel
@@ -2233,6 +2234,44 @@ def test_exception_during_parallel_tool_calls(remotely_hosted_llm):
     ):
         status = conversation.execute()
 
+    _check_each_tool_request_is_followed_by_single_matching_tool_result(conversation.get_messages())
+
+
+def test_agent_handles_parallel_tool_calls_with_canonicalized_native_template():
+    class CanonicalizedDummyModel(DummyModel):
+        @property
+        def default_agent_template(self) -> PromptTemplate:
+            return NATIVE_AGENT_TEMPLATE.with_additional_post_rendering_transform(
+                CanonicalizationMessageTransform()
+            )
+
+    llm = CanonicalizedDummyModel()
+    agent = Agent(
+        tools=[success_tool],
+        llm=llm,
+        custom_instruction="some instructions",
+        can_finish_conversation=False,
+        max_iterations=40,
+    )
+
+    conversation = agent.start_conversation(messages="do something")
+
+    with patch_llm(
+        llm,
+        outputs=[
+            [
+                ToolRequest(name="success_tool", args={}, tool_request_id="id1"),
+                ToolRequest(name="success_tool", args={}, tool_request_id="id2"),
+                ToolRequest(name="success_tool", args={}, tool_request_id="id3"),
+            ],
+            "done",
+        ],
+        patch_internal=True,
+    ) as (_, stream_generate):
+        conversation.execute()
+        assert stream_generate.call_count == 2
+
+    assert conversation.get_last_message().content == "done"
     _check_each_tool_request_is_followed_by_single_matching_tool_result(conversation.get_messages())
 
 

--- a/wayflowcore/tests/transforms/test_transforms.py
+++ b/wayflowcore/tests/transforms/test_transforms.py
@@ -26,6 +26,16 @@ def assert_messages_are_correct(messages: List[Message], expected_messages: List
         assert message.content == expected_message.content
 
 
+def assert_messages_have_same_semantics(messages: List[Message], expected_messages: List[Message]):
+    assert len(messages) == len(expected_messages), messages
+    for message, expected_message in zip(messages, expected_messages):
+        assert message.role == expected_message.role
+        assert message.message_type == expected_message.message_type
+        assert message.content == expected_message.content
+        assert message.tool_requests == expected_message.tool_requests
+        assert message.tool_result == expected_message.tool_result
+
+
 SYSTEM_MESSAGE = Message(message_type=MessageType.SYSTEM, content="You are a helpful assistant")
 USER_MESSAGE = Message(message_type=MessageType.USER, content="What is the capital of Switzerland?")
 TOOL_REQUEST_MESSAGE = Message(
@@ -213,11 +223,20 @@ T_REQ_1_MSG = Message(
     tool_requests=[ToolRequest(name="get_weather", args={"city": "zurich"}, tool_request_id="id1")],
 )
 T_RES_1_MSG = Message(tool_result=ToolResult(content="sunny", tool_request_id="id1"))
+T_RES_1_ASSISTANT_MSG = Message(
+    role="assistant", tool_result=ToolResult(content="sunny", tool_request_id="id1")
+)
 T_REQ_2_MSG = Message(
     content="robot",
     tool_requests=[ToolRequest(name="get_weather", args={"city": "basel"}, tool_request_id="id2")],
 )
+T_REQ_2_ONLY_MSG = Message(
+    tool_requests=[ToolRequest(name="get_weather", args={"city": "basel"}, tool_request_id="id2")]
+)
 T_RES_2_MSG = Message(tool_result=ToolResult(content="rainy", tool_request_id="id2"))
+T_RES_2_ASSISTANT_MSG = Message(
+    role="assistant", tool_result=ToolResult(content="rainy", tool_request_id="id2")
+)
 T_REQ_3_MSG = Message(
     content="robot",
     tool_requests=[
@@ -294,3 +313,33 @@ def test_alternating_message_transform(messages, expected_length):
             tool_ids.remove(msg.tool_result.tool_request_id)
 
     assert len(tool_ids) == 0
+
+
+def test_alternating_message_transform_handles_assistant_role_tool_result():
+    transform = CanonicalizationMessageTransform()
+
+    transformed_messages = transform([SYSTEM_MSG, USER_MSG, T_REQ_1_MSG, T_RES_1_ASSISTANT_MSG])
+
+    assert_messages_have_same_semantics(
+        transformed_messages, [SYSTEM_MSG, USER_MSG, T_REQ_1_MSG, T_RES_1_MSG]
+    )
+
+
+def test_alternating_message_transform_handles_parallel_assistant_role_tool_results():
+    transform = CanonicalizationMessageTransform()
+
+    transformed_messages = transform(
+        [SYSTEM_MSG, USER_MSG, T_REQ_3_MSG, T_RES_1_ASSISTANT_MSG, T_RES_2_ASSISTANT_MSG]
+    )
+
+    assert_messages_have_same_semantics(
+        transformed_messages,
+        [
+            SYSTEM_MSG,
+            USER_MSG,
+            T_REQ_1_MSG,
+            T_RES_1_MSG,
+            T_REQ_2_ONLY_MSG,
+            T_RES_2_MSG,
+        ],
+    )


### PR DESCRIPTION
## Summary

Fix canonicalization of assistant-role tool results so parallel tool calls are preserved correctly when using canonicalized templates.

## Problem

Some runtimes persist tool results as Message(role="assistant", tool_result=...). The canonicalization transform treated those as normal assistant messages instead of user-side tool responses, which broke tool-call/result interleaving and caused missing tool_call_id style failures with parallel tool calls.

## Fix

Update CanonicalizationMessageTransform to detect tool_result messages first and canonicalize them as user-role tool responses, regardless of their stored role.

## Tests

Added regression coverage for:

 - a single assistant-role tool result
- parallel assistant-role tool results
- an end-to-end agent flow with parallel tool calls and a canonicalized native template