### PR TITLE
Update agent server access defaults

### DIFF
--- a/docs/wayflowcore/source/core/changelog.rst
+++ b/docs/wayflowcore/source/core/changelog.rst
@@ -82,6 +82,13 @@ Documentation
 Possibly Breaking Changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
+* **Agent servers require API keys on non-loopback hosts**
+
+  ``A2AServer`` and ``OpenAIResponsesServer`` now require an ``api_key`` when
+  binding to non-loopback hosts such as ``0.0.0.0`` or a public interface.
+  Unauthenticated local development on loopback hosts remains available with a
+  warning.
+
 * **Summarization Transforms now do not do caching if the datastore is None**
 
   Previously when the `datastore` arguments of `MessageSummarizationTransform` and `ConversationSummarizationTransform` were set to `None`, an in-memory datastore was automatically created. Now, the in-memory datastore is created

--- a/docs/wayflowcore/source/core/changelog.rst
+++ b/docs/wayflowcore/source/core/changelog.rst
@@ -51,6 +51,14 @@ New features
 Improvements
 ^^^^^^^^^^^^
 
+* **Improved agent server access defaults**
+
+  ``A2AServer.run(api_key=...)`` now enforces bearer-token authentication when an API key is
+  provided. ``A2AServer`` and ``OpenAIResponsesServer`` now require an API key when binding to
+  non-loopback hosts, while unauthenticated loopback development remains available with a warning.
+  ``OpenAIResponsesServer`` no longer enables CORS by default and supports explicit allowed
+  origins configuration.
+
 * **Removed ``starlette`` from third party dependencies**
 
   Direct ``starlette`` imports were removed in favor of FastAPI equivalent alternatives, so ``wayflowcore`` no longer

--- a/docs/wayflowcore/source/core/changelog.rst
+++ b/docs/wayflowcore/source/core/changelog.rst
@@ -86,8 +86,9 @@ Possibly Breaking Changes
 
   ``A2AServer`` and ``OpenAIResponsesServer`` now require an ``api_key`` when
   binding to non-loopback hosts such as ``0.0.0.0`` or a public interface.
-  Unauthenticated local development on loopback hosts remains available with a
-  warning.
+  A loopback host only accepts connections from the same machine, for example
+  ``127.0.0.1`` or ``localhost``. Unauthenticated local development on loopback
+  hosts remains available with a warning.
 
 * **Summarization Transforms now do not do caching if the datastore is None**
 

--- a/wayflowcore/src/wayflowcore/agentserver/server.py
+++ b/wayflowcore/src/wayflowcore/agentserver/server.py
@@ -1,4 +1,4 @@
-# Copyright © 2026 Oracle and/or its affiliates.
+# Copyright © 2025, 2026 Oracle and/or its affiliates.
 #
 # This software is under the Apache License 2.0
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License

--- a/wayflowcore/src/wayflowcore/agentserver/server.py
+++ b/wayflowcore/src/wayflowcore/agentserver/server.py
@@ -181,8 +181,19 @@ class OpenAIResponsesServer:
         storage_config:
             Cch will not guarantee persistence of data across runs.
         allowed_origins:
-            Origins allowed to make browser requests to the server. If not provided,
-            CORS middleware is not enabled.
+            Origins allowed to make browser cross-origin requests to the server through
+            CORS (Cross-Origin Resource Sharing). CORS is a browser access-control
+            mechanism that decides whether JavaScript loaded from one origin, such as
+            ``https://app.example.com``, may call this server on another origin.
+            An origin is the scheme, host, and port, for example
+            ``https://app.example.com`` or ``http://localhost:3000``.
+            If not provided, CORS middleware is not enabled and browsers deny
+            cross-origin requests by default.
+            Examples:
+            ``["https://app.example.com"]`` allows one browser application origin.
+            ``["*"]`` allows any origin, but only when ``allow_credentials`` is false.
+            Wildcard subdomain patterns such as ``["*.example.com"]`` are not
+            supported here; list each allowed origin explicitly.
         allow_credentials:
             Whether CORS requests may include credentials.
         allowed_methods:
@@ -351,6 +362,8 @@ def _validate_server_auth_configuration(host: str, api_key: Optional[str]) -> No
     if api_key is None and not _is_loopback_host(host):
         raise ValueError(
             "An api_key is required when binding the server to a non-loopback host. "
+            "A loopback host only accepts connections from the same machine, for "
+            "example host='127.0.0.1' or host='localhost'. "
             "Use host='127.0.0.1' for local unauthenticated development."
         )
 

--- a/wayflowcore/src/wayflowcore/agentserver/server.py
+++ b/wayflowcore/src/wayflowcore/agentserver/server.py
@@ -1,4 +1,4 @@
-# Copyright © 2025 Oracle and/or its affiliates.
+# Copyright © 2026 Oracle and/or its affiliates.
 #
 # This software is under the Apache License 2.0
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
@@ -7,7 +7,8 @@ import secrets
 import warnings
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Any, Dict, Optional
+from ipaddress import ip_address
+from typing import Any, Dict, Optional, Sequence
 from urllib.parse import urlparse
 
 from fasta2a.broker import InMemoryBroker
@@ -137,9 +138,13 @@ class A2AServer:
         import uvicorn
 
         # we log a warning since this server has no security implemented
-        warn_server_is_not_secured()
+        _validate_server_auth_configuration(host=host, api_key=api_key)
+        if api_key is None:
+            warn_server_is_not_secured()
 
         app = self.get_app(host, port)
+        if api_key is not None:
+            _add_token_authentication_auth(app=app, api_key=api_key)
         uvicorn.run(
             app=app,
             host=host,
@@ -156,6 +161,10 @@ class OpenAIResponsesServer:
         agents: Optional[Dict[str, ConversationalComponent]] = None,
         storage: Optional[Datastore] = None,
         storage_config: Optional[ServerStorageConfig] = None,
+        allowed_origins: Optional[Sequence[str]] = None,
+        allow_credentials: bool = True,
+        allowed_methods: Optional[Sequence[str]] = None,
+        allowed_headers: Optional[Sequence[str]] = None,
     ):
         """
         Public-facing server for exposing an Agent or Flow via the OpenAI Responses protocol.
@@ -171,6 +180,15 @@ class OpenAIResponsesServer:
             in the `storage_config`.
         storage_config:
             Cch will not guarantee persistence of data across runs.
+        allowed_origins:
+            Origins allowed to make browser requests to the server. If not provided,
+            CORS middleware is not enabled.
+        allow_credentials:
+            Whether CORS requests may include credentials.
+        allowed_methods:
+            HTTP methods accepted by CORS preflight requests.
+        allowed_headers:
+            HTTP headers accepted by CORS preflight requests.
         """
         self.app = FastAPI(
             title="WayFlow Responses API",
@@ -185,7 +203,12 @@ class OpenAIResponsesServer:
             storage=storage,
             storage_config=storage_config,
         )
-        self._setup_middleware()
+        self._setup_middleware(
+            allowed_origins=allowed_origins,
+            allow_credentials=allow_credentials,
+            allowed_methods=allowed_methods,
+            allowed_headers=allowed_headers,
+        )
         self._setup_routes()
 
     def serve_agent(self, agent_id: str, agent: ConversationalComponent) -> None:
@@ -201,14 +224,24 @@ class OpenAIResponsesServer:
         """
         self.agent_service._add_agent(agent_id, agent)
 
-    def _setup_middleware(self) -> None:
+    def _setup_middleware(
+        self,
+        allowed_origins: Optional[Sequence[str]],
+        allow_credentials: bool,
+        allowed_methods: Optional[Sequence[str]],
+        allowed_headers: Optional[Sequence[str]],
+    ) -> None:
         """Set up CORS and other middleware."""
+        if not allowed_origins:
+            return
+        if allow_credentials and "*" in allowed_origins:
+            raise ValueError("Wildcard CORS origins cannot be used with credentials enabled.")
         self.app.add_middleware(
             CORSMiddleware,
-            allow_origins=["*"],  # Configure as needed for production
-            allow_credentials=True,
-            allow_methods=["*"],
-            allow_headers=["*"],
+            allow_origins=list(allowed_origins),
+            allow_credentials=allow_credentials,
+            allow_methods=list(allowed_methods or ["*"]),
+            allow_headers=list(allowed_headers or ["*"]),
         )
 
     def _setup_routes(self) -> None:
@@ -282,8 +315,9 @@ class OpenAIResponsesServer:
         """
         import uvicorn
 
-        # we log a warning since this server has no security implemented
-        warn_server_is_not_secured()
+        _validate_server_auth_configuration(host=host, api_key=api_key)
+        if api_key is None:
+            warn_server_is_not_secured()
 
         app = self.get_app()
         if api_key is not None:
@@ -308,6 +342,24 @@ def _add_token_authentication_auth(app: FastAPI, api_key: str) -> None:
                 content={"detail": "Missing or invalid bearer token"},
             )
         return await call_next(request)
+
+
+def _validate_server_auth_configuration(host: str, api_key: Optional[str]) -> None:
+    if api_key is None and not _is_loopback_host(host):
+        raise ValueError(
+            "An api_key is required when binding the server to a non-loopback host. "
+            "Use host='127.0.0.1' for local unauthenticated development."
+        )
+
+
+def _is_loopback_host(host: str) -> bool:
+    normalized_host = host.strip("[]").lower()
+    if normalized_host == "localhost":
+        return True
+    try:
+        return ip_address(normalized_host).is_loopback
+    except ValueError:
+        return False
 
 
 _WARNING_MESSAGE = r"""

--- a/wayflowcore/src/wayflowcore/agentserver/server.py
+++ b/wayflowcore/src/wayflowcore/agentserver/server.py
@@ -233,6 +233,9 @@ class OpenAIResponsesServer:
     ) -> None:
         """Set up CORS and other middleware."""
         if not allowed_origins:
+            # allowed_methods and allowed_headers are only meaningful once CORS is enabled
+            # with an origin allow-list. Without allowed_origins, keep CORS disabled so
+            # browser cross-origin access is denied by default.
             return
         if allow_credentials and "*" in allowed_origins:
             raise ValueError("Wildcard CORS origins cannot be used with credentials enabled.")

--- a/wayflowcore/tests/agentserver/test_server_access_defaults.py
+++ b/wayflowcore/tests/agentserver/test_server_access_defaults.py
@@ -1,0 +1,126 @@
+# Copyright © 2026 Oracle and/or its affiliates.
+#
+# This software is under the Apache License 2.0
+# (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
+# (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
+
+import warnings
+from typing import Any, TypeVar
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from wayflowcore.agentserver.server import A2AServer, OpenAIResponsesServer
+
+ServerT = TypeVar("ServerT", A2AServer, OpenAIResponsesServer)
+
+
+def _capture_uvicorn_app(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    def fake_run(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    import uvicorn
+
+    monkeypatch.setattr(uvicorn, "run", fake_run)
+    return captured
+
+
+def _ok_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/")
+    async def ok() -> dict[str, str]:
+        return {"status": "ok"}
+
+    return app
+
+
+def _make_server(server_cls: type[ServerT], **kwargs: Any) -> ServerT:
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="InMemoryDatastore is for DEVELOPMENT")
+        return server_cls(**kwargs)
+
+
+@pytest.mark.parametrize("server_cls", [A2AServer, OpenAIResponsesServer])
+def test_server_run_rejects_non_loopback_without_api_key(server_cls: type[Any]) -> None:
+    server = _make_server(server_cls)
+
+    with pytest.raises(ValueError, match="api_key is required"):
+        server.run(host="0.0.0.0", api_key=None)
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1"])
+@pytest.mark.parametrize("server_cls", [A2AServer, OpenAIResponsesServer])
+def test_server_allows_loopback_without_api_key(
+    server_cls: type[Any], host: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured = _capture_uvicorn_app(monkeypatch)
+    server = _make_server(server_cls)
+    if isinstance(server, A2AServer):
+        monkeypatch.setattr(server, "get_app", lambda host, port: _ok_app())
+
+    with pytest.warns(UserWarning):
+        server.run(host=host, api_key=None)
+
+    assert captured["host"] == host
+
+
+@pytest.mark.parametrize(
+    "server_cls,path", [(A2AServer, "/"), (OpenAIResponsesServer, "/v1/models")]
+)
+def test_server_requires_bearer_when_api_key_is_set(
+    server_cls: type[Any], path: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured = _capture_uvicorn_app(monkeypatch)
+    server = _make_server(server_cls)
+    if isinstance(server, A2AServer):
+        monkeypatch.setattr(server, "get_app", lambda host, port: _ok_app())
+
+    server.run(host="0.0.0.0", api_key="secret")
+
+    client = TestClient(captured["app"])
+    assert client.get(path).status_code == 401
+    assert client.get(path, headers={"authorization": "Bearer secret"}).status_code == 200
+
+
+def test_openai_responses_server_does_not_enable_cors_by_default() -> None:
+    client = TestClient(_make_server(OpenAIResponsesServer).get_app())
+
+    response = client.options(
+        "/v1/responses",
+        headers={
+            "origin": "https://example.com",
+            "access-control-request-method": "POST",
+        },
+    )
+
+    assert response.status_code == 405
+    assert "access-control-allow-origin" not in response.headers
+    assert "access-control-allow-credentials" not in response.headers
+    assert "access-control-allow-methods" not in response.headers
+
+
+def test_openai_responses_server_allows_configured_cors_origin() -> None:
+    client = TestClient(
+        _make_server(OpenAIResponsesServer, allowed_origins=["https://app.example.com"]).get_app()
+    )
+
+    response = client.options(
+        "/v1/responses",
+        headers={
+            "origin": "https://app.example.com",
+            "access-control-request-method": "POST",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://app.example.com"
+    assert response.headers["access-control-allow-credentials"] == "true"
+
+
+def test_openai_responses_server_rejects_wildcard_cors_with_credentials() -> None:
+    with pytest.raises(ValueError, match="Wildcard CORS origins"):
+        _make_server(OpenAIResponsesServer, allowed_origins=["*"], allow_credentials=True)

--- a/wayflowcore/tests/agentserver/test_server_access_defaults.py
+++ b/wayflowcore/tests/agentserver/test_server_access_defaults.py
@@ -5,10 +5,10 @@
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
 import warnings
-from typing import Any, TypeVar
+from types import SimpleNamespace
+from typing import Any, TypeVar, cast
 
 import pytest
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from wayflowcore.agentserver.server import A2AServer, OpenAIResponsesServer
@@ -28,20 +28,15 @@ def _capture_uvicorn_app(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     return captured
 
 
-def _ok_app() -> FastAPI:
-    app = FastAPI()
-
-    @app.get("/")
-    async def ok() -> dict[str, str]:
-        return {"status": "ok"}
-
-    return app
-
-
 def _make_server(server_cls: type[ServerT], **kwargs: Any) -> ServerT:
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message="InMemoryDatastore is for DEVELOPMENT")
-        return server_cls(**kwargs)
+        server = server_cls(**kwargs)
+    if isinstance(server, A2AServer):
+        server.serve_agent(
+            agent=cast(Any, SimpleNamespace(name="test_agent", description="test agent"))
+        )
+    return server
 
 
 @pytest.mark.parametrize("server_cls", [A2AServer, OpenAIResponsesServer])
@@ -59,8 +54,6 @@ def test_server_allows_loopback_without_api_key(
 ) -> None:
     captured = _capture_uvicorn_app(monkeypatch)
     server = _make_server(server_cls)
-    if isinstance(server, A2AServer):
-        monkeypatch.setattr(server, "get_app", lambda host, port: _ok_app())
 
     with pytest.warns(UserWarning):
         server.run(host=host, api_key=None)
@@ -69,21 +62,20 @@ def test_server_allows_loopback_without_api_key(
 
 
 @pytest.mark.parametrize(
-    "server_cls,path", [(A2AServer, "/"), (OpenAIResponsesServer, "/v1/models")]
+    "server_cls,path",
+    [(A2AServer, "/.well-known/agent-card.json"), (OpenAIResponsesServer, "/v1/models")],
 )
 def test_server_requires_bearer_when_api_key_is_set(
     server_cls: type[Any], path: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     captured = _capture_uvicorn_app(monkeypatch)
     server = _make_server(server_cls)
-    if isinstance(server, A2AServer):
-        monkeypatch.setattr(server, "get_app", lambda host, port: _ok_app())
 
     server.run(host="0.0.0.0", api_key="secret")
 
-    client = TestClient(captured["app"])
-    assert client.get(path).status_code == 401
-    assert client.get(path, headers={"authorization": "Bearer secret"}).status_code == 200
+    with TestClient(captured["app"]) as client:
+        assert client.get(path).status_code == 401
+        assert client.get(path, headers={"authorization": "Bearer secret"}).status_code == 200
 
 
 def test_openai_responses_server_does_not_enable_cors_by_default() -> None:


### PR DESCRIPTION
## Summary
- require an API key before binding agent servers to non-loopback hosts
- wire the A2A server API key through the same bearer-token middleware used by the Responses server
- make Responses server CORS opt-in with explicit allowed origins
- add focused regression coverage for auth and CORS defaults