### PR TITLE
Improve default requirements in remote Components

### DIFF
--- a/docs/wayflowcore/source/core/changelog.rst
+++ b/docs/wayflowcore/source/core/changelog.rst
@@ -73,6 +73,15 @@ Improvements
   ``OpenAIResponsesServer`` no longer enables CORS by default and supports explicit allowed
   origins configuration.
 
+* **Agent Spec component loading policies can be customized**
+
+  ``AgentSpecLoader`` now accepts ``allowed_components`` and ``blocked_components``
+  so applications can control which Agent Spec and WayFlow plugin component types
+  are allowed to load. This is useful for trusted deployments that need to opt in
+  to runtime-sensitive components, and for stricter deployments that want to
+  explicitly allow only a known component set. WayFlow extends PyAgentSpec's default
+  blocked components with WayFlow-specific runtime-sensitive components.
+
 * **Removed ``starlette`` from third party dependencies**
 
   Direct ``starlette`` imports were removed in favor of FastAPI equivalent alternatives, so ``wayflowcore`` no longer
@@ -125,6 +134,15 @@ Possibly Breaking Changes
   A loopback host only accepts connections from the same machine, for example
   ``127.0.0.1`` or ``localhost``. Unauthenticated local development on loopback
   hosts remains available with a warning.
+
+* **MCP stdio transports are blocked by default in Agent Spec loaders**
+
+  Configurations containing Agent Spec ``StdioTransport`` or WayFlow ``PluginStdioTransport``
+  will no longer load by default through ``AgentSpecLoader``. WayFlow inherits the
+  PyAgentSpec default blocked components and adds ``PluginStdioTransport``. If a trusted
+  configuration intentionally uses stdio transports, pass ``blocked_components=[]`` to the
+  loader, or provide a custom ``blocked_components`` value that does not include those
+  transport component types.
 
 * **Summarization Transforms now do not do caching if the datastore is None**
 

--- a/docs/wayflowcore/source/core/code_examples/howto_retry_configuration.py
+++ b/docs/wayflowcore/source/core/code_examples/howto_retry_configuration.py
@@ -36,9 +36,11 @@ llm = OpenAICompatibleModel(
 from wayflowcore.steps import ApiCallStep
 from wayflowcore.tools import RemoteTool
 
+ORDER_API_BASE_URL = "https://example.com/orders"
+
 api_step = ApiCallStep(
     name="fetch_order_step",
-    url="https://example.com/orders",
+    url=ORDER_API_BASE_URL,
     method="POST",
     retry_policy=retry_policy,
 )
@@ -46,9 +48,10 @@ api_step = ApiCallStep(
 remote_tool = RemoteTool(
     name="fetch_order",
     description="Fetch an order from a remote API.",
-    url="https://example.com/orders/{{ order_id }}",
+    url=ORDER_API_BASE_URL + "/{{ order_id }}",  # keep the base URL fixed and template only the path parameter
     method="GET",
     retry_policy=retry_policy,
+    url_allow_list=[ORDER_API_BASE_URL],
 )
 # .. end-##_Configure_remote_steps_and_tools
 

--- a/docs/wayflowcore/source/core/code_examples/howto_serve_agents.py
+++ b/docs/wayflowcore/source/core/code_examples/howto_serve_agents.py
@@ -87,7 +87,7 @@ storage_config = ServerStorageConfig(table_name="assistant_conversations")
 
 connection_config = WithoutTlsPostgresDatabaseConnectionConfig(
     user=os.environ.get("PG_USER", "postgres"),
-    password=os.environ.get("PG_PASSWORD", "password"),
+    password=os.environ["PG_PASSWORD"],
     url=os.environ.get("PG_HOST", "localhost:5432"),
 )
 
@@ -109,7 +109,7 @@ import secrets
 from fastapi import Request, status
 from fastapi.responses import JSONResponse
 
-API_TOKEN = os.environ.get("WAYFLOW_SERVER_TOKEN", "change-me")
+API_TOKEN = os.environ["WAYFLOW_SERVER_TOKEN"]
 
 secured_app = server.get_app()
 

--- a/docs/wayflowcore/source/core/security.rst
+++ b/docs/wayflowcore/source/core/security.rst
@@ -50,7 +50,7 @@ Tool Security Specifics
 *   **Secure Connections (`allow_insecure_http`)**: By default, :ref:`RemoteTool <remotetool>` disallows non-HTTPS URLs (``allow_insecure_http=False``). Maintain this default unless there's an explicit, well-justified reason to allow insecure HTTP, and ensure the risks are understood.
 *   **Credential Handling (`allow_credentials`)**: By default (``allow_credentials=True``), URLs can contain credentials (e.g., ``https://user:pass@example.com``). If your use case does not require this, set ``allow_credentials=False`` to prevent accidental leakage or misuse of credentials in URLs.
 *   **URL Fragments (`allow_fragments`)**: Control whether URL fragments (e.g., ``#section``) are permitted in requested URLs and allow list entries. Default is ``True``. Set to ``False`` if fragments are not needed and could introduce ambiguity or bypass attempts.
-*   **Non-Public IP Targets**: Requests to loopback, link-local, or private IP literal targets emit a runtime warning. Treat this as a sign to double-check that the destination is expected and properly restricted.
+*   **Non-Public IP Targets**: Requests to loopback, link-local, or private IP literal targets that are not explicitly allow-listed emit a runtime warning. Treat this as a sign to double-check that the destination is expected and properly restricted.
 *   **Output Parsing (`output_jq_query`)**: If using ``output_jq_query`` to parse JSON responses, be aware that complex queries on very large or maliciously structured JSON could consume significant resources. While primarily a performance concern, extreme cases might have denial-of-service implications.
 
 .. caution::

--- a/docs/wayflowcore/source/core/security.rst
+++ b/docs/wayflowcore/source/core/security.rst
@@ -169,9 +169,9 @@ Network Connection Requirements
      - • Container network policies (iptables, Calico, Cilium) allowing only approved LLM endpoints, Tool API destinations, telemetry sinks, and DNS.
    * - External API Call Security (e.g., :ref:`ApiCallStep <apicallstep>`, :ref:`RemoteTool <remotetool>`)
      - • Enforce HTTPS: Use ``allow_insecure_http=False`` (default for both).
-      • **URL Allow Lists**: Strongly prefer configuring ``url_allow_list`` for :ref:`RemoteTool <remotetool>` and other outbound request components. In code, ``url_allow_list`` is required only when an :ref:`ApiCallStep <apicallstep>` or :ref:`RemoteTool <remotetool>` URL template contains placeholders in the destination part of the URL (scheme, host, or port). Placeholders limited to the path or query do not trigger this requirement.
-      • Validate/sanitize templated URLs and other request parameters (headers, body) derived from potentially untrusted inputs, and prefer fixed developer-controlled base URLs with templated path/query/body values only.
-      • Treat warnings for loopback, link-local, or private IP literal targets as a security review signal, not as something to ignore.
+       • **URL Allow Lists**: Strongly prefer configuring ``url_allow_list`` for :ref:`RemoteTool <remotetool>` and other outbound request components. In code, ``url_allow_list`` is required only when an :ref:`ApiCallStep <apicallstep>` or :ref:`RemoteTool <remotetool>` URL template contains placeholders in the destination part of the URL (scheme, host, or port). Placeholders limited to the path or query do not trigger this requirement.
+       • Validate/sanitize templated URLs and other request parameters (headers, body) derived from potentially untrusted inputs, and prefer fixed developer-controlled base URLs with templated path/query/body values only.
+       • Treat warnings for loopback, link-local, or private IP literal targets as a security review signal, not as something to ignore.
        • Consider ``allow_credentials=False`` and ``allow_fragments=False`` for :ref:`RemoteTool <remotetool>` if those features are not strictly necessary.
        • Use connection timeouts/rate limiting (tool-specific or via infrastructure).
        • Log outbound requests (destination URLs, sanitized headers/bodies) for audit.

--- a/docs/wayflowcore/source/core/security.rst
+++ b/docs/wayflowcore/source/core/security.rst
@@ -45,11 +45,12 @@ Tool Security Specifics
 
 **`RemoteTool` Considerations:**
 
-*   **Templated Request Arguments**: :ref:`RemoteTool <remotetool>` allows various parts of the HTTP request (URL, method, body, headers, etc.) to be templated using Jinja. This is powerful but introduces risks if the inputs to these templates are not strictly controlled. Maliciously crafted inputs could lead to information leakage (e.g., exposing sensitive data in URLs or headers) or enable attacks like SSRF (Server-Side Request Forgery) or automated DDoS.
-*   **URL Allow List (`url_allow_list`)**: This is a critical security feature. Always define a ``url_allow_list`` to restrict the tool to a predefined set of allowed URLs or URL patterns. This significantly mitigates the risk of the tool being used to make requests to unintended or malicious endpoints. Refer to the API documentation for detailed matching rules.
+*   **Templated Request Arguments**: :ref:`RemoteTool <remotetool>` allows various parts of the HTTP request (URL, method, body, headers, etc.) to be templated using Jinja. This is powerful but introduces risks if the inputs to these templates are not strictly controlled. Maliciously crafted inputs could lead to information leakage (e.g., exposing sensitive data in URLs or headers) or enable attacks like SSRF (Server-Side Request Forgery) or automated DDoS. Prefer a fixed developer-controlled base URL and template only path, query, or body values.
+*   **URL Allow List (`url_allow_list`)**: This is a critical security feature. We strongly recommend defining a ``url_allow_list`` to restrict the tool to a predefined set of allowed URLs or URL patterns. This significantly mitigates the risk of the tool being used to make requests to unintended or malicious endpoints. In code, ``url_allow_list`` is required only when placeholders appear in the destination part of the URL (scheme, host, or port). Placeholders limited to the path or query do not trigger this requirement. Refer to the API documentation for detailed matching rules.
 *   **Secure Connections (`allow_insecure_http`)**: By default, :ref:`RemoteTool <remotetool>` disallows non-HTTPS URLs (``allow_insecure_http=False``). Maintain this default unless there's an explicit, well-justified reason to allow insecure HTTP, and ensure the risks are understood.
 *   **Credential Handling (`allow_credentials`)**: By default (``allow_credentials=True``), URLs can contain credentials (e.g., ``https://user:pass@example.com``). If your use case does not require this, set ``allow_credentials=False`` to prevent accidental leakage or misuse of credentials in URLs.
 *   **URL Fragments (`allow_fragments`)**: Control whether URL fragments (e.g., ``#section``) are permitted in requested URLs and allow list entries. Default is ``True``. Set to ``False`` if fragments are not needed and could introduce ambiguity or bypass attempts.
+*   **Non-Public IP Targets**: Requests to loopback, link-local, or private IP literal targets emit a runtime warning. Treat this as a sign to double-check that the destination is expected and properly restricted.
 *   **Output Parsing (`output_jq_query`)**: If using ``output_jq_query`` to parse JSON responses, be aware that complex queries on very large or maliciously structured JSON could consume significant resources. While primarily a performance concern, extreme cases might have denial-of-service implications.
 
 .. caution::
@@ -60,7 +61,9 @@ Tool Security Specifics
    vectors like automated DDOS attacks. Please use :ref:`RemoteTool <remotetool>` responsibly and ensure
    that only valid URLs can be given as arguments or that no sensitive information is used for any of these
    arguments by the agent. Utilize ``url_allow_list``, ``allow_credentials``, and ``allow_fragments``
-   to control URL validity.
+   to control URL validity. ``url_allow_list`` is required only when placeholders appear in the
+   destination part of the URL (scheme, host, or port), not when placeholders are limited to the
+   path or query.
 
 Harden All Tools (ServerTool, ClientTool and RemoteTool)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -78,7 +81,9 @@ Harden All Tools (ServerTool, ClientTool and RemoteTool)
        *  For :ref:`RemoteTool <remotetool>`:
 
           *  Rigorously validate and sanitize any inputs used in templated arguments (``url``, ``method``, ``data``, ``params``, ``headers``, ``cookies``).
-          *  **Crucially, always configure `url_allow_list`** to restrict outbound requests to known, trusted endpoints.
+          *  Keep the base URL developer-controlled and template only path, query, or body values whenever possible.
+          *  Strongly prefer configuring ``url_allow_list`` to restrict outbound requests to known, trusted endpoints.
+          *  ``url_allow_list`` is required only when placeholders appear in the destination part of the URL (scheme, host, or port). Placeholders limited to the path or query do not trigger this requirement.
           *  Leverage ``allow_insecure_http=False`` (default), and consider setting ``allow_credentials=False`` if not needed.
    * - Excessive privileges (for :ref:`ServerTool <servertool>`)
      - Run in least-privilege containers/pods.
@@ -164,8 +169,9 @@ Network Connection Requirements
      - • Container network policies (iptables, Calico, Cilium) allowing only approved LLM endpoints, Tool API destinations, telemetry sinks, and DNS.
    * - External API Call Security (e.g., :ref:`ApiCallStep <apicallstep>`, :ref:`RemoteTool <remotetool>`)
      - • Enforce HTTPS: Use ``allow_insecure_http=False`` (default for both).
-       • **URL Allow Lists**: For :ref:`RemoteTool <remotetool>`, always configure its ``url_allow_list`` parameter. For :ref:`ApiCallStep <apicallstep>`, ensure broader network-level allow-lists are in place.
-       • Validate/sanitize templated URLs and other request parameters (headers, body) derived from potentially untrusted inputs.
+      • **URL Allow Lists**: Strongly prefer configuring ``url_allow_list`` for :ref:`RemoteTool <remotetool>` and other outbound request components. In code, ``url_allow_list`` is required only when an :ref:`ApiCallStep <apicallstep>` or :ref:`RemoteTool <remotetool>` URL template contains placeholders in the destination part of the URL (scheme, host, or port). Placeholders limited to the path or query do not trigger this requirement.
+      • Validate/sanitize templated URLs and other request parameters (headers, body) derived from potentially untrusted inputs, and prefer fixed developer-controlled base URLs with templated path/query/body values only.
+      • Treat warnings for loopback, link-local, or private IP literal targets as a security review signal, not as something to ignore.
        • Consider ``allow_credentials=False`` and ``allow_fragments=False`` for :ref:`RemoteTool <remotetool>` if those features are not strictly necessary.
        • Use connection timeouts/rate limiting (tool-specific or via infrastructure).
        • Log outbound requests (destination URLs, sanitized headers/bodies) for audit.

--- a/docs/wayflowcore/source/core/security.rst
+++ b/docs/wayflowcore/source/core/security.rst
@@ -631,6 +631,27 @@ Deserializing data from untrusted sources is inherently risky. Always treat seri
 Remember that :ref:`autodeserialize <autodeserialize>` expects parsed YAML (a Python dictionary), not the raw YAML string, if using ``safe_load``. Passing a string directly to ``autodeserialize`` makes it use ``yaml.safe_load`` internally. Explicit ``safe_load`` first allows pre-validation of the YAML structure.
 
 
+Considerations regarding Agent Spec loading
+-------------------------------------------
+
+WayFlow can load Agent Spec configurations through :ref:`AgentSpecLoader <agentspecloader>`.
+Treat configurations from external or unverified origins as runtime definitions
+that can instantiate tools, transports, and WayFlow plugin components.
+
+Use ``allowed_components`` and ``blocked_components`` on ``AgentSpecLoader`` to
+control which component types may be loaded. For stricter environments, prefer
+an explicit ``allowed_components`` list that contains only the Agent Spec and
+WayFlow plugin component types required by the application.
+
+WayFlow blocks Agent Spec ``StdioTransport`` and WayFlow ``PluginStdioTransport``
+by default because these transports can start local MCP server subprocesses on the
+machine loading the configuration. WayFlow inherits PyAgentSpec's default blocked
+components and adds WayFlow-specific runtime-sensitive components. If a trusted
+configuration intentionally uses stdio transports, pass ``blocked_components=[]`` to
+``AgentSpecLoader``, or provide a custom ``blocked_components`` value that does not
+include those transport component types.
+
+
 Other Security Concerns
 -----------------------
 

--- a/wayflowcore/constraints/constraints_dev.txt
+++ b/wayflowcore/constraints/constraints_dev.txt
@@ -8,7 +8,7 @@ PyYAML==6.0.3
 pydantic==2.12.5
 httpx==0.28.1
 mcp==1.24.0
-pyagentspec==26.2.0.dev4 # Main branch of pyagentspec
+pyagentspec==26.2.0.dev5 # Main branch of pyagentspec
 opentelemetry-api==1.36.0
 opentelemetry-sdk==1.36.0
 litellm==1.83.14

--- a/wayflowcore/dev_scripts/openai-models-gen/generate_apis.sh
+++ b/wayflowcore/dev_scripts/openai-models-gen/generate_apis.sh
@@ -1,22 +1,38 @@
-# Copyright © 2025 Oracle and/or its affiliates.
+#!/usr/bin/env bash
+
+# Copyright © 2025, 2026 Oracle and/or its affiliates.
 #
 # This software is under the Apache License 2.0
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
-# THIS FILE IS USED TO GENERATE THE PYDANTIC MODELS FOR THE OPENAI RESPONSES PEN API SPEC
+set -euo pipefail
 
-#
+# Generate the Pydantic models for the OpenAI Responses API spec.
+
+# SHA for the upstream spec when it reported info.version 2.3.0.
+spec_sha256="2de8031d85add4117952fc327644b9e6dfc0453d9367c03c10d2bf217d0a2a5d"
+spec_path="data/openapi.documented.yml"
+
+# Run from this script folder and make sure the data folder exists.
+cd "$(dirname "$0")"
 mkdir -p data
 
-# 1. get the latest version of the open API spec
-wget -N -P data https://app.stainless.com/api/spec/documented/openai/openapi.documented.yml
+# Download the spec in a tmp file and check its SHA.
+tmp_spec="$(mktemp "${TMPDIR:-/tmp}/openapi.documented.XXXXXX.yml")"
+trap 'rm -f "$tmp_spec"' EXIT
 
-# 2. filter only the models needed for the APIs we want to support (responses)
-python generate_models.py
+curl -fsSL --proto '=https' "https://app.stainless.com/api/spec/documented/openai/openapi.documented.yml" -o "$tmp_spec"
+python verify_openapi_spec.py "$tmp_spec" "$spec_sha256"
 
-# 3. generate the pydantic models for these models
-python generate_pydantic_models.py
+# If everything is ok, save the approved spec file
+mv "$tmp_spec" "$spec_path"
 
-# 4. copy the models in src/wayflowcore/agentserver/models/openairesponsespydanticmodels.py
+# Filter only the models needed for the APIs we want to support (responses)
+python generate_models.py --spec "$spec_path"
+
+# Build the Pydantic models.
+python generate_pydantic_models.py --spec "$spec_path"
+
+# Copy the models in src/wayflowcore/agentserver/models/openairesponsespydanticmodels.py
 # and run formatting with git hooks

--- a/wayflowcore/dev_scripts/openai-models-gen/verify_openapi_spec.py
+++ b/wayflowcore/dev_scripts/openai-models-gen/verify_openapi_spec.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+# Copyright © 2025 Oracle and/or its affiliates.
+#
+# This software is under the Apache License 2.0
+# (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
+# (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
+
+"""
+Small helper used by `generate_apis.sh` to verify a downloaded OpenAPI spec.
+
+Usage:
+    python verify_openapi_spec.py SPEC_PATH EXPECTED_SHA256
+
+Example:
+    python verify_openapi_spec.py data/openapi.documented.yml 2de803...
+
+Exit code 0 means the file matches the approved SHA256. Exit code 1 means it does not.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: verify_openapi_spec.py SPEC_PATH EXPECTED_SHA256", file=sys.stderr)
+        return 1
+
+    spec_path = Path(sys.argv[1])
+    expected_sha256 = sys.argv[2]
+
+    digest = hashlib.sha256()
+    with spec_path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    actual_sha256 = digest.hexdigest()
+
+    if actual_sha256 != expected_sha256:
+        print(
+            f"ERROR: OpenAI spec SHA256 mismatch: expected {expected_sha256}, got {actual_sha256}",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/wayflowcore/src/wayflowcore/agentserver/server.py
+++ b/wayflowcore/src/wayflowcore/agentserver/server.py
@@ -290,7 +290,7 @@ class OpenAIResponsesServer:
         >>> import secrets
         >>> from fastapi import Request, status
         >>> from fastapi.responses import JSONResponse
-        >>> API_TOKEN = os.environ.get("WAYFLOW_SERVER_TOKEN", "change-me")
+        >>> API_TOKEN = os.environ["WAYFLOW_SERVER_TOKEN"]  # doctest: +SKIP
         >>>
         >>> app = server.get_app()  # doctest: +SKIP
         >>>

--- a/wayflowcore/src/wayflowcore/agentspec/runtimeloader.py
+++ b/wayflowcore/src/wayflowcore/agentspec/runtimeloader.py
@@ -7,17 +7,30 @@
 import warnings
 from typing import Any, Callable, Dict, List, Literal, Mapping, Optional, Union, overload
 
+from pyagentspec.adapters._agentspecloader import (
+    _DEFAULT_BLOCKED_COMPONENTS as _AGENTSPEC_DEFAULT_BLOCKED_COMPONENTS,
+)
 from pyagentspec.component import Component as AgentSpecComponent
 from pyagentspec.serialization import AgentSpecDeserializer, ComponentDeserializationPlugin
+from pyagentspec.serialization.componentpolicy import (
+    ComponentLoadPolicy,
+    ComponentPolicyEntry,
+    ComponentPolicyInput,
+)
 from pyagentspec.serialization.types import ComponentsRegistryT as AgentSpecComponentsRegistryT
 from typing_extensions import TypeAlias
 
+from wayflowcore.agentspec.components.mcp import PluginStdioTransport
 from wayflowcore.component import Component as RuntimeComponent
 from wayflowcore.serialization.plugins import WayflowDeserializationPlugin
 from wayflowcore.tools import ServerTool as RuntimeServerTool
 
 FieldName: TypeAlias = str
 RuntimeComponentsRegistryT: TypeAlias = Mapping[str, Union[RuntimeComponent, Any]]
+_DEFAULT_BLOCKED_COMPONENTS: tuple[ComponentPolicyEntry, ...] = (
+    *_AGENTSPEC_DEFAULT_BLOCKED_COMPONENTS,
+    PluginStdioTransport,
+)
 
 
 class AgentSpecLoader:
@@ -29,6 +42,9 @@ class AgentSpecLoader:
         plugins: Optional[
             List[Union[WayflowDeserializationPlugin, ComponentDeserializationPlugin]]
         ] = None,
+        *,
+        allowed_components: Optional[ComponentPolicyInput] = None,
+        blocked_components: Optional[ComponentPolicyInput] = None,
     ):
         """
         Parameters
@@ -45,9 +61,29 @@ class AgentSpecLoader:
 
               Passing a list of ``ComponentDeserializationPlugin`` from ``pyagentspec`` is deprecated
               since wayflowcore==26.1.0.
+        allowed_components:
+            Optional iterable of Agent Spec component type names or Component classes allowed
+            to be loaded.
+            If omitted, all component types are allowed unless blocked.
+        blocked_components:
+            Optional iterable of Agent Spec component type names or Component classes blocked
+            from loading.
+            If omitted, WayFlow extends the Agent Spec loader defaults and also blocks
+            WayFlow's ``PluginStdioTransport``. Resolvable type names and Component
+            classes also match subclasses; unresolved type names match only the exact
+            serialized component type.
 
         """
         self.tool_registry = tool_registry or {}
+        blocked_components = (
+            _DEFAULT_BLOCKED_COMPONENTS if blocked_components is None else blocked_components
+        )
+        self.component_load_policy = ComponentLoadPolicy(
+            allowed_components=allowed_components,
+            blocked_components=blocked_components,
+        )
+        self.allowed_components = self.component_load_policy.allowed_components
+        self.blocked_components = self.component_load_policy.blocked_components
         self.plugins: List[WayflowDeserializationPlugin] = (
             [plugin for plugin in plugins if isinstance(plugin, WayflowDeserializationPlugin)]
             if plugins
@@ -244,7 +280,11 @@ class AgentSpecLoader:
         ... )
 
         """
-        deserializer = AgentSpecDeserializer(plugins=self._get_all_agentspec_plugins())
+        deserializer = AgentSpecDeserializer(
+            plugins=self._get_all_agentspec_plugins(),
+            allowed_components=self.allowed_components,
+            blocked_components=self.blocked_components,
+        )
         converted_registry = (
             self._convert_component_registry(components_registry)
             if components_registry is not None
@@ -419,7 +459,11 @@ class AgentSpecLoader:
         ... )
 
         """
-        deserializer = AgentSpecDeserializer(plugins=self._get_all_agentspec_plugins())
+        deserializer = AgentSpecDeserializer(
+            plugins=self._get_all_agentspec_plugins(),
+            allowed_components=self.allowed_components,
+            blocked_components=self.blocked_components,
+        )
         converted_registry = (
             self._convert_component_registry(components_registry)
             if components_registry is not None
@@ -481,6 +525,7 @@ class AgentSpecLoader:
         """
         from wayflowcore.agentspec._runtimeconverter import AgentSpecToWayflowConversionContext
 
+        self.component_load_policy.validate_component_tree(agentspec_component)
         runtime_assistant = AgentSpecToWayflowConversionContext(plugins=self.plugins).convert(
             agentspec_component, self.tool_registry
         )

--- a/wayflowcore/src/wayflowcore/serialization/_builtins_deserialization_plugin.py
+++ b/wayflowcore/src/wayflowcore/serialization/_builtins_deserialization_plugin.py
@@ -143,9 +143,7 @@ from wayflowcore.agentspec.components import (
 from wayflowcore.agentspec.components import (
     PluginVllmEmbeddingConfig as AgentSpecPluginVllmEmbeddingConfig,
 )
-from wayflowcore.agentspec.components import (
-    all_deserialization_plugin,
-)
+from wayflowcore.agentspec.components import all_deserialization_plugin
 from wayflowcore.agentspec.components.agent import ExtendedAgent as AgentSpecExtendedAgent
 from wayflowcore.agentspec.components.contextprovider import (
     PluginConstantContextProvider as AgentSpecPluginConstantContextProvider,

--- a/wayflowcore/src/wayflowcore/serialization/_builtins_deserialization_plugin.py
+++ b/wayflowcore/src/wayflowcore/serialization/_builtins_deserialization_plugin.py
@@ -143,7 +143,9 @@ from wayflowcore.agentspec.components import (
 from wayflowcore.agentspec.components import (
     PluginVllmEmbeddingConfig as AgentSpecPluginVllmEmbeddingConfig,
 )
-from wayflowcore.agentspec.components import all_deserialization_plugin
+from wayflowcore.agentspec.components import (
+    all_deserialization_plugin,
+)
 from wayflowcore.agentspec.components.agent import ExtendedAgent as AgentSpecExtendedAgent
 from wayflowcore.agentspec.components.contextprovider import (
     PluginConstantContextProvider as AgentSpecPluginConstantContextProvider,
@@ -1403,6 +1405,7 @@ class WayflowBuiltinsDeserializationPlugin(WayflowDeserializationPlugin):
                 retry_policy=self._convert_retry_policy_to_runtime(
                     agentspec_component.retry_policy
                 ),
+                url_allow_list=agentspec_component.url_allow_list,
                 store_response=store_response,
                 output_values_json={
                     output_.title: f".{output_.title}"
@@ -1597,6 +1600,7 @@ class WayflowBuiltinsDeserializationPlugin(WayflowDeserializationPlugin):
                 retry_policy=self._convert_retry_policy_to_runtime(
                     agentspec_component.retry_policy
                 ),
+                url_allow_list=agentspec_component.url_allow_list,
                 requires_confirmation=agentspec_component.requires_confirmation,
                 **self._get_component_arguments(agentspec_component),
             )

--- a/wayflowcore/src/wayflowcore/serialization/_builtins_serialization_plugin.py
+++ b/wayflowcore/src/wayflowcore/serialization/_builtins_serialization_plugin.py
@@ -142,7 +142,9 @@ from wayflowcore.agentspec.components import (
 from wayflowcore.agentspec.components import (
     PluginVllmEmbeddingConfig as AgentSpecPluginVllmEmbeddingConfig,
 )
-from wayflowcore.agentspec.components import all_serialization_plugin
+from wayflowcore.agentspec.components import (
+    all_serialization_plugin,
+)
 from wayflowcore.agentspec.components.agent import ExtendedAgent as AgentSpecExtendedAgent
 from wayflowcore.agentspec.components.contextprovider import (
     PluginConstantContextProvider as AgentSpecPluginConstantContextProvider,
@@ -388,7 +390,9 @@ from wayflowcore.models.ociclientconfig import (
 from wayflowcore.models.ociclientconfig import (
     OCIClientConfigWithUserAuthentication as RuntimeOCIClientConfigWithUserAuthentication,
 )
-from wayflowcore.models.openaicompatiblemodel import EMPTY_API_KEY
+from wayflowcore.models.openaicompatiblemodel import (
+    EMPTY_API_KEY,
+)
 from wayflowcore.models.openaicompatiblemodel import (
     OpenAICompatibleModel as RuntimeOpenAICompatibleModel,
 )
@@ -1514,6 +1518,7 @@ class WayflowBuiltinsSerializationPlugin(WayflowSerializationPlugin):
                     if isinstance(inner_api_step.sensitive_headers, dict)
                     else dict()
                 ),
+                url_allow_list=inner_api_step.url_allow_list,
                 requires_confirmation=runtime_tool.requires_confirmation,
                 retry_policy=(
                     self._retrypolicy_convert_to_agentspec(inner_api_step.retry_policy)
@@ -3150,6 +3155,7 @@ class WayflowBuiltinsSerializationPlugin(WayflowSerializationPlugin):
                     if isinstance(runtime_step.sensitive_headers, dict)
                     else dict()
                 ),
+                url_allow_list=runtime_step.url_allow_list,
                 retry_policy=(
                     self._retrypolicy_convert_to_agentspec(runtime_step.retry_policy)
                     if runtime_step.retry_policy is not None

--- a/wayflowcore/src/wayflowcore/serialization/_builtins_serialization_plugin.py
+++ b/wayflowcore/src/wayflowcore/serialization/_builtins_serialization_plugin.py
@@ -142,9 +142,7 @@ from wayflowcore.agentspec.components import (
 from wayflowcore.agentspec.components import (
     PluginVllmEmbeddingConfig as AgentSpecPluginVllmEmbeddingConfig,
 )
-from wayflowcore.agentspec.components import (
-    all_serialization_plugin,
-)
+from wayflowcore.agentspec.components import all_serialization_plugin
 from wayflowcore.agentspec.components.agent import ExtendedAgent as AgentSpecExtendedAgent
 from wayflowcore.agentspec.components.contextprovider import (
     PluginConstantContextProvider as AgentSpecPluginConstantContextProvider,
@@ -390,9 +388,7 @@ from wayflowcore.models.ociclientconfig import (
 from wayflowcore.models.ociclientconfig import (
     OCIClientConfigWithUserAuthentication as RuntimeOCIClientConfigWithUserAuthentication,
 )
-from wayflowcore.models.openaicompatiblemodel import (
-    EMPTY_API_KEY,
-)
+from wayflowcore.models.openaicompatiblemodel import EMPTY_API_KEY
 from wayflowcore.models.openaicompatiblemodel import (
     OpenAICompatibleModel as RuntimeOpenAICompatibleModel,
 )

--- a/wayflowcore/src/wayflowcore/steps/apicallstep.py
+++ b/wayflowcore/src/wayflowcore/steps/apicallstep.py
@@ -266,6 +266,52 @@ def _normalize_allow_list(
     return allow_list
 
 
+def _get_url_destination_placeholder_names(url: str) -> List[str]:
+    """Return placeholder names that appear in the destination part of a URL.
+
+    The destination is limited to the URL scheme and authority (host and port).
+    Placeholders appearing only in the path, query string, or fragment are
+    intentionally ignored so that ``url_allow_list`` is required only when
+    templating can redirect the request to a different destination.
+    """
+    scheme_separator = url.find("://")
+    if scheme_separator != -1:
+        scheme_part = url[:scheme_separator]
+        remainder = url[scheme_separator + 3 :]
+    else:
+        scheme_part = ""
+        remainder = url
+
+    authority_end_candidates = [
+        idx for idx in (remainder.find("/"), remainder.find("?"), remainder.find("#")) if idx != -1
+    ]
+    authority_end = min(authority_end_candidates) if authority_end_candidates else len(remainder)
+    authority = remainder[:authority_end]
+    hostport = authority.rsplit("@", 1)[1] if "@" in authority else authority
+
+    destination_variables = set(get_variable_names_from_object(scheme_part))
+    destination_variables.update(get_variable_names_from_object(hostport))
+    return list(sorted(destination_variables))
+
+
+def _warn_if_non_public_ip_target(url: str) -> None:
+    hostname = urlparse(url).hostname
+    if hostname is None:
+        return
+
+    try:
+        ip_target = ipaddress.ip_address(hostname)
+    except ValueError:
+        return
+
+    if ip_target.is_loopback or ip_target.is_link_local or ip_target.is_private:
+        warnings.warn(
+            "Requested URL targets a loopback, link-local, or private IP address. "
+            "Please ensure this destination is expected and appropriately controlled.",
+            UserWarning,
+        )
+
+
 class ApiCallStep(Step):
     """A step for calling remote APIs.
     It can do GET/POST/PUT/DELETE/etc. requests to endpoints.
@@ -277,7 +323,11 @@ class ApiCallStep(Step):
         Since the Agent can generate arguments (url, method, data, params, headers, cookies) or parts of these arguments in the respective Jinja
         templates, this can impose a security risk of information leakage and enable specific attack vectors like automated DDOS attacks. Please use
         ``ApiCallStep`` responsibly and ensure that only valid URLs can be given as arguments or that no sensitive information is used for any of these arguments by the agent.
-        Please use the url_allow_list, allow_credentials and allow_fragments parameters to control which URLs are treated as valid.
+        Please use the url_allow_list, allow_credentials and allow_fragments parameters to control which URLs are treated as valid. If the ``url``
+        template contains placeholders in the destination part of the request (scheme, host, or port), ``url_allow_list`` must be configured.
+        Placeholders limited to the path or query do not trigger this requirement. The recommended pattern is to keep the base URL
+        developer-controlled and template only path, query, or body values. Requests to loopback, link-local, and private IP literal targets emit
+        a runtime warning.
     """
 
     HTTP_RESPONSE = "http_response"
@@ -340,6 +390,11 @@ class ApiCallStep(Step):
         url
             Url to call.
             Can be templated using jinja templates.
+
+            If placeholders appear in the destination part of the URL (scheme, host, or port), ``url_allow_list`` must be configured.
+            Placeholders limited to the path or query do not trigger this requirement. The recommended pattern is a fixed developer-controlled
+            base URL with templated path, query, or body values only. Requests to loopback, link-local, and private IP literal targets emit a
+            runtime warning.
         method
             HTTP method to call.
             Common methods are: GET, OPTIONS, HEAD, POST, PUT, PATCH, or DELETE.
@@ -414,6 +469,10 @@ class ApiCallStep(Step):
             A list of URLs that any request URL is matched against.
             If there is at least one entry in the allow list that the requested URL matches,
             the request is considered allowed.
+
+            This parameter is required only when placeholders appear in the destination part
+            of the ``url`` template (scheme, host, or port). Placeholders limited to the path
+            or query do not trigger this requirement.
 
             We consider URLs following the generic-URL syntax as defined in `RFC 1808`_:
             ``<scheme>://<net_loc>/<path>;<params>?<query>#<fragment>``
@@ -492,9 +551,9 @@ class ApiCallStep(Step):
         ... )
         >>>
         >>> create_order_step = ApiCallStep(
-        ...     url = "https://example.com/orders/{{ order_id }}",         # call the URL https://example.com/orders/{{ order_id }}
+        ...     url = "https://example.com/orders/{{ order_id }}",         # keep the base URL fixed and template only the path parameter
         ...     method = "POST",                            # using the POST method
-        ...     data = {                               # sending an object which will automatically be transformed into JSON
+        ...     data = {                                    # sending an object which will automatically be transformed into JSON
         ...         "topic_id": 12345,                      # define a static body parameter
         ...         "item_id": "{{ item_id }}",             # define a templated body parameter. the value for {{ item_id }} will be taken from the IO system at runtime
         ...     },
@@ -548,6 +607,18 @@ class ApiCallStep(Step):
             raise ValueError(
                 f"Some headers have been specified in both `headers` and "
                 f"`sensitive_headers`: {repeated_headers}. This is not allowed."
+            )
+
+        templated_destination_variables = _get_url_destination_placeholder_names(url)
+        if templated_destination_variables and url_allow_list is None:
+            variable_list = ", ".join(
+                f"`{variable}`" for variable in templated_destination_variables
+            )
+            raise ValueError(
+                "Templated URL destinations require `url_allow_list`. "
+                f"The `url` template changes the scheme, host, or port via {variable_list}."
+                "Use a developer-controlled base URL and template only path, query, or body values, "
+                "or configure `url_allow_list` explicitly."
             )
 
         if num_retry_on_bad_http_request is not None and retry_policy is None:
@@ -742,9 +813,11 @@ class ApiCallStep(Step):
 
             if not any(match_results):
                 raise ValueError(
-                    f"Requested URL is not in allowed list.\
-                                   Please contact the application administrator to help adding your URL to the list."
+                    "Requested URL is not in allowed list. "
+                    "Please contact the application administrator to help adding your URL to the list."
                 )
+
+        _warn_if_non_public_ip_target(request["url"])
 
         # Default behavior: keep legacy retry loop unless a RetryPolicy is provided.
         policy = self.retry_policy

--- a/wayflowcore/src/wayflowcore/steps/apicallstep.py
+++ b/wayflowcore/src/wayflowcore/steps/apicallstep.py
@@ -327,8 +327,8 @@ class ApiCallStep(Step):
         Please use the url_allow_list, allow_credentials and allow_fragments parameters to control which URLs are treated as valid. If the ``url``
         template contains placeholders in the destination part of the request (scheme, host, or port), ``url_allow_list`` must be configured.
         Placeholders limited to the path or query do not trigger this requirement. The recommended pattern is to keep the base URL
-        developer-controlled and template only path, query, or body values. Requests to loopback, link-local, and private IP literal targets emit
-        a runtime warning.
+        developer-controlled and template only path, query, or body values. Requests to loopback, link-local, and private IP literal targets that
+        are not explicitly allow-listed emit a runtime warning.
     """
 
     HTTP_RESPONSE = "http_response"
@@ -394,8 +394,8 @@ class ApiCallStep(Step):
 
             If placeholders appear in the destination part of the URL (scheme, host, or port), ``url_allow_list`` must be configured.
             Placeholders limited to the path or query do not trigger this requirement. The recommended pattern is a fixed developer-controlled
-            base URL with templated path, query, or body values only. Requests to loopback, link-local, and private IP literal targets emit a
-            runtime warning.
+            base URL with templated path, query, or body values only. Requests to loopback, link-local, and private IP literal targets that are
+            not explicitly allow-listed emit a runtime warning.
         method
             HTTP method to call.
             Common methods are: GET, OPTIONS, HEAD, POST, PUT, PATCH, or DELETE.
@@ -807,18 +807,21 @@ class ApiCallStep(Step):
         if not parsed_url:
             raise ValueError("An error occurred when normalizing the URL.")
 
+        is_explicitly_allow_listed = False
         if self.url_allow_list is not None:
             match_results = [
                 _is_allowed_url(parsed_url, pattern) for pattern in self.url_allow_list
             ]
+            is_explicitly_allow_listed = any(match_results)
 
-            if not any(match_results):
+            if not is_explicitly_allow_listed:
                 raise ValueError(
                     "Requested URL is not in allowed list. "
                     "Please contact the application administrator to help adding your URL to the list."
                 )
 
-        _warn_if_non_public_ip_target(request["url"])
+        if not is_explicitly_allow_listed:
+            _warn_if_non_public_ip_target(request["url"])
 
         # Default behavior: keep legacy retry loop unless a RetryPolicy is provided.
         policy = self.retry_policy

--- a/wayflowcore/src/wayflowcore/steps/apicallstep.py
+++ b/wayflowcore/src/wayflowcore/steps/apicallstep.py
@@ -27,6 +27,7 @@ from wayflowcore.models._requesthelpers import RetryingAsyncClient
 from wayflowcore.property import IntegerProperty, Property, StringProperty, string_to_property
 from wayflowcore.retrypolicy import RetryPolicy
 from wayflowcore.steps.step import Step, StepResult
+from wayflowcore.warnings import SecurityWarning
 
 if TYPE_CHECKING:
     from wayflowcore.executors._flowconversation import FlowConversation
@@ -308,7 +309,7 @@ def _warn_if_non_public_ip_target(url: str) -> None:
         warnings.warn(
             "Requested URL targets a loopback, link-local, or private IP address. "
             "Please ensure this destination is expected and appropriately controlled.",
-            UserWarning,
+            SecurityWarning,
         )
 
 

--- a/wayflowcore/src/wayflowcore/tools/remotetools.py
+++ b/wayflowcore/src/wayflowcore/tools/remotetools.py
@@ -36,7 +36,12 @@ class RemoteTool(SerializableDataclassMixin, ServerTool, SerializableObject):
         attacks. Please use ``RemoteTool`` responsibly and ensure that only valid URLs can be given
         as arguments or that no sensitive information is used for any of these arguments by the
         agent. Please use the ``url_allow_list``, ``allow_credentials`` and ``allow_fragments``
-        parameters to control which URLs are treated as valid.
+        parameters to control which URLs are treated as valid. If the ``url`` template contains
+        placeholders in the destination part of the request (scheme, host, or port),
+        ``url_allow_list`` must be configured. Placeholders limited to the path or query do not
+        trigger this requirement. The recommended pattern is a developer-controlled base URL with
+        templated path, query, or body values only. Requests to loopback, link-local, and private
+        IP literal targets emit a runtime warning.
 
     Parameters
     ----------
@@ -47,6 +52,12 @@ class RemoteTool(SerializableDataclassMixin, ServerTool, SerializableObject):
     url
         Url to call.
         Can be templated using jinja templates.
+
+        If placeholders appear in the destination part of the URL (scheme, host, or port),
+        ``url_allow_list`` must be configured. Placeholders limited to the path or query do not
+        trigger this requirement. The recommended pattern is a fixed developer-controlled base URL
+        with templated path, query, or body values only. Requests to loopback, link-local, and
+        private IP literal targets emit a runtime warning.
     method
         HTTP method to call.
         Common methods are: GET, OPTIONS, HEAD, POST, PUT, PATCH, or DELETE.
@@ -106,6 +117,10 @@ class RemoteTool(SerializableDataclassMixin, ServerTool, SerializableObject):
        A list of URLs that any request URL is matched against.
         If there is at least one entry in the allow list that the requested URL matches,
         the request is considered allowed.
+
+        This parameter is required only when placeholders appear in the destination part of the
+        ``url`` template (scheme, host, or port). Placeholders limited to the path or query do not
+        trigger this requirement.
 
         We consider URLs following the generic-URL syntax as defined in `RFC 1808`_:
         ``<scheme>://<net_loc>/<path>;<params>?<query>#<fragment>``

--- a/wayflowcore/src/wayflowcore/tools/remotetools.py
+++ b/wayflowcore/src/wayflowcore/tools/remotetools.py
@@ -41,7 +41,7 @@ class RemoteTool(SerializableDataclassMixin, ServerTool, SerializableObject):
         ``url_allow_list`` must be configured. Placeholders limited to the path or query do not
         trigger this requirement. The recommended pattern is a developer-controlled base URL with
         templated path, query, or body values only. Requests to loopback, link-local, and private
-        IP literal targets emit a runtime warning.
+        IP literal targets that are not explicitly allow-listed emit a runtime warning.
 
     Parameters
     ----------
@@ -57,7 +57,7 @@ class RemoteTool(SerializableDataclassMixin, ServerTool, SerializableObject):
         ``url_allow_list`` must be configured. Placeholders limited to the path or query do not
         trigger this requirement. The recommended pattern is a fixed developer-controlled base URL
         with templated path, query, or body values only. Requests to loopback, link-local, and
-        private IP literal targets emit a runtime warning.
+        private IP literal targets that are not explicitly allow-listed emit a runtime warning.
     method
         HTTP method to call.
         Common methods are: GET, OPTIONS, HEAD, POST, PUT, PATCH, or DELETE.

--- a/wayflowcore/tests/agentspec/test_agentspec_to_core_conversion.py
+++ b/wayflowcore/tests/agentspec/test_agentspec_to_core_conversion.py
@@ -46,6 +46,7 @@ def agentspec_remote_tool_with_specified_io() -> AgentSpecRemoteTool:
         url="https://example.com",
         http_method="POST",
         data={"payload": {"query": "{{query}}"}},
+        url_allow_list=["https://example.com/search/"],
         inputs=[AgentSpecStringProperty(title="query", type="string")],
         outputs=[AgentSpecStringProperty(title="search_results", type="string")],
     )
@@ -231,6 +232,7 @@ def test_agentspec_remote_tool_preserves_custom_io_descriptors_when_loaded(
     assert [descriptor.name for descriptor in loaded_remote_tool.output_descriptors] == [
         "search_results"
     ]
+    assert loaded_remote_tool.url_allow_list == ["https://example.com/search/"]
 
 
 def test_toolnode_with_remote_tool_custom_output_can_be_loaded(

--- a/wayflowcore/tests/agentspec/test_core_to_agentspec_conversion.py
+++ b/wayflowcore/tests/agentspec/test_core_to_agentspec_conversion.py
@@ -37,6 +37,7 @@ def runtime_remote_tool_with_specified_io() -> RuntimeRemoteTool:
         url="https://example.com",
         method="POST",
         data={"payload": {"query": "{{query}}"}},
+        url_allow_list=["https://example.com/search/"],
         input_descriptors=[RuntimeStringProperty(name="query")],
         output_descriptors=[RuntimeStringProperty(name="search_results")],
     )
@@ -145,6 +146,7 @@ def test_runtime_remote_tool_preserves_custom_io_descriptors_when_exported(
     assert exported_remote_tool.outputs is not None and [
         descriptor.title for descriptor in exported_remote_tool.outputs
     ] == ["search_results"]
+    assert exported_remote_tool.url_allow_list == ["https://example.com/search/"]
 
 
 @pytest.mark.parametrize(

--- a/wayflowcore/tests/agentspec/test_mcptool.py
+++ b/wayflowcore/tests/agentspec/test_mcptool.py
@@ -6,10 +6,15 @@
 import json
 
 import pytest
+from pyagentspec.adapters._agentspecloader import (
+    _DEFAULT_BLOCKED_COMPONENTS as _AGENTSPEC_DEFAULT_BLOCKED_COMPONENTS,
+)
 from pyagentspec.versioning import AgentSpecVersionEnum
 
 from wayflowcore import Agent
 from wayflowcore.agentspec import AgentSpecExporter, AgentSpecLoader
+from wayflowcore.agentspec.components.mcp import PluginMCPTool, PluginStdioTransport
+from wayflowcore.agentspec.runtimeloader import _DEFAULT_BLOCKED_COMPONENTS
 from wayflowcore.mcp import (
     MCPTool,
     MCPToolBox,
@@ -58,7 +63,6 @@ from wayflowcore.warnings import SecurityWarning
             key_file="key_fil",
             timeout=100,
         ),
-        StdioTransport(command="command", cwd=".."),
     ],
 )
 def test_mcp_tool_can_be_converted_to_agentspec_and_back(
@@ -94,6 +98,73 @@ def test_mcp_tool_can_be_converted_to_agentspec_and_back(
     assert len(all_agent_tools) == len(all_reloaded_agent_tools)
     for key, value in all_agent_tools.items():
         assert value == all_reloaded_agent_tools[key]
+
+
+def _make_agent_with_mcp_stdio_transport(remotely_hosted_llm):
+    client_transport = StdioTransport(command="command", cwd="..")
+    mcp_tool = MCPTool(
+        name="fooza_tool",
+        client_transport=client_transport,
+        _validate_server_exists=False,
+        description="some description",
+        input_descriptors=[StringProperty(name="a"), StringProperty(name="b")],
+    )
+    mcp_toolbox = MCPToolBox(client_transport=client_transport, requires_confirmation=False)
+    return Agent(llm=remotely_hosted_llm, tools=[mcp_tool, mcp_toolbox])
+
+
+def test_default_blocked_components_extend_agentspec_defaults() -> None:
+    assert all(
+        blocked_component in _DEFAULT_BLOCKED_COMPONENTS
+        for blocked_component in _AGENTSPEC_DEFAULT_BLOCKED_COMPONENTS
+    )
+    assert PluginStdioTransport in _DEFAULT_BLOCKED_COMPONENTS
+
+
+def test_mcp_tool_with_stdio_transport_is_blocked_by_default(remotely_hosted_llm, with_mcp_enabled):
+    agent = _make_agent_with_mcp_stdio_transport(remotely_hosted_llm)
+    agentspec_agent = AgentSpecExporter().to_json(
+        agent, agentspec_version=AgentSpecVersionEnum.current_version
+    )
+
+    with pytest.raises(ValueError, match="StdioTransport.*in the block list"):
+        AgentSpecLoader().load_json(agentspec_agent)
+
+
+def test_mcp_tool_with_stdio_transport_can_be_loaded_when_unblocked(
+    remotely_hosted_llm, with_mcp_enabled
+):
+    agent = _make_agent_with_mcp_stdio_transport(remotely_hosted_llm)
+    agentspec_agent = AgentSpecExporter().to_json(
+        agent, agentspec_version=AgentSpecVersionEnum.current_version
+    )
+
+    reloaded_agent = AgentSpecLoader(blocked_components=[]).load_json(agentspec_agent)
+
+    assert isinstance(reloaded_agent, Agent)
+    assert any(isinstance(tool.client_transport, StdioTransport) for tool in reloaded_agent.tools)
+
+
+def test_plugin_stdio_transport_is_blocked_by_default() -> None:
+    plugin_tool = PluginMCPTool(
+        name="plugin_stdio_tool",
+        client_transport=PluginStdioTransport(name="plugin_stdio", command="command"),
+    )
+
+    with pytest.raises(ValueError, match="PluginStdioTransport.*in the block list"):
+        AgentSpecLoader().load_component(plugin_tool)
+
+
+def test_plugin_stdio_transport_remains_blocked_when_allowed_with_defaults() -> None:
+    plugin_tool = PluginMCPTool(
+        name="plugin_stdio_tool",
+        client_transport=PluginStdioTransport(name="plugin_stdio", command="command"),
+    )
+
+    with pytest.raises(ValueError, match="PluginStdioTransport.*in the block list"):
+        AgentSpecLoader(
+            allowed_components=[PluginMCPTool, PluginStdioTransport],
+        ).load_component(plugin_tool)
 
 
 @pytest.mark.parametrize("requires_confirmation", [True, False])

--- a/wayflowcore/tests/agentspec/test_retry_policy_conversion.py
+++ b/wayflowcore/tests/agentspec/test_retry_policy_conversion.py
@@ -25,6 +25,7 @@ def test_api_call_step_retry_policy_converts_to_agentspec_and_back() -> None:
     runtime_step = ApiCallStep(
         url="https://example.com",
         method="POST",
+        url_allow_list=["https://example.com/orders/"],
         retry_policy=RetryPolicy(max_attempts=3),
     )
 
@@ -32,6 +33,7 @@ def test_api_call_step_retry_policy_converts_to_agentspec_and_back() -> None:
         runtime_step,
         referenced_objects={},
     )
+    assert agentspec_node.url_allow_list == ["https://example.com/orders/"]
     assert agentspec_node.retry_policy is not None
     assert agentspec_node.retry_policy.max_attempts == 3
 
@@ -40,6 +42,7 @@ def test_api_call_step_retry_policy_converts_to_agentspec_and_back() -> None:
         tool_registry={},
         converted_components={},
     )
+    assert round_tripped.url_allow_list == ["https://example.com/orders/"]
     assert round_tripped.retry_policy is not None
     assert round_tripped.retry_policy.max_attempts == 3
 

--- a/wayflowcore/tests/integration/steps/test_api_call_step.py
+++ b/wayflowcore/tests/integration/steps/test_api_call_step.py
@@ -27,6 +27,7 @@ from wayflowcore.property import ListProperty, StringProperty
 from wayflowcore.serialization.serializer import deserialize
 from wayflowcore.steps.apicallstep import ApiCallStep
 from wayflowcore.steps.step import Step
+from wayflowcore.warnings import SecurityWarning
 
 from ...utils import get_available_port
 
@@ -602,7 +603,8 @@ def test_api_call_step_warns_for_non_public_ip_targets(faked_request, url):
     step = ApiCallStep(url=url, method="GET")
 
     with pytest.warns(
-        UserWarning, match="Requested URL targets a loopback, link-local, or private IP address"
+        SecurityWarning,
+        match="Requested URL targets a loopback, link-local, or private IP address",
     ):
         run_single_step(step)
 

--- a/wayflowcore/tests/integration/steps/test_api_call_step.py
+++ b/wayflowcore/tests/integration/steps/test_api_call_step.py
@@ -546,12 +546,21 @@ def test_api_call_step_disallow_http_by_default_runstep(faked_request):
         step = ApiCallStep(
             url="{{scheme}}://example.com/endpoint",
             method="GET",
+            url_allow_list=["http://example.com/endpoint"],
         )
 
         inputs_dict = {
             "scheme": "http",
         }
         run_single_step(step, inputs_dict)
+
+
+def test_api_call_step_requires_allow_list_for_templated_host():
+    with pytest.raises(ValueError, match="Templated URL destinations require `url_allow_list`"):
+        ApiCallStep(
+            url="https://{{service_host}}/endpoint",
+            method="GET",
+        )
 
 
 def test_api_call_step_disallow_http_by_default_allowed(faked_request):
@@ -579,6 +588,23 @@ def test_api_call_step_does_not_throw_if_allow_list_none(faked_request):
     )
 
     run_single_step(step)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://127.0.0.1/metadata",
+        "https://10.0.0.7/metadata",
+        "https://169.254.1.1/metadata",
+    ],
+)
+def test_api_call_step_warns_for_non_public_ip_targets(faked_request, url):
+    step = ApiCallStep(url=url, method="GET")
+
+    with pytest.warns(
+        UserWarning, match="Requested URL targets a loopback, link-local, or private IP address"
+    ):
+        run_single_step(step)
 
 
 def test_api_call_step_throws_if_disallowed_credentials(faked_request):

--- a/wayflowcore/tests/integration/steps/test_api_call_step.py
+++ b/wayflowcore/tests/integration/steps/test_api_call_step.py
@@ -33,6 +33,11 @@ from ...utils import get_available_port
 
 URL_TEMPLATE_VALUE = "a/b/c?param=baram&rama=bu77er"
 ENCODED_URL_TEMPLATE_VALUE = "a%2Fb%2Fc%3Fparam%3Dbaram%26rama%3Dbu77er"
+LOOPBACK_ADDRESSES = [
+    "https://127.0.0.1/metadata",
+    "https://10.0.0.7/metadata",
+    "https://169.254.1.1/metadata",
+]
 
 
 @dataclass
@@ -591,14 +596,7 @@ def test_api_call_step_does_not_throw_if_allow_list_none(faked_request):
     run_single_step(step)
 
 
-@pytest.mark.parametrize(
-    "url",
-    [
-        "https://127.0.0.1/metadata",
-        "https://10.0.0.7/metadata",
-        "https://169.254.1.1/metadata",
-    ],
-)
+@pytest.mark.parametrize("url", LOOPBACK_ADDRESSES)
 def test_api_call_step_warns_for_non_public_ip_targets(faked_request, url):
     step = ApiCallStep(url=url, method="GET")
 
@@ -609,14 +607,7 @@ def test_api_call_step_warns_for_non_public_ip_targets(faked_request, url):
         run_single_step(step)
 
 
-@pytest.mark.parametrize(
-    "url",
-    [
-        "https://127.0.0.1/metadata",
-        "https://10.0.0.7/metadata",
-        "https://169.254.1.1/metadata",
-    ],
-)
+@pytest.mark.parametrize("url", LOOPBACK_ADDRESSES)
 def test_api_call_step_does_not_warn_for_allow_listed_non_public_ip_targets(faked_request, url):
     step = ApiCallStep(url=url, method="GET", url_allow_list=[url])
 

--- a/wayflowcore/tests/integration/steps/test_api_call_step.py
+++ b/wayflowcore/tests/integration/steps/test_api_call_step.py
@@ -609,6 +609,27 @@ def test_api_call_step_warns_for_non_public_ip_targets(faked_request, url):
         run_single_step(step)
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://127.0.0.1/metadata",
+        "https://10.0.0.7/metadata",
+        "https://169.254.1.1/metadata",
+    ],
+)
+def test_api_call_step_does_not_warn_for_allow_listed_non_public_ip_targets(faked_request, url):
+    step = ApiCallStep(url=url, method="GET", url_allow_list=[url])
+
+    with warnings.catch_warnings(record=True) as recorded_warnings:
+        warnings.simplefilter("always")
+        run_single_step(step)
+
+    security_warnings = [
+        warning for warning in recorded_warnings if issubclass(warning.category, SecurityWarning)
+    ]
+    assert security_warnings == []
+
+
 def test_api_call_step_throws_if_disallowed_credentials(faked_request):
     with pytest.raises(ValueError):
         step = ApiCallStep(

--- a/wayflowcore/tests/test_docs_examples.py
+++ b/wayflowcore/tests/test_docs_examples.py
@@ -156,6 +156,7 @@ def test_code_examples_in_docs_can_be_successfully_run(
     embedding_model,
     test_with_llm_fixture,
     request,
+    monkeypatch,
 ) -> None:
     """
     Failure rate:          0 out of 20
@@ -182,6 +183,12 @@ def test_code_examples_in_docs_can_be_successfully_run(
 
     if "expired_token" in file_path:
         globs["mock_server_url"] = request.getfixturevalue("mock_server")
+
+    if file_path.endswith("howto_serve_agents.py"):
+        if "WAYFLOW_SERVER_TOKEN" not in os.environ:
+            monkeypatch.setenv("WAYFLOW_SERVER_TOKEN", "test-wayflow-server-token")
+        if "PG_PASSWORD" not in os.environ:
+            monkeypatch.setenv("PG_PASSWORD", "test-postgres-password")
 
     try:
         runpy.run_path(file_path, init_globals=globs)


### PR DESCRIPTION
This PR refines URL templating behavior in ApiCallStep and RemoteTool. It now requires url_allow_list only when placeholders are used in the destination part of a URL (scheme, host, or port), adds a runtime warning for localhost/private IP literal destinations, and updates tests, docs, and examples to reflect the recommended patterns.