### PR TITLE
Improve TLS defaults for MCP HTTP transports

### DIFF
--- a/docs/wayflowcore/source/core/changelog.rst
+++ b/docs/wayflowcore/source/core/changelog.rst
@@ -58,6 +58,13 @@ Improvements
   helper remains available, but now emits a ``SecurityWarning``. Authless MCP use also emits
   a ``SecurityWarning`` when validation is bypassed.
 
+* **Improved TLS defaults for MCP HTTP transports**
+
+  ``SSETransport`` and ``StreamableHTTPTransport`` now use standard HTTPS certificate
+  verification by default. ``SSEmTLSTransport`` and ``StreamableHTTPmTLSTransport``
+  now also verify that the server certificate matches the requested hostname unless
+  this check is explicitly disabled.
+
 * **Improved agent server access defaults**
 
   ``A2AServer.run(api_key=...)`` now enforces bearer-token authentication when an API key is
@@ -102,6 +109,14 @@ Possibly Breaking Changes
   authentication. The legacy ``enable_mcp_without_auth()`` helper remains
   available, but emits a ``SecurityWarning``. Code that treats warnings as errors
   may need to catch or filter this warning for local tests.
+
+* **MCP HTTPS transports now expect valid certificate configuration**
+
+  ``SSETransport`` and ``StreamableHTTPTransport`` now use standard HTTPS certificate
+  verification by default, and ``SSEmTLSTransport`` and ``StreamableHTTPmTLSTransport``
+  now verify the requested hostname by default. Deployments using self-signed certificates,
+  custom certificate authorities, or certificates whose hostname does not match the MCP
+  server URL may require certificate updates or transport configuration changes.
 
 * **Agent servers require API keys on non-loopback hosts**
 

--- a/wayflowcore/src/wayflowcore/mcp/clienttransport.py
+++ b/wayflowcore/src/wayflowcore/mcp/clienttransport.py
@@ -248,18 +248,7 @@ class _HttpxClientFactory:
         retry_policy: Optional[RetryPolicy] = None,
     ):
         self.verify: bool | ssl.SSLContext
-        if verify:
-            # Default behaviour: Client verification
-            if not (key_file and cert_file and ssl_ca_cert):
-                raise ValueError(
-                    "When verify=True, all `key_file`, `cert_file` and `ssl_ca_cert` "
-                    "must be defined."
-                )
-            ssl_ctx = ssl.create_default_context(cafile=ssl_ca_cert)
-            ssl_ctx.load_cert_chain(certfile=cert_file, keyfile=key_file)
-            ssl_ctx.check_hostname = check_hostname
-            self.verify = ssl_ctx
-        else:
+        if not verify:
             # If verify=False the cert/key files should not be specified
             if key_file or cert_file or ssl_ca_cert:
                 raise ValueError(
@@ -267,6 +256,16 @@ class _HttpxClientFactory:
                     "or `verify=False`, not both."
                 )
             self.verify = verify
+        elif bool(key_file) != bool(cert_file):
+            raise ValueError("Both `key_file` and `cert_file` must be provided together.")
+        elif not any(file_path is not None for file_path in (key_file, cert_file, ssl_ca_cert)):
+            self.verify = True
+        else:
+            ssl_ctx = ssl.create_default_context(cafile=ssl_ca_cert)
+            if cert_file is not None and key_file is not None:
+                ssl_ctx.load_cert_chain(certfile=cert_file, keyfile=key_file)
+            ssl_ctx.check_hostname = check_hostname
+            self.verify = ssl_ctx
 
         self.follow_redirects = follow_redirects
         self.retry_policy = retry_policy
@@ -324,7 +323,6 @@ class SSETransport(RemoteBaseTransport, ClientTransportWithAuth, SerializableObj
             sse_read_timeout=self.sse_read_timeout,
             auth=self._get_auth_provider(),
             httpx_client_factory=_HttpxClientFactory(
-                verify=False,
                 follow_redirects=self.follow_redirects,
                 retry_policy=self.retry_policy,
             ),
@@ -346,10 +344,10 @@ class HTTPmTLSBaseTransport(RemoteBaseTransport):
     ssl_ca_cert: str = field(default_factory=_raise_if_missing("ssl_ca_cert"))
     """The path to the trusted CA certificate file (PEM format) to verify the server. If None, system cert store is used."""
 
-    check_hostname: bool = False
+    check_hostname: bool = True
     """Whether to verify that the server's hostname matches the certificate.
     If True, the client will reject connections where the server's certificate hostname does not match the expected hostname.
-    Defaults to False."""
+    Defaults to True."""
 
 
 @dataclass
@@ -432,7 +430,6 @@ class StreamableHTTPTransport(RemoteBaseTransport, ClientTransportWithAuth, Seri
             sse_read_timeout=datetime.timedelta(seconds=self.sse_read_timeout),
             auth=self._get_auth_provider(),
             httpx_client_factory=_HttpxClientFactory(
-                verify=False,
                 follow_redirects=self.follow_redirects,
                 retry_policy=self.retry_policy,
             ),

--- a/wayflowcore/src/wayflowcore/mcp/clienttransport.py
+++ b/wayflowcore/src/wayflowcore/mcp/clienttransport.py
@@ -7,6 +7,7 @@
 import datetime
 import logging
 import ssl
+import warnings
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, List, Literal, Optional
@@ -26,6 +27,7 @@ from wayflowcore.serialization.serializer import (
     SerializableDataclassMixin,
     SerializableObject,
 )
+from wayflowcore.warnings import SecurityWarning
 
 if TYPE_CHECKING:
     from wayflowcore.serialization.context import SerializationContext
@@ -261,9 +263,18 @@ class _HttpxClientFactory:
         elif not any(file_path is not None for file_path in (key_file, cert_file, ssl_ca_cert)):
             self.verify = True
         else:
-            ssl_ctx = ssl.create_default_context(cafile=ssl_ca_cert)
+            ssl_ctx = ssl.create_default_context()
+            if ssl_ca_cert is not None:
+                ssl_ctx.load_verify_locations(cafile=ssl_ca_cert)
             if cert_file is not None and key_file is not None:
                 ssl_ctx.load_cert_chain(certfile=cert_file, keyfile=key_file)
+            if not check_hostname:
+                warnings.warn(
+                    "Hostname verification is disabled for this TLS connection. "
+                    "This is not recommended for production environments.",
+                    SecurityWarning,
+                    stacklevel=2,
+                )
             ssl_ctx.check_hostname = check_hostname
             self.verify = ssl_ctx
 

--- a/wayflowcore/tests/mcptools/encryption.py
+++ b/wayflowcore/tests/mcptools/encryption.py
@@ -119,9 +119,11 @@ def issue_server_cert(
     csr: x509.CertificateSigningRequest,
     days: int = 365,
     tmpdir: str = "",
+    subject_alt_names: list[x509.GeneralName] | None = None,
 ):
     san = x509.SubjectAlternativeName(
-        [
+        subject_alt_names
+        or [
             x509.DNSName("localhost"),
             x509.IPAddress(ipaddress.IPv4Address("127.0.0.1")),
         ]

--- a/wayflowcore/tests/mcptools/test_mcp_tools.py
+++ b/wayflowcore/tests/mcptools/test_mcp_tools.py
@@ -158,7 +158,8 @@ def sse_client_transport_with_headers(sse_mcp_server_http):
 
 
 @pytest.fixture
-def sse_client_transport_https(sse_mcp_server_https):
+def sse_client_transport_https(sse_mcp_server_https, ca_cert_path, monkeypatch):
+    monkeypatch.setenv("SSL_CERT_FILE", ca_cert_path)
     return SSETransport(url=sse_mcp_server_https)
 
 
@@ -183,7 +184,10 @@ def alt_sse_client_transport(alt_sse_mcp_server_http):
 
 
 @pytest.fixture
-def streamablehttp_client_transport_https(streamablehttp_mcp_server_https):
+def streamablehttp_client_transport_https(
+    streamablehttp_mcp_server_https, ca_cert_path, monkeypatch
+):
+    monkeypatch.setenv("SSL_CERT_FILE", ca_cert_path)
     return StreamableHTTPTransport(url=streamablehttp_mcp_server_https)
 
 
@@ -296,6 +300,39 @@ def run_tool_can_be_executed_from_thread(transport: ClientTransport) -> None:
 def test_mcp_tool_can_be_executed_from_thread(client_transport_name, with_mcp_enabled, request):
     client_transport = request.getfixturevalue(client_transport_name)
     run_tool_can_be_executed_from_thread(client_transport)
+
+
+def test_sse_transport_uses_tls_verification_by_default(monkeypatch):
+    captured_factory = {}
+
+    def fake_sse_client(*args, **kwargs):
+        captured_factory["value"] = kwargs["httpx_client_factory"]
+        return object()
+
+    monkeypatch.setattr("wayflowcore.mcp.clienttransport.sse_client", fake_sse_client)
+
+    transport = SSETransport(url="https://server/sse")
+    transport._get_client_transport_cm()
+
+    assert captured_factory["value"].verify is True
+
+
+def test_streamablehttp_transport_uses_tls_verification_by_default(monkeypatch):
+    captured_factory = {}
+
+    def fake_streamablehttp_client(*args, **kwargs):
+        captured_factory["value"] = kwargs["httpx_client_factory"]
+        return object()
+
+    monkeypatch.setattr(
+        "wayflowcore.mcp.clienttransport.streamablehttp_client",
+        fake_streamablehttp_client,
+    )
+
+    transport = StreamableHTTPTransport(url="https://server/mcp")
+    transport._get_client_transport_cm()
+
+    assert captured_factory["value"].verify is True
 
 
 def test_mcp_toolbox_properly_filters_tools(sse_client_transport, with_mcp_enabled):


### PR DESCRIPTION
SSETransport and StreamableHTTPTransport now use standard HTTPS certificate verification by default, and the mTLS transports now enable hostname verification by default as well. The change keeps the public transport shape unchanged while making the default behavior better aligned with normal HTTPS expectations.