### PR TITLE
  Improve retry policy and test reliability

### DIFF
--- a/wayflowcore/src/wayflowcore/models/_requesthelpers.py
+++ b/wayflowcore/src/wayflowcore/models/_requesthelpers.py
@@ -325,7 +325,7 @@ def _is_transport_exception_without_response(exc: BaseException) -> bool:
         return False
 
     status_code = _get_http_status_code_from_exception(exc)
-    return status_code is None or status_code <= 0 or status_code == 408 or status_code >= 500
+    return status_code is None or status_code <= 0 or status_code == 408
 
 
 def _classify_http_exception_for_retry(

--- a/wayflowcore/src/wayflowcore/models/_requesthelpers.py
+++ b/wayflowcore/src/wayflowcore/models/_requesthelpers.py
@@ -314,18 +314,44 @@ def _get_http_error_text_from_exception(exc: BaseException) -> str:
     return _stringify_response_error(body)
 
 
-def _is_transport_exception_without_response(exc: BaseException) -> bool:
+_PRE_RESPONSE_TRANSPORT_EXCEPTION_CLASS_NAMES = {
+    "APIConnectionError",
+    "APITimeoutError",
+    "Timeout",
+}
+
+
+def _is_transport_failure_without_http_response(exc: BaseException) -> bool:
+    """Return whether an exception is a network/client failure before an HTTP response."""
+    # Native httpx transport failures do not represent HTTP responses.
     if isinstance(exc, httpx.TransportError):
         return True
 
-    # Some OpenAI-compatible SDKs expose connection/timeout failures as their
-    # own exception classes with a request and sometimes a synthetic status_code,
-    # but no response. Treat only transport-shaped statuses this way.
-    if getattr(exc, "request", None) is None or getattr(exc, "response", None) is not None:
+    # SDK status errors normally carry a response and must be classified by HTTP
+    # status. Only SDK wrapper errors with a request and no response can be
+    # pre-response transport failures.
+    if getattr(exc, "request", None) is None:
+        return False
+    if getattr(exc, "response", None) is not None:
         return False
 
+    # No real HTTP response exists. Treat absent/invalid status values and the
+    # request-timeout status as transport failures.
     status_code = _get_http_status_code_from_exception(exc)
-    return status_code is None or status_code <= 0 or status_code == 408
+    if status_code is None or status_code <= 0 or status_code == 408:
+        return True
+
+    if not 500 <= status_code < 600:
+        return False
+
+    # LiteLLM/OpenAI connection and timeout wrappers can attach synthetic 5xx
+    # statuses despite having no response. Only transport-shaped wrappers get
+    # this treatment; real no-response APIError 5xx exceptions stay on the HTTP
+    # policy path. Avoid importing optional provider SDKs here; their stable
+    # class names are visible through the MRO when those SDKs are installed.
+    return any(
+        cls.__name__ in _PRE_RESPONSE_TRANSPORT_EXCEPTION_CLASS_NAMES for cls in type(exc).__mro__
+    )
 
 
 def _classify_http_exception_for_retry(
@@ -336,7 +362,7 @@ def _classify_http_exception_for_retry(
     # classes. Keep retry classification based on stable HTTP attributes and
     # httpx transport causes so importing those optional SDKs is not required.
     for current in _iter_exception_chain(exc):
-        if _is_transport_exception_without_response(current):
+        if _is_transport_failure_without_http_response(current):
             if _is_tls_or_cert_error(current):
                 return None
             return None, None

--- a/wayflowcore/src/wayflowcore/models/_requesthelpers.py
+++ b/wayflowcore/src/wayflowcore/models/_requesthelpers.py
@@ -23,6 +23,7 @@ from typing import (
     Callable,
     Dict,
     Generator,
+    Iterator,
     Mapping,
     Optional,
     Tuple,
@@ -150,10 +151,15 @@ def _get_retry_after_seconds(
 
 
 def _is_tls_or_cert_error(exc: BaseException) -> bool:
-    current: Optional[BaseException] = exc
-    while current is not None:
+    pending: list[BaseException] = [exc]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
         if isinstance(current, ssl.SSLCertVerificationError):
             return True
+        seen.add(id(current))
         msg = str(current)
         if any(
             s in msg
@@ -165,7 +171,10 @@ def _is_tls_or_cert_error(exc: BaseException) -> bool:
             ]
         ):
             return True
-        current = current.__cause__
+        if current.__context__ is not None:
+            pending.append(current.__context__)
+        if current.__cause__ is not None:
+            pending.append(current.__cause__)
     return False
 
 
@@ -253,6 +262,97 @@ def _classify_oci_service_error_for_retry(
     if not _is_retryable_http_error(policy, status_code, exc.message):
         return None
     return status_code, _get_retry_after_value_from_headers(exc.headers)
+
+
+def _iter_exception_chain(exc: BaseException) -> Iterator[BaseException]:
+    pending: list[BaseException] = [exc]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        yield current
+        seen.add(id(current))
+        # Provider SDKs sometimes wrap the transport exception in __cause__,
+        # and framework code may use __context__; walk both links when present.
+        if current.__context__ is not None:
+            pending.append(current.__context__)
+        if current.__cause__ is not None:
+            pending.append(current.__cause__)
+
+
+def _get_http_status_code_from_exception(exc: BaseException) -> Optional[int]:
+    # SDK status exceptions usually expose status_code/status directly; fall
+    # back to response.status_code for HTTP client exceptions such as httpx.
+    status_code = getattr(exc, "status_code", getattr(exc, "status", None))
+    if status_code is None:
+        response = getattr(exc, "response", None)
+        status_code = getattr(response, "status_code", None) if response is not None else None
+    try:
+        return int(status_code) if status_code is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _get_http_headers_from_exception(exc: BaseException) -> Optional[Mapping[str, Any]]:
+    # Retry-After may live either on the exception or the wrapped response.
+    headers = getattr(exc, "headers", None)
+    if headers is None:
+        response = getattr(exc, "response", None)
+        headers = getattr(response, "headers", None) if response is not None else None
+    return cast(Optional[Mapping[str, Any]], headers)
+
+
+def _get_http_error_text_from_exception(exc: BaseException) -> str:
+    # Prefer structured provider error bodies, because retry policies may match
+    # on provider-specific error codes embedded in the response payload.
+    body = getattr(exc, "body", None)
+    if body is None:
+        body = getattr(exc, "message", None)
+    if body is None:
+        body = str(exc)
+    return _stringify_response_error(body)
+
+
+def _is_transport_exception_without_response(exc: BaseException) -> bool:
+    if isinstance(exc, httpx.TransportError):
+        return True
+
+    # Some OpenAI-compatible SDKs expose connection/timeout failures as their
+    # own exception classes with a request and sometimes a synthetic status_code,
+    # but no response. Treat only transport-shaped statuses this way.
+    if getattr(exc, "request", None) is None or getattr(exc, "response", None) is not None:
+        return False
+
+    status_code = _get_http_status_code_from_exception(exc)
+    return status_code is None or status_code <= 0 or status_code == 408 or status_code >= 500
+
+
+def _classify_http_exception_for_retry(
+    exc: BaseException,
+    policy: RetryPolicy,
+) -> RetryClassification:
+    # Some optional provider SDKs wrap HTTP failures in their own exception
+    # classes. Keep retry classification based on stable HTTP attributes and
+    # httpx transport causes so importing those optional SDKs is not required.
+    for current in _iter_exception_chain(exc):
+        if _is_transport_exception_without_response(current):
+            if _is_tls_or_cert_error(current):
+                return None
+            return None, None
+
+        status_code = _get_http_status_code_from_exception(current)
+        if status_code is None:
+            continue
+
+        error_message = _get_http_error_text_from_exception(current)
+        if not _is_retryable_http_error(policy, status_code, error_message):
+            return None
+        return status_code, _get_retry_after_value_from_headers(
+            _get_http_headers_from_exception(current)
+        )
+
+    return None
 
 
 def execute_sync_with_retry(

--- a/wayflowcore/src/wayflowcore/models/geminimodel.py
+++ b/wayflowcore/src/wayflowcore/models/geminimodel.py
@@ -7,21 +7,8 @@
 import json
 import logging
 import os
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    AsyncIterable,
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, AsyncIterable, Dict, Iterable, List, Optional, Union, cast
 
-import httpx
-from openai import APIConnectionError, APIStatusError, APITimeoutError
 from pydantic import BaseModel
 
 from wayflowcore._metadata import MetadataType
@@ -38,10 +25,7 @@ from ._requesthelpers import (
     StreamChunkType,
     TaggedMessageChunkType,
     TaggedMessageChunkTypeWithTokenUsage,
-    _get_retry_after_value_from_headers,
-    _is_retryable_http_error,
-    _is_tls_or_cert_error,
-    _stringify_response_error,
+    _classify_http_exception_for_retry,
     execute_async_with_retry,
     execute_sync_with_retry,
 )
@@ -113,63 +97,6 @@ def _rename_message_and_tool_call_field(
             if target_key not in mapping:
                 mapping[target_key] = source_value
     return message_payload
-
-
-# LiteLLM/OpenAI errors may wrap the retryable transport or status exception
-# one or more levels deep, so walk the causal chain before classifying.
-def _iter_exception_chain(exc: BaseException) -> Iterator[BaseException]:
-    current: Optional[BaseException] = exc
-    seen: set[int] = set()
-    while current is not None and id(current) not in seen:
-        yield current
-        seen.add(id(current))
-        current = current.__cause__ or current.__context__
-
-
-def _classify_gemini_retry_exception(
-    exc: Exception, policy: RetryPolicy
-) -> Optional[tuple[Optional[int], Optional[str]]]:
-    for current in _iter_exception_chain(exc):
-        if isinstance(current, APIStatusError):
-            if current.status_code is None:
-                return None
-            error_message = _stringify_response_error(current.body)
-            if not _is_retryable_http_error(policy, current.status_code, error_message):
-                return None
-            retry_after = (
-                _get_retry_after_value_from_headers(current.response.headers)
-                if current.response is not None
-                else None
-            )
-            return current.status_code, retry_after
-
-        if isinstance(current, (APITimeoutError, APIConnectionError, httpx.TransportError)):
-            if _is_tls_or_cert_error(current):
-                return None
-            return None, None
-
-        status_code = getattr(current, "status_code", getattr(current, "status", None))
-        try:
-            normalized_status_code = int(status_code) if status_code is not None else None
-        except (TypeError, ValueError):
-            normalized_status_code = None
-
-        if normalized_status_code is None:
-            continue
-
-        error_message = _stringify_response_error(
-            getattr(current, "body", getattr(current, "message", str(current)))
-        )
-        if not _is_retryable_http_error(policy, normalized_status_code, error_message):
-            return None
-
-        headers = getattr(current, "headers", None)
-        response = getattr(current, "response", None)
-        if headers is None and response is not None:
-            headers = getattr(response, "headers", None)
-        return normalized_status_code, _get_retry_after_value_from_headers(headers)
-
-    return None
 
 
 class GeminiModel(LlmModel):
@@ -464,7 +391,7 @@ class GeminiModel(LlmModel):
         return execute_sync_with_retry(
             lambda: _get_litellm().completion(**request),
             retry_policy=self.retry_policy,
-            classify_exception=_classify_gemini_retry_exception,
+            classify_exception=_classify_http_exception_for_retry,
             retry_budget_exhausted_message=(
                 "Gemini streaming request retry budget exhausted"
                 if stream
@@ -477,7 +404,7 @@ class GeminiModel(LlmModel):
         return await execute_async_with_retry(
             lambda: _get_litellm().acompletion(**request),
             retry_policy=self.retry_policy,
-            classify_exception=_classify_gemini_retry_exception,
+            classify_exception=_classify_http_exception_for_retry,
             retry_budget_exhausted_message=(
                 "Gemini streaming request retry budget exhausted"
                 if stream

--- a/wayflowcore/src/wayflowcore/models/ocigenaimodel.py
+++ b/wayflowcore/src/wayflowcore/models/ocigenaimodel.py
@@ -24,7 +24,6 @@ from typing import (
     cast,
 )
 
-from openai import APIConnectionError, APIStatusError, APITimeoutError
 from pydantic import BaseModel
 
 from wayflowcore._metadata import MetadataType
@@ -47,12 +46,9 @@ from ._requesthelpers import (
     _DEFAULT_RNG,
     StreamChunkType,
     TaggedMessageChunkTypeWithTokenUsage,
+    _classify_http_exception_for_retry,
     _classify_oci_service_error_for_retry,
     _compute_wait_before_next_attempt,
-    _get_retry_after_value_from_headers,
-    _is_retryable_http_error,
-    _is_tls_or_cert_error,
-    _stringify_response_error,
     execute_async_with_retry,
     execute_sync_with_retry,
 )
@@ -93,31 +89,6 @@ def _detect_serving_mode_from_model_id(model_id: str) -> ServingMode:
     if "generativeaimodel" in model_id:
         return ServingMode.DEDICATED
     return ServingMode.ON_DEMAND
-
-
-def _classify_openai_retry_exception(
-    exc: Exception, policy: RetryPolicy
-) -> Optional[Tuple[Optional[int], Optional[str]]]:
-    """Classify OpenAI-compatible client exceptions into retry metadata."""
-    if isinstance(exc, APIStatusError):
-        if exc.status_code is None:
-            return None
-        error_message = _stringify_response_error(exc.body)
-        if not _is_retryable_http_error(policy, exc.status_code, error_message):
-            return None
-        retry_after = (
-            _get_retry_after_value_from_headers(exc.response.headers)
-            if exc.response is not None
-            else None
-        )
-        return exc.status_code, retry_after
-
-    if isinstance(exc, (APITimeoutError, APIConnectionError)):
-        if _is_tls_or_cert_error(exc):
-            return None
-        return None, None
-
-    return None
 
 
 def _classify_oci_retry_exception(
@@ -411,7 +382,7 @@ class OCIGenAIModel(LlmModel):
         return await execute_async_with_retry(
             operation,
             retry_policy=self.retry_policy,
-            classify_exception=_classify_openai_retry_exception,
+            classify_exception=_classify_http_exception_for_retry,
             retry_budget_exhausted_message="OCI OpenAI-compatible request retry budget exhausted",
         )
 

--- a/wayflowcore/tests/a2a/conftest.py
+++ b/wayflowcore/tests/a2a/conftest.py
@@ -7,6 +7,7 @@
 import importlib
 import os
 import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -29,7 +30,7 @@ def _start_a2a_server(
         if not is_package_installed("google.adk") or not is_package_installed("a2a"):
             pytest.skip("Skipping because the google-adk[a2a] package is not installed.")
     process_args = [
-        "python",
+        sys.executable,
         "-u",  # unbuffered output
         _START_SERVER_FILE_PATH,
         "--host",

--- a/wayflowcore/tests/a2a/start_a2a_server.py
+++ b/wayflowcore/tests/a2a/start_a2a_server.py
@@ -253,9 +253,8 @@ def create_server(agent_type: AgentType, host: str, port: int):
 
 def main(host: str, port: int, agent_type: AgentType):
     if agent_type == AgentType.ADK_AGENT:
-        from google.adk.a2a.utils.agent_to_a2a import to_a2a
-
-        from a2a.types import AgentCard
+        from google.adk.a2a.utils.agent_to_a2a import to_a2a  # isort: skip
+        from a2a.types import AgentCard  # isort: skip
 
         my_agent_card = AgentCard(
             **{

--- a/wayflowcore/tests/a2a/start_a2a_server.py
+++ b/wayflowcore/tests/a2a/start_a2a_server.py
@@ -9,7 +9,6 @@ import os
 from enum import Enum
 from typing import Annotated, Callable
 
-import pytest
 import uvicorn
 
 from wayflowcore.agent import Agent, CallerInputMode
@@ -97,10 +96,6 @@ def get_agent_with_server_tool() -> Agent:
     )
 
 
-# google-adk warnings
-@pytest.mark.filterwarnings("ignore::UserWarning")
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 @register_agent(AgentType.ADK_AGENT)
 def get_adk_agent():
     from google.adk.agents import Agent as ADKAgent
@@ -256,14 +251,11 @@ def create_server(agent_type: AgentType, host: str, port: int):
     return server
 
 
-# google-adk warnings
-@pytest.mark.filterwarnings("ignore::UserWarning")
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 def main(host: str, port: int, agent_type: AgentType):
     if agent_type == AgentType.ADK_AGENT:
-        from a2a.types import AgentCard
         from google.adk.a2a.utils.agent_to_a2a import to_a2a
+
+        from a2a.types import AgentCard
 
         my_agent_card = AgentCard(
             **{

--- a/wayflowcore/tests/agentserver/conftest.py
+++ b/wayflowcore/tests/agentserver/conftest.py
@@ -5,6 +5,7 @@
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 import os
 import subprocess
+import sys
 import tempfile
 import time
 from dataclasses import asdict
@@ -271,7 +272,7 @@ wayflow_server_http_oracle = register_wayflow_server_fixture(
 def multi_agent_inmemory_server(session_tmp_path):
     available_port = get_available_port(session_tmp_path)
     print(f"Starting a multi-agent server on port {available_port}")
-    cmd = ["python", str(TEST_DIR / "multi_agent_server.py"), "--port", str(available_port)]
+    cmd = [sys.executable, str(TEST_DIR / "multi_agent_server.py"), "--port", str(available_port)]
     url = f"http://127.0.0.1:{available_port}"
 
     process, url, tee = _run_server(url, cmd, timeout=20)
@@ -299,7 +300,12 @@ def oracle_db_with_names():
 def datastore_agent_inmemory_server(oracle_db_with_names, session_tmp_path):
     available_port = get_available_port(session_tmp_path)
     print(f"Starting datastore agent server on port {available_port}")
-    cmd = ["python", str(TEST_DIR / "datastore_agent_server.py"), "--port", str(available_port)]
+    cmd = [
+        sys.executable,
+        str(TEST_DIR / "datastore_agent_server.py"),
+        "--port",
+        str(available_port),
+    ]
     url = f"http://127.0.0.1:{available_port}"
 
     process, url, tee = _run_server(url, cmd, timeout=20)

--- a/wayflowcore/tests/conftest.py
+++ b/wayflowcore/tests/conftest.py
@@ -148,11 +148,10 @@ DUMMY_OCI_USER_CONFIG_DICT = {
 }
 
 
-# Live model tests already use pytest-level retries where needed. Keep the HTTP
-# attempt bounded so a wedged model server does not stall CI for minutes. This is
-# a runtime object because these Python fixtures are used both with
-# LlmModelFactory.from_config and direct model constructors.
-LIVE_LLM_TEST_RETRY_POLICY = RetryPolicy(max_attempts=0, request_timeout=30.0)
+def _create_live_llm_test_retry_policy() -> RetryPolicy:
+    # Live model tests already use pytest-level retries where needed. Keep the
+    # HTTP attempt bounded so a wedged model server does not stall CI for minutes.
+    return RetryPolicy(max_attempts=0, request_timeout=30.0)
 
 
 @pytest.fixture
@@ -203,7 +202,7 @@ VLLM_MODEL_CONFIG = {
     "host_port": llama_api_url,
     "model_id": "meta-llama/Meta-Llama-3.1-8B-Instruct",
     "generation_config": {"max_tokens": 512},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
+    "retry_policy": _create_live_llm_test_retry_policy(),
 }
 
 VLLM_OSS_CONFIG = {
@@ -212,7 +211,7 @@ VLLM_OSS_CONFIG = {
     "model_id": "openai/gpt-oss-120b",
     "generation_config": {"max_tokens": 512},
     "api_type": OpenAIAPIType.RESPONSES,
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
+    "retry_policy": _create_live_llm_test_retry_policy(),
 }
 
 VLLM_OSS_REASONING_CONFIG = {
@@ -221,7 +220,7 @@ VLLM_OSS_REASONING_CONFIG = {
     "model_id": "openai/gpt-oss-120b",
     "generation_config": {"max_tokens": 4096, "reasoning": {"effort": "high"}},
     "api_type": OpenAIAPIType.RESPONSES,
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
+    "retry_policy": _create_live_llm_test_retry_policy(),
 }
 
 OPENAI_COMPATIBLE_MODEL_CONFIG = {
@@ -231,7 +230,7 @@ OPENAI_COMPATIBLE_MODEL_CONFIG = {
     "generation_config": {"max_tokens": 512},
     "supports_structured_generation": True,
     "supports_tool_calling": True,
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
+    "retry_policy": _create_live_llm_test_retry_policy(),
 }
 
 OPENAI_CONFIG = {
@@ -239,7 +238,7 @@ OPENAI_CONFIG = {
     "model_id": "gpt-4o-mini",
     "proxy": oracle_http_proxy,
     "generation_config": {"max_tokens": 512},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
+    "retry_policy": _create_live_llm_test_retry_policy(),
 }
 
 OPENAI_RESPONSES_CONFIG = {
@@ -248,7 +247,7 @@ OPENAI_RESPONSES_CONFIG = {
     "proxy": oracle_http_proxy,
     "generation_config": {"max_tokens": 512, "reasoning": {"effort": "minimal"}},
     "api_type": OpenAIAPIType.RESPONSES,
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
+    "retry_policy": _create_live_llm_test_retry_policy(),
 }
 
 OPENAI_REASONING_RESPONSES_CONFIG = {
@@ -257,7 +256,7 @@ OPENAI_REASONING_RESPONSES_CONFIG = {
     "proxy": oracle_http_proxy,
     "generation_config": {"max_tokens": 4096, "reasoning": {"effort": "high"}},
     "api_type": OpenAIAPIType.RESPONSES,
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
+    "retry_policy": _create_live_llm_test_retry_policy(),
 }
 
 GEMMA_CONFIG = {
@@ -265,7 +264,7 @@ GEMMA_CONFIG = {
     "host_port": gemma_api_url,
     "model_id": "google/gemma-3-27b-it",
     "generation_config": {"max_tokens": 512},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
+    "retry_policy": _create_live_llm_test_retry_policy(),
 }
 
 
@@ -274,7 +273,7 @@ OPENAI_REASONING_CONFIG = {
     "model_id": "o3-mini",
     "proxy": oracle_http_proxy,
     "generation_config": {"max_tokens": 512},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
+    "retry_policy": _create_live_llm_test_retry_policy(),
 }
 
 COHERE_OCI_INSTANCE_PRINCIPAL_CONFIG = {
@@ -286,7 +285,7 @@ COHERE_OCI_INSTANCE_PRINCIPAL_CONFIG = {
         "auth_type": "INSTANCE_PRINCIPAL",
     },
     "generation_config": {"max_tokens": 512},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
+    "retry_policy": _create_live_llm_test_retry_policy(),
 }
 
 COHERE_OCI_API_KEY_CONFIG = {
@@ -298,7 +297,7 @@ COHERE_OCI_API_KEY_CONFIG = {
         "auth_type": "API_KEY",
     },
     "generation_config": {"max_tokens": 512},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
+    "retry_policy": _create_live_llm_test_retry_policy(),
 }
 
 LLAMA_OCI_INSTANCE_PRINCIPAL_CONFIG = {
@@ -310,7 +309,7 @@ LLAMA_OCI_INSTANCE_PRINCIPAL_CONFIG = {
         "auth_type": "INSTANCE_PRINCIPAL",
     },
     "generation_config": {"max_tokens": 512},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
+    "retry_policy": _create_live_llm_test_retry_policy(),
 }
 
 LLAMA_OCI_API_KEY_CONFIG = {
@@ -322,7 +321,7 @@ LLAMA_OCI_API_KEY_CONFIG = {
         "auth_type": "API_KEY",
     },
     "generation_config": {"max_tokens": 512},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
+    "retry_policy": _create_live_llm_test_retry_policy(),
 }
 
 LLAMA_4_OCI_API_KEY_CONFIG = {
@@ -334,7 +333,7 @@ LLAMA_4_OCI_API_KEY_CONFIG = {
         "auth_type": "API_KEY",
     },
     "generation_config": {"max_tokens": 512},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
+    "retry_policy": _create_live_llm_test_retry_policy(),
 }
 
 
@@ -347,7 +346,7 @@ GROK_OCI_API_KEY_CONFIG = {
         "auth_type": "API_KEY",
     },
     "generation_config": {"max_tokens": 1024},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
+    "retry_policy": _create_live_llm_test_retry_policy(),
 }
 
 GROK_OCI_RESPONSE_API_KEY_CONFIG = {
@@ -360,7 +359,7 @@ GROK_OCI_RESPONSE_API_KEY_CONFIG = {
     },
     "generation_config": {"max_tokens": 1024},
     "api_type": "openai_responses",
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
+    "retry_policy": _create_live_llm_test_retry_policy(),
 }
 
 GROK_OCI_CHAT_COMPLETIONS_API_KEY_CONFIG = {
@@ -373,7 +372,7 @@ GROK_OCI_CHAT_COMPLETIONS_API_KEY_CONFIG = {
     },
     "generation_config": {"max_tokens": 1024},
     "api_type": "openai_chat_completions",
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
+    "retry_policy": _create_live_llm_test_retry_policy(),
 }
 
 
@@ -386,7 +385,7 @@ OCI_REASONING_MODEL_API_KEY_CONFIG = {
         "auth_type": "API_KEY",
     },
     "generation_config": {"max_tokens": 2000},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
+    "retry_policy": _create_live_llm_test_retry_policy(),
 }
 
 OLLAMA_MODEL_CONFIG = {
@@ -394,7 +393,7 @@ OLLAMA_MODEL_CONFIG = {
     "host_port": ollama8bv31_api_url,  # example: 8.8.8.8:8000
     "model_id": "meta-llama/Meta-Llama-3.1-8B-Instruct",
     "generation_config": {"max_tokens": 512},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
+    "retry_policy": _create_live_llm_test_retry_policy(),
 }
 
 BIG_VLLM_CONFIG = {
@@ -402,7 +401,7 @@ BIG_VLLM_CONFIG = {
     "host_port": LLAMA70BV33_API_URL,
     "model_id": "/storage/models/Llama-3.3-70B-Instruct",
     "generation_config": {"max_tokens": 512},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
+    "retry_policy": _create_live_llm_test_retry_policy(),
 }
 
 ALL_VLLM_CONFIGS = [VLLM_MODEL_CONFIG]

--- a/wayflowcore/tests/conftest.py
+++ b/wayflowcore/tests/conftest.py
@@ -35,6 +35,7 @@ from wayflowcore.models.ociclientconfig import (
     OCIUserAuthenticationConfig,
 )
 from wayflowcore.models.openaiapitype import OpenAIAPIType
+from wayflowcore.retrypolicy import RetryPolicy
 from wayflowcore.steps import OutputMessageStep
 from wayflowcore.tools import ToolRequest
 from wayflowcore.warnings import SecurityWarning
@@ -147,12 +148,11 @@ DUMMY_OCI_USER_CONFIG_DICT = {
 }
 
 
-LIVE_LLM_TEST_RETRY_POLICY_CONFIG = {
-    # Live model tests already use pytest-level retries where needed. Keep the
-    # HTTP attempt bounded so a wedged model server does not stall CI for minutes.
-    "max_attempts": 0,
-    "request_timeout": 30.0,
-}
+# Live model tests already use pytest-level retries where needed. Keep the HTTP
+# attempt bounded so a wedged model server does not stall CI for minutes. This is
+# a runtime object because these Python fixtures are used both with
+# LlmModelFactory.from_config and direct model constructors.
+LIVE_LLM_TEST_RETRY_POLICY = RetryPolicy(max_attempts=0, request_timeout=30.0)
 
 
 @pytest.fixture
@@ -203,7 +203,7 @@ VLLM_MODEL_CONFIG = {
     "host_port": llama_api_url,
     "model_id": "meta-llama/Meta-Llama-3.1-8B-Instruct",
     "generation_config": {"max_tokens": 512},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
 }
 
 VLLM_OSS_CONFIG = {
@@ -212,7 +212,7 @@ VLLM_OSS_CONFIG = {
     "model_id": "openai/gpt-oss-120b",
     "generation_config": {"max_tokens": 512},
     "api_type": OpenAIAPIType.RESPONSES,
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
 }
 
 VLLM_OSS_REASONING_CONFIG = {
@@ -221,7 +221,7 @@ VLLM_OSS_REASONING_CONFIG = {
     "model_id": "openai/gpt-oss-120b",
     "generation_config": {"max_tokens": 4096, "reasoning": {"effort": "high"}},
     "api_type": OpenAIAPIType.RESPONSES,
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
 }
 
 OPENAI_COMPATIBLE_MODEL_CONFIG = {
@@ -231,7 +231,7 @@ OPENAI_COMPATIBLE_MODEL_CONFIG = {
     "generation_config": {"max_tokens": 512},
     "supports_structured_generation": True,
     "supports_tool_calling": True,
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
 }
 
 OPENAI_CONFIG = {
@@ -239,7 +239,7 @@ OPENAI_CONFIG = {
     "model_id": "gpt-4o-mini",
     "proxy": oracle_http_proxy,
     "generation_config": {"max_tokens": 512},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
 }
 
 OPENAI_RESPONSES_CONFIG = {
@@ -248,7 +248,7 @@ OPENAI_RESPONSES_CONFIG = {
     "proxy": oracle_http_proxy,
     "generation_config": {"max_tokens": 512, "reasoning": {"effort": "minimal"}},
     "api_type": OpenAIAPIType.RESPONSES,
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
 }
 
 OPENAI_REASONING_RESPONSES_CONFIG = {
@@ -257,7 +257,7 @@ OPENAI_REASONING_RESPONSES_CONFIG = {
     "proxy": oracle_http_proxy,
     "generation_config": {"max_tokens": 4096, "reasoning": {"effort": "high"}},
     "api_type": OpenAIAPIType.RESPONSES,
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
 }
 
 GEMMA_CONFIG = {
@@ -265,7 +265,7 @@ GEMMA_CONFIG = {
     "host_port": gemma_api_url,
     "model_id": "google/gemma-3-27b-it",
     "generation_config": {"max_tokens": 512},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
 }
 
 
@@ -274,7 +274,7 @@ OPENAI_REASONING_CONFIG = {
     "model_id": "o3-mini",
     "proxy": oracle_http_proxy,
     "generation_config": {"max_tokens": 512},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
 }
 
 COHERE_OCI_INSTANCE_PRINCIPAL_CONFIG = {
@@ -286,7 +286,7 @@ COHERE_OCI_INSTANCE_PRINCIPAL_CONFIG = {
         "auth_type": "INSTANCE_PRINCIPAL",
     },
     "generation_config": {"max_tokens": 512},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
 }
 
 COHERE_OCI_API_KEY_CONFIG = {
@@ -298,7 +298,7 @@ COHERE_OCI_API_KEY_CONFIG = {
         "auth_type": "API_KEY",
     },
     "generation_config": {"max_tokens": 512},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
 }
 
 LLAMA_OCI_INSTANCE_PRINCIPAL_CONFIG = {
@@ -310,7 +310,7 @@ LLAMA_OCI_INSTANCE_PRINCIPAL_CONFIG = {
         "auth_type": "INSTANCE_PRINCIPAL",
     },
     "generation_config": {"max_tokens": 512},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
 }
 
 LLAMA_OCI_API_KEY_CONFIG = {
@@ -322,7 +322,7 @@ LLAMA_OCI_API_KEY_CONFIG = {
         "auth_type": "API_KEY",
     },
     "generation_config": {"max_tokens": 512},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
 }
 
 LLAMA_4_OCI_API_KEY_CONFIG = {
@@ -334,25 +334,25 @@ LLAMA_4_OCI_API_KEY_CONFIG = {
         "auth_type": "API_KEY",
     },
     "generation_config": {"max_tokens": 512},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
 }
 
 
 GROK_OCI_API_KEY_CONFIG = {
     "model_type": "ocigenai",
-    "model_id": "xai.grok-3-mini",
+    "model_id": "xai.grok-4.3",
     "client_config": {
         "service_endpoint": "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
         "compartment_id": compartment_id,
         "auth_type": "API_KEY",
     },
     "generation_config": {"max_tokens": 1024},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
 }
 
 GROK_OCI_RESPONSE_API_KEY_CONFIG = {
     "model_type": "ocigenai",
-    "model_id": "xai.grok-3-fast",
+    "model_id": "xai.grok-4.3",
     "client_config": {
         "service_endpoint": "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
         "compartment_id": compartment_id,
@@ -360,12 +360,12 @@ GROK_OCI_RESPONSE_API_KEY_CONFIG = {
     },
     "generation_config": {"max_tokens": 1024},
     "api_type": "openai_responses",
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
 }
 
 GROK_OCI_CHAT_COMPLETIONS_API_KEY_CONFIG = {
     "model_type": "ocigenai",
-    "model_id": "xai.grok-3-fast",
+    "model_id": "xai.grok-4.3",
     "client_config": {
         "service_endpoint": "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
         "compartment_id": compartment_id,
@@ -373,7 +373,7 @@ GROK_OCI_CHAT_COMPLETIONS_API_KEY_CONFIG = {
     },
     "generation_config": {"max_tokens": 1024},
     "api_type": "openai_chat_completions",
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
 }
 
 
@@ -386,7 +386,7 @@ OCI_REASONING_MODEL_API_KEY_CONFIG = {
         "auth_type": "API_KEY",
     },
     "generation_config": {"max_tokens": 2000},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
 }
 
 OLLAMA_MODEL_CONFIG = {
@@ -394,7 +394,7 @@ OLLAMA_MODEL_CONFIG = {
     "host_port": ollama8bv31_api_url,  # example: 8.8.8.8:8000
     "model_id": "meta-llama/Meta-Llama-3.1-8B-Instruct",
     "generation_config": {"max_tokens": 512},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
 }
 
 BIG_VLLM_CONFIG = {
@@ -402,7 +402,7 @@ BIG_VLLM_CONFIG = {
     "host_port": LLAMA70BV33_API_URL,
     "model_id": "/storage/models/Llama-3.3-70B-Instruct",
     "generation_config": {"max_tokens": 512},
-    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY,
 }
 
 ALL_VLLM_CONFIGS = [VLLM_MODEL_CONFIG]

--- a/wayflowcore/tests/conftest.py
+++ b/wayflowcore/tests/conftest.py
@@ -147,6 +147,14 @@ DUMMY_OCI_USER_CONFIG_DICT = {
 }
 
 
+LIVE_LLM_TEST_RETRY_POLICY_CONFIG = {
+    # Live model tests already use pytest-level retries where needed. Keep the
+    # HTTP attempt bounded so a wedged model server does not stall CI for minutes.
+    "max_attempts": 0,
+    "request_timeout": 30.0,
+}
+
+
 @pytest.fixture
 def dummy_oci_client_config_with_user_authentication():
     user_config = OCIUserAuthenticationConfig(
@@ -195,6 +203,7 @@ VLLM_MODEL_CONFIG = {
     "host_port": llama_api_url,
     "model_id": "meta-llama/Meta-Llama-3.1-8B-Instruct",
     "generation_config": {"max_tokens": 512},
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
 }
 
 VLLM_OSS_CONFIG = {
@@ -203,6 +212,7 @@ VLLM_OSS_CONFIG = {
     "model_id": "openai/gpt-oss-120b",
     "generation_config": {"max_tokens": 512},
     "api_type": OpenAIAPIType.RESPONSES,
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
 }
 
 VLLM_OSS_REASONING_CONFIG = {
@@ -211,6 +221,7 @@ VLLM_OSS_REASONING_CONFIG = {
     "model_id": "openai/gpt-oss-120b",
     "generation_config": {"max_tokens": 4096, "reasoning": {"effort": "high"}},
     "api_type": OpenAIAPIType.RESPONSES,
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
 }
 
 OPENAI_COMPATIBLE_MODEL_CONFIG = {
@@ -220,6 +231,7 @@ OPENAI_COMPATIBLE_MODEL_CONFIG = {
     "generation_config": {"max_tokens": 512},
     "supports_structured_generation": True,
     "supports_tool_calling": True,
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
 }
 
 OPENAI_CONFIG = {
@@ -227,6 +239,7 @@ OPENAI_CONFIG = {
     "model_id": "gpt-4o-mini",
     "proxy": oracle_http_proxy,
     "generation_config": {"max_tokens": 512},
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
 }
 
 OPENAI_RESPONSES_CONFIG = {
@@ -235,6 +248,7 @@ OPENAI_RESPONSES_CONFIG = {
     "proxy": oracle_http_proxy,
     "generation_config": {"max_tokens": 512, "reasoning": {"effort": "minimal"}},
     "api_type": OpenAIAPIType.RESPONSES,
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
 }
 
 OPENAI_REASONING_RESPONSES_CONFIG = {
@@ -243,12 +257,15 @@ OPENAI_REASONING_RESPONSES_CONFIG = {
     "proxy": oracle_http_proxy,
     "generation_config": {"max_tokens": 4096, "reasoning": {"effort": "high"}},
     "api_type": OpenAIAPIType.RESPONSES,
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
 }
 
 GEMMA_CONFIG = {
     "model_type": "vllm",
     "host_port": gemma_api_url,
     "model_id": "google/gemma-3-27b-it",
+    "generation_config": {"max_tokens": 512},
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
 }
 
 
@@ -257,6 +274,7 @@ OPENAI_REASONING_CONFIG = {
     "model_id": "o3-mini",
     "proxy": oracle_http_proxy,
     "generation_config": {"max_tokens": 512},
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
 }
 
 COHERE_OCI_INSTANCE_PRINCIPAL_CONFIG = {
@@ -268,6 +286,7 @@ COHERE_OCI_INSTANCE_PRINCIPAL_CONFIG = {
         "auth_type": "INSTANCE_PRINCIPAL",
     },
     "generation_config": {"max_tokens": 512},
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
 }
 
 COHERE_OCI_API_KEY_CONFIG = {
@@ -279,6 +298,7 @@ COHERE_OCI_API_KEY_CONFIG = {
         "auth_type": "API_KEY",
     },
     "generation_config": {"max_tokens": 512},
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
 }
 
 LLAMA_OCI_INSTANCE_PRINCIPAL_CONFIG = {
@@ -290,6 +310,7 @@ LLAMA_OCI_INSTANCE_PRINCIPAL_CONFIG = {
         "auth_type": "INSTANCE_PRINCIPAL",
     },
     "generation_config": {"max_tokens": 512},
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
 }
 
 LLAMA_OCI_API_KEY_CONFIG = {
@@ -301,6 +322,7 @@ LLAMA_OCI_API_KEY_CONFIG = {
         "auth_type": "API_KEY",
     },
     "generation_config": {"max_tokens": 512},
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
 }
 
 LLAMA_4_OCI_API_KEY_CONFIG = {
@@ -312,6 +334,7 @@ LLAMA_4_OCI_API_KEY_CONFIG = {
         "auth_type": "API_KEY",
     },
     "generation_config": {"max_tokens": 512},
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
 }
 
 
@@ -324,6 +347,7 @@ GROK_OCI_API_KEY_CONFIG = {
         "auth_type": "API_KEY",
     },
     "generation_config": {"max_tokens": 1024},
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
 }
 
 GROK_OCI_RESPONSE_API_KEY_CONFIG = {
@@ -336,6 +360,7 @@ GROK_OCI_RESPONSE_API_KEY_CONFIG = {
     },
     "generation_config": {"max_tokens": 1024},
     "api_type": "openai_responses",
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
 }
 
 GROK_OCI_CHAT_COMPLETIONS_API_KEY_CONFIG = {
@@ -348,6 +373,7 @@ GROK_OCI_CHAT_COMPLETIONS_API_KEY_CONFIG = {
     },
     "generation_config": {"max_tokens": 1024},
     "api_type": "openai_chat_completions",
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
 }
 
 
@@ -360,6 +386,7 @@ OCI_REASONING_MODEL_API_KEY_CONFIG = {
         "auth_type": "API_KEY",
     },
     "generation_config": {"max_tokens": 2000},
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
 }
 
 OLLAMA_MODEL_CONFIG = {
@@ -367,6 +394,7 @@ OLLAMA_MODEL_CONFIG = {
     "host_port": ollama8bv31_api_url,  # example: 8.8.8.8:8000
     "model_id": "meta-llama/Meta-Llama-3.1-8B-Instruct",
     "generation_config": {"max_tokens": 512},
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
 }
 
 BIG_VLLM_CONFIG = {
@@ -374,6 +402,7 @@ BIG_VLLM_CONFIG = {
     "host_port": LLAMA70BV33_API_URL,
     "model_id": "/storage/models/Llama-3.3-70B-Instruct",
     "generation_config": {"max_tokens": 512},
+    "retry_policy": LIVE_LLM_TEST_RETRY_POLICY_CONFIG,
 }
 
 ALL_VLLM_CONFIGS = [VLLM_MODEL_CONFIG]

--- a/wayflowcore/tests/mcptools/conftest.py
+++ b/wayflowcore/tests/mcptools/conftest.py
@@ -7,6 +7,7 @@
 import os
 import ssl
 import subprocess
+import sys
 import time
 from typing import Optional, Tuple
 
@@ -173,7 +174,7 @@ def _start_mcp_server(
     ready_timeout_s: float = 10.0,
 ) -> Tuple[subprocess.Popen, str, LogTee]:
     process_args = [
-        "python",
+        sys.executable,
         "-u",  # unbuffered output
         start_server_file_path,
         "--host",

--- a/wayflowcore/tests/models/test_geminimodel.py
+++ b/wayflowcore/tests/models/test_geminimodel.py
@@ -413,40 +413,93 @@ def test_geminimodel_sync_generate_retries_connection_errors(monkeypatch) -> Non
     assert timeouts == [retry_policy.request_timeout] * 3
 
 
-def test_geminimodel_sync_generate_retries_litellm_timeout_errors(monkeypatch) -> None:
+def test_geminimodel_sync_generate_handles_litellm_no_response_transport_wrappers(
+    monkeypatch,
+) -> None:
+    from litellm.exceptions import APIConnectionError as LiteLLMAPIConnectionError
     from litellm.exceptions import Timeout
 
+    prompt = Prompt(messages=[Message(role="user", content="Hello")])
+
+    def successful_response() -> dict[str, Any]:
+        return {
+            "choices": [{"message": {"role": "assistant", "content": "hello"}}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+
+    for make_error in (
+        lambda llm: LiteLLMAPIConnectionError(
+            "connection lost", model=llm.model_id, llm_provider="gemini"
+        ),
+        lambda llm: Timeout(
+            "timed out",
+            model=llm.model_id,
+            llm_provider="gemini",
+            exception_status_code=504,
+        ),
+    ):
+        # LiteLLM connection/timeout wrappers carry a request and no response,
+        # but they also set synthetic 5xx status codes. They should retry as
+        # pre-response transport failures even when broad 5xx retries are off.
+        retry_policy = RetryPolicy(
+            max_attempts=1,
+            request_timeout=12.5,
+            initial_retry_delay=0.001,
+            max_retry_delay=0.001,
+            service_error_retry_on_any_5xx=False,
+        )
+        llm = GeminiModel(
+            model_id="gemini-2.5-flash",
+            auth=GeminiApiKeyAuth(api_key="test-key"),
+            retry_policy=retry_policy,
+        )
+        call_count = 0
+
+        def fake_completion(**_kwargs: Any) -> Any:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise make_error(llm)
+            return successful_response()
+
+        monkeypatch.setattr("wayflowcore.models.geminimodel.litellm.completion", fake_completion)
+
+        completion = llm.generate(prompt)
+
+        assert completion.message.content == "hello"
+        assert call_count == 2
+
+    # A certificate failure wrapped by LiteLLM's synthetic-500 connection error
+    # must still be detected as TLS and should not be retried.
     retry_policy = RetryPolicy(
-        max_attempts=1,
+        max_attempts=2,
         request_timeout=12.5,
         initial_retry_delay=0.001,
         max_retry_delay=0.001,
-        service_error_retry_on_any_5xx=False,
     )
     llm = GeminiModel(
         model_id="gemini-2.5-flash",
         auth=GeminiApiKeyAuth(api_key="test-key"),
         retry_policy=retry_policy,
     )
-    prompt = Prompt(messages=[Message(role="user", content="Hello")])
     call_count = 0
 
-    def fake_completion(**_kwargs: Any) -> Any:
+    def fake_tls_completion(**_kwargs: Any) -> Any:
         nonlocal call_count
         call_count += 1
-        if call_count == 1:
-            raise Timeout("timed out", model=llm.model_id, llm_provider="gemini")
-        return {
-            "choices": [{"message": {"role": "assistant", "content": "hello"}}],
-            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
-        }
+        try:
+            raise ssl.SSLCertVerificationError("certificate verify failed")
+        except ssl.SSLCertVerificationError as tls_error:
+            raise LiteLLMAPIConnectionError(
+                "connection lost", model=llm.model_id, llm_provider="gemini"
+            ) from tls_error
 
-    monkeypatch.setattr("wayflowcore.models.geminimodel.litellm.completion", fake_completion)
+    monkeypatch.setattr("wayflowcore.models.geminimodel.litellm.completion", fake_tls_completion)
 
-    completion = llm.generate(prompt)
+    with pytest.raises(LiteLLMAPIConnectionError, match="connection lost"):
+        llm.generate(prompt)
 
-    assert completion.message.content == "hello"
-    assert call_count == 2
+    assert call_count == 1
 
 
 @pytest.mark.parametrize(

--- a/wayflowcore/tests/models/test_geminimodel.py
+++ b/wayflowcore/tests/models/test_geminimodel.py
@@ -6,6 +6,7 @@
 
 import json
 import os
+import ssl
 from typing import Annotated, Any
 from unittest.mock import patch
 
@@ -392,7 +393,12 @@ def test_geminimodel_sync_generate_retries_connection_errors(monkeypatch) -> Non
         call_count += 1
         timeouts.append(kwargs["timeout"])
         if call_count < 3:
-            raise APIConnectionError(message="Connection error.", request=request)
+            # The OpenAI SDK wraps transport failures this way, so exercise the
+            # retry classifier through the realistic __cause__ chain.
+            transport_error = httpx.ConnectError("Connection error.", request=request)
+            raise APIConnectionError(
+                message="Connection error.", request=request
+            ) from transport_error
         return {
             "choices": [{"message": {"role": "assistant", "content": "hello"}}],
             "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
@@ -405,6 +411,110 @@ def test_geminimodel_sync_generate_retries_connection_errors(monkeypatch) -> Non
     assert completion.message.content == "hello"
     assert call_count == 3
     assert timeouts == [retry_policy.request_timeout] * 3
+
+
+def test_geminimodel_sync_generate_retries_litellm_timeout_errors(monkeypatch) -> None:
+    from litellm.exceptions import Timeout
+
+    retry_policy = RetryPolicy(
+        max_attempts=1,
+        request_timeout=12.5,
+        initial_retry_delay=0.001,
+        max_retry_delay=0.001,
+        service_error_retry_on_any_5xx=False,
+    )
+    llm = GeminiModel(
+        model_id="gemini-2.5-flash",
+        auth=GeminiApiKeyAuth(api_key="test-key"),
+        retry_policy=retry_policy,
+    )
+    prompt = Prompt(messages=[Message(role="user", content="Hello")])
+    call_count = 0
+
+    def fake_completion(**_kwargs: Any) -> Any:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise Timeout("timed out", model=llm.model_id, llm_provider="gemini")
+        return {
+            "choices": [{"message": {"role": "assistant", "content": "hello"}}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+
+    monkeypatch.setattr("wayflowcore.models.geminimodel.litellm.completion", fake_completion)
+
+    completion = llm.generate(prompt)
+
+    assert completion.message.content == "hello"
+    assert call_count == 2
+
+
+def test_geminimodel_sync_generate_does_not_retry_openai_tls_errors_in_context(
+    monkeypatch,
+) -> None:
+    retry_policy = RetryPolicy(
+        max_attempts=2,
+        request_timeout=12.5,
+        initial_retry_delay=0.001,
+        max_retry_delay=0.001,
+    )
+    llm = GeminiModel(
+        model_id="gemini-2.5-flash",
+        auth=GeminiApiKeyAuth(api_key="test-key"),
+        retry_policy=retry_policy,
+    )
+    prompt = Prompt(messages=[Message(role="user", content="Hello")])
+    request = httpx.Request("POST", "https://example.test")
+    call_count = 0
+
+    def fake_completion(**_kwargs: Any) -> Any:
+        nonlocal call_count
+        call_count += 1
+        try:
+            raise ssl.SSLCertVerificationError("certificate verify failed")
+        except ssl.SSLCertVerificationError:
+            # Raising without "from" mirrors wrapper code that preserves the
+            # TLS failure in __context__ instead of __cause__.
+            raise APIConnectionError(message="Connection error.", request=request)
+
+    monkeypatch.setattr("wayflowcore.models.geminimodel.litellm.completion", fake_completion)
+
+    with pytest.raises(APIConnectionError, match="Connection error"):
+        llm.generate(prompt)
+
+    assert call_count == 1
+
+
+def test_geminimodel_sync_generate_does_not_retry_litellm_bad_request_errors(
+    monkeypatch,
+) -> None:
+    from litellm.exceptions import BadRequestError
+
+    retry_policy = RetryPolicy(
+        max_attempts=2,
+        request_timeout=12.5,
+        initial_retry_delay=0.001,
+        max_retry_delay=0.001,
+    )
+    llm = GeminiModel(
+        model_id="gemini-2.5-flash",
+        auth=GeminiApiKeyAuth(api_key="test-key"),
+        retry_policy=retry_policy,
+    )
+    prompt = Prompt(messages=[Message(role="user", content="Hello")])
+    call_count = 0
+
+    def fake_completion(**_kwargs: Any) -> Any:
+        nonlocal call_count
+        call_count += 1
+        raise BadRequestError("bad request", model=llm.model_id, llm_provider="gemini")
+
+    monkeypatch.setattr("wayflowcore.models.geminimodel.litellm.completion", fake_completion)
+
+    with pytest.raises(BadRequestError, match="bad request"):
+        llm.generate(prompt)
+
+    assert call_count == 1
 
 
 @pytest.mark.anyio
@@ -649,6 +759,12 @@ def test_geminimodel_aistudio_gemini3_pro_preview_roundtrips_real_provider_field
     llm = GeminiModel(
         model_id="gemini-3.1-pro-preview",
         auth=GeminiApiKeyAuth(api_key=os.environ["GEMINI_API_KEY"]),
+        retry_policy=RetryPolicy(
+            max_attempts=1,
+            request_timeout=60.0,
+            initial_retry_delay=1.0,
+            max_retry_delay=1.0,
+        ),
     )
     prompt = prompt_with_tool_replay.copy()
     completion, _request, response_message, tool_call = (

--- a/wayflowcore/tests/models/test_geminimodel.py
+++ b/wayflowcore/tests/models/test_geminimodel.py
@@ -449,6 +449,59 @@ def test_geminimodel_sync_generate_retries_litellm_timeout_errors(monkeypatch) -
     assert call_count == 2
 
 
+@pytest.mark.parametrize(
+    "retry_policy",
+    [
+        RetryPolicy(
+            max_attempts=2,
+            request_timeout=12.5,
+            initial_retry_delay=0.001,
+            max_retry_delay=0.001,
+            service_error_retry_on_any_5xx=False,
+        ),
+        RetryPolicy(
+            max_attempts=2,
+            request_timeout=12.5,
+            initial_retry_delay=0.001,
+            max_retry_delay=0.001,
+            recoverable_statuses={"500": ["quotaExceeded"]},
+        ),
+    ],
+    ids=["no-broad-5xx", "textual-status-mismatch"],
+)
+def test_geminimodel_sync_generate_respects_retry_policy_for_litellm_api_errors_without_response(
+    monkeypatch, retry_policy: RetryPolicy
+) -> None:
+    from litellm.exceptions import APIError
+
+    llm = GeminiModel(
+        model_id="gemini-2.5-flash",
+        auth=GeminiApiKeyAuth(api_key="test-key"),
+        retry_policy=retry_policy,
+    )
+    prompt = Prompt(messages=[Message(role="user", content="Hello")])
+    request = httpx.Request("POST", "https://example.test")
+    call_count = 0
+
+    def fake_completion(**_kwargs: Any) -> Any:
+        nonlocal call_count
+        call_count += 1
+        raise APIError(
+            status_code=500,
+            message="backend unavailable",
+            llm_provider="gemini",
+            model=llm.model_id,
+            request=request,
+        )
+
+    monkeypatch.setattr("wayflowcore.models.geminimodel.litellm.completion", fake_completion)
+
+    with pytest.raises(APIError, match="backend unavailable"):
+        llm.generate(prompt)
+
+    assert call_count == 1
+
+
 def test_geminimodel_sync_generate_does_not_retry_openai_tls_errors_in_context(
     monkeypatch,
 ) -> None:

--- a/wayflowcore/tests/models/test_ocigenaimodel.py
+++ b/wayflowcore/tests/models/test_ocigenaimodel.py
@@ -19,6 +19,7 @@ from wayflowcore.messagelist import ImageContent, Message, MessageContent, TextC
 from wayflowcore.models import LlmGenerationConfig, LlmModelFactory, OCIGenAIModel, Prompt
 from wayflowcore.models.ociclientconfig import OCIClientConfig, _OCIAuthType
 from wayflowcore.models.ocigenaimodel import ModelProvider, OciAPIType, ServingMode
+from wayflowcore.retrypolicy import RetryPolicy
 from wayflowcore.templates import PromptTemplate
 from wayflowcore.tools.tools import ToolRequest
 
@@ -413,15 +414,22 @@ def test_oci_cohere_invalid_content_and_unsupported_types(messages, match):
 
 
 def test_oci_model_raises_warning_when_parameters_are_not_supported(grok_oci_llm, caplog):
+    # The shared live-model retry policy disables HTTP retries. This test needs one
+    # retry so Wayflow can handle OCI's unsupported-parameter error by removing
+    # `stop` from the generation config and resubmitting the request.
+    grok_oci_llm.retry_policy = RetryPolicy(max_attempts=1, request_timeout=30.0)
+
     with caplog.at_level(logging.WARNING):
-        grok_oci_llm.generate(
+        completion = grok_oci_llm.generate(
             prompt=Prompt(
-                messages=[Message(content="2+2=", role="user")],
-                generation_config=LlmGenerationConfig(
-                    stop=["4"],
-                ),
+                messages=[Message(content="Reply with a short greeting.", role="user")],
+                generation_config=LlmGenerationConfig(max_tokens=32, stop=["unused_stop"]),
             )
         )
+
+    assert len(completion.message.contents) > 0
+    assert isinstance(completion.message.contents[0], TextContent)
+    assert len(completion.message.contents[0].content) > 0
     assert "Parameter `stop` is not supported by the OCI GenAI endpoint" in caplog.text
 
 

--- a/wayflowcore/tests/serialization/conftest.py
+++ b/wayflowcore/tests/serialization/conftest.py
@@ -6,6 +6,7 @@
 
 import os
 import subprocess
+import sys
 import time
 
 import pytest
@@ -21,7 +22,7 @@ def _start_a2a_server(
     host: str, port: int, ready_timeout_s: float = 20.0
 ) -> tuple[subprocess.Popen, str]:
     process_args = [
-        "python",
+        sys.executable,
         "-u",  # unbuffered output
         _START_SERVER_FILE_PATH,
         "--host",

--- a/wayflowcore/tests/serialization/test_serializableobject.py
+++ b/wayflowcore/tests/serialization/test_serializableobject.py
@@ -5,6 +5,7 @@
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
 import subprocess
+import sys
 from textwrap import dedent
 
 from wayflowcore.serialization.serializer import _import_all_submodules
@@ -246,7 +247,7 @@ def test_componentregistry_is_complete(tmp_path):
     testfile = tmp_path / "_temp_test_componentregistry_is_complete.py"
     with open(testfile, "w") as f:
         f.write(script)
-    result = subprocess.run(["python", testfile], capture_output=True, text=True)
+    result = subprocess.run([sys.executable, testfile], capture_output=True, text=True)
     assert (
         result.returncode == 0
     ), f"Component registry does not match the components registry. Did you forget to add a new component to the test list?\n{result.stderr}"
@@ -268,7 +269,7 @@ def test_all_components_are_builtin_components(tmp_path):
     testfile = tmp_path / "_temp_test_all_components_are_builtin_components.py"
     with open(testfile, "w") as f:
         f.write(script)
-    result = subprocess.run(["python", testfile])
+    result = subprocess.run([sys.executable, testfile])
     assert (
         result.returncode == 0
     ), f"Builtins component registry does not match the components registry. Did you forget to add a new component to the _BUILTIN_COMPONENTS?\n{result}"

--- a/wayflowcore/tests/test_swarm.py
+++ b/wayflowcore/tests/test_swarm.py
@@ -1355,17 +1355,17 @@ def _setup_swarm_for_multiple_tool_calling(vllm_responses_llm, raise_exceptions)
     return conv
 
 
-@retry_test(max_attempts=3)
+@retry_test(max_attempts=7)
 def test_swarm_can_do_multiple_tool_calling_with_tool_raising_exception_raises_error(
     vllm_responses_llm,
 ):
     """
-    Failure rate:          0 out of 20
-    Observed on:           2026-01-28
-    Average success time:  5.19 seconds per successful attempt
-    Average failure time:  No time measurement
-    Max attempt:           3
-    Justification:         (0.05 ** 3) ~= 9.4 / 100'000
+    Failure rate:          4 out of 20
+    Observed on:           2026-05-12
+    Average success time:  5.68 seconds per successful attempt
+    Average failure time:  3.38 seconds per failed attempt
+    Max attempt:           7
+    Justification:         (0.23 ** 7) ~= 3.1 / 100'000
     """
     conv = _setup_swarm_for_multiple_tool_calling(vllm_responses_llm, raise_exceptions=True)
     with pytest.raises(ValueError, match="Cannot compute result using fooza tool."):

--- a/wayflowcore/tests/testhelpers/test_server_port_retrieval.py
+++ b/wayflowcore/tests/testhelpers/test_server_port_retrieval.py
@@ -4,8 +4,10 @@
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
+import socket
 import uuid
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import closing
 
 import pytest
 
@@ -24,3 +26,38 @@ def test_get_available_port_returns_unique_ports_in_parallel(
         futures = [executor.submit(get_available_port, str(temp_dir)) for _ in range(request_count)]
     ports = {future.result() for future in futures}
     assert len(ports) == request_count
+
+
+def test_get_available_port_skips_ports_occupied_on_ipv6(
+    monkeypatch, tmp_path_factory: pytest.TempPathFactory
+):
+    if not socket.has_ipv6:
+        pytest.skip("IPv6 is not available on this host")
+
+    # Simulate a host where ``localhost`` binds through ::1 while the allocator
+    # would otherwise only see 127.0.0.1 as free.
+    occupied_socket = None
+    occupied_port = None
+    for port in range(21000, 21100):
+        try:
+            occupied_socket = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+            occupied_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            occupied_socket.bind(("::1", port))
+            occupied_socket.listen(1)
+            occupied_port = port
+            break
+        except OSError:
+            if occupied_socket is not None:
+                occupied_socket.close()
+
+    if occupied_socket is None or occupied_port is None:
+        pytest.skip("No free IPv6 loopback port available for test setup")
+
+    with closing(occupied_socket):
+        monkeypatch.setenv("WAYFLOW_TEST_PORT_BASE", str(occupied_port))
+        monkeypatch.setenv("WAYFLOW_TEST_PORT_SPAN", "20")
+
+        temp_dir = tmp_path_factory.mktemp(f"port-retrieval-ipv6-{uuid.uuid4().hex}")
+        port = get_available_port(str(temp_dir))
+
+    assert port != occupied_port

--- a/wayflowcore/tests/testhelpers/testhelpers.py
+++ b/wayflowcore/tests/testhelpers/testhelpers.py
@@ -15,6 +15,8 @@ from datetime import date, datetime
 from functools import wraps
 from typing import Any, Callable, Dict, List, Mapping, Optional
 
+from _pytest.outcomes import Failed as PytestFailed
+
 from wayflowcore._utils._templating_helpers import render_template
 from wayflowcore.agent import Agent
 from wayflowcore.controlconnection import ControlFlowEdge
@@ -69,6 +71,7 @@ these logs using the option `--show-capture=log --disable-warnings`.
 """
 
 FLAKY_TEST_DOCSTRING_REGEX_PATTERN = r"[\s\S]*Failure rate:.*\n\s*Observed on:.*\n\s*Average success time:.*\n\s*Average failure time:.*\n\s*Max attempt:.*\n\s*Justification:.*"
+RETRYABLE_TEST_FAILURES = (Exception, PytestFailed)
 
 
 def _validate_retry_decorator_docstring_format(test_func: Callable[..., Any]) -> None:
@@ -276,7 +279,7 @@ def retry_test(
                         )
                         signal.alarm(0)
                         break
-                    except Exception as exception_error:
+                    except RETRYABLE_TEST_FAILURES as exception_error:
                         failed_count += 1
                         total_time_of_failed_runs += time.perf_counter() - start_time
                         signal.alarm(0)
@@ -320,7 +323,7 @@ def retry_test(
             while attempt_count < max_attempts:
                 try:
                     return test_func(*args, **kwargs)
-                except Exception as exception_error:
+                except RETRYABLE_TEST_FAILURES as exception_error:
                     exception_message = exception_error.__str__().split("\n", maxsplit=1)[0]
                     attempt_count += 1
                     logger.warning(

--- a/wayflowcore/tests/transforms/conftest.py
+++ b/wayflowcore/tests/transforms/conftest.py
@@ -72,8 +72,26 @@ def find_datastore_by_schema(pool, schema):
 
 MESSAGE_SUMMARIZATION_CACHE_COLLECTION_NAME = "messages_cache"
 CONVERSATION_SUMMARIZATION_CACHE_COLLECTION_NAME = "conversations_cache"
-AGENTSPEC_LIVE_LLM_GENERATION_CONFIG = AgentSpecLlmGenerationConfig(max_tokens=512)
-AGENTSPEC_LIVE_LLM_RETRY_POLICY = AgentSpecRetryPolicy(max_attempts=0, request_timeout=30.0)
+
+
+@pytest.fixture
+def agentspec_live_summarization_llm_config() -> AgentSpecVllmConfig:
+    return AgentSpecVllmConfig(
+        name="vllm",
+        model_id=GEMMA_CONFIG["model_id"],
+        url=GEMMA_CONFIG["host_port"],
+        default_generation_parameters=AgentSpecLlmGenerationConfig(max_tokens=512),
+        retry_policy=AgentSpecRetryPolicy(max_attempts=0, request_timeout=30.0),
+    )
+
+
+@pytest.fixture
+def agentspec_mock_llm_config() -> AgentSpecVllmConfig:
+    return AgentSpecVllmConfig(
+        name="vllm",
+        model_id=MOCK_LLM_CONFIG["model_id"],
+        url=MOCK_LLM_CONFIG["host_port"],
+    )
 
 
 @pytest.fixture(scope="session")
@@ -243,7 +261,10 @@ def _get_dll_for_deletion_of_one_entity_schema(schema: dict[str, "Entity"]) -> l
 
 
 @pytest.fixture
-def converted_wayflow_agent_with_message_summarization_transform_from_agentspec():
+def converted_wayflow_agent_with_message_summarization_transform_from_agentspec(
+    agentspec_live_summarization_llm_config: AgentSpecVllmConfig,
+    agentspec_mock_llm_config: AgentSpecVllmConfig,
+):
     collection_name = MESSAGE_SUMMARIZATION_CACHE_COLLECTION_NAME
     agent_spec_datastore = AgentSpecInMemoryCollection(
         name="test-inmemory-datastore",
@@ -251,36 +272,27 @@ def converted_wayflow_agent_with_message_summarization_transform_from_agentspec(
             collection_name: AgentSpecMessageSummarizationTransform.get_entity_definition()
         },
     )
-    summarization_llm_config = AgentSpecVllmConfig(
-        name="vllm",
-        model_id=GEMMA_CONFIG["model_id"],
-        url=GEMMA_CONFIG["host_port"],
-        default_generation_parameters=AGENTSPEC_LIVE_LLM_GENERATION_CONFIG,
-        retry_policy=AGENTSPEC_LIVE_LLM_RETRY_POLICY,
-    )
     agent_spec_transform = AgentSpecMessageSummarizationTransform(
         name="message-summarizer",
-        llm=summarization_llm_config,
+        llm=agentspec_live_summarization_llm_config,
         datastore=agent_spec_datastore,
         max_message_size=500,
         cache_collection_name=collection_name,
     )
-    agent_llm_config = AgentSpecVllmConfig(
-        name="vllm", model_id=MOCK_LLM_CONFIG["model_id"], url=MOCK_LLM_CONFIG["host_port"]
-    )
     agent_spec_agent = AgentSpecAgent(
         name="test-agent",
         system_prompt="",
-        llm_config=agent_llm_config,
+        llm_config=agentspec_mock_llm_config,
         transforms=[agent_spec_transform],
     )
-    loader = AgentSpecLoader()
-    wayflow_agent = loader.load_component(agent_spec_agent)
-    return wayflow_agent
+    return AgentSpecLoader().load_component(agent_spec_agent)
 
 
 @pytest.fixture
-def converted_wayflow_agent_with_conversation_summarization_transform_from_agentspec():
+def converted_wayflow_agent_with_conversation_summarization_transform_from_agentspec(
+    agentspec_live_summarization_llm_config: AgentSpecVllmConfig,
+    agentspec_mock_llm_config: AgentSpecVllmConfig,
+):
     collection_name = CONVERSATION_SUMMARIZATION_CACHE_COLLECTION_NAME
     agent_spec_datastore = AgentSpecInMemoryCollection(
         name="test-inmemory-datastore",
@@ -288,29 +300,18 @@ def converted_wayflow_agent_with_conversation_summarization_transform_from_agent
             collection_name: AgentSpecConversationSummarizationTransform.get_entity_definition()
         },
     )
-    summarization_llm_config = AgentSpecVllmConfig(
-        name="vllm",
-        model_id=GEMMA_CONFIG["model_id"],
-        url=GEMMA_CONFIG["host_port"],
-        default_generation_parameters=AGENTSPEC_LIVE_LLM_GENERATION_CONFIG,
-        retry_policy=AGENTSPEC_LIVE_LLM_RETRY_POLICY,
-    )
     agent_spec_transform = AgentSpecConversationSummarizationTransform(
         name="conversation-summarizer",
-        llm=summarization_llm_config,
+        llm=agentspec_live_summarization_llm_config,
         datastore=agent_spec_datastore,
         max_num_messages=10,
         min_num_messages=5,
         cache_collection_name=collection_name,
     )
-    agent_llm_config = AgentSpecVllmConfig(
-        name="vllm", model_id=MOCK_LLM_CONFIG["model_id"], url=MOCK_LLM_CONFIG["host_port"]
-    )
     agent_spec_agent = AgentSpecAgent(
         name="test-agent",
         system_prompt="",
-        llm_config=agent_llm_config,
+        llm_config=agentspec_mock_llm_config,
         transforms=[agent_spec_transform],
     )
-    wayflow_agent = AgentSpecLoader().load_component(agent_spec_agent)
-    return wayflow_agent
+    return AgentSpecLoader().load_component(agent_spec_agent)

--- a/wayflowcore/tests/transforms/conftest.py
+++ b/wayflowcore/tests/transforms/conftest.py
@@ -13,6 +13,8 @@ from pyagentspec.datastores.datastore import (
     InMemoryCollectionDatastore as AgentSpecInMemoryCollection,
 )
 from pyagentspec.llms import VllmConfig as AgentSpecVllmConfig
+from pyagentspec.llms.llmgenerationconfig import LlmGenerationConfig as AgentSpecLlmGenerationConfig
+from pyagentspec.retrypolicy import RetryPolicy as AgentSpecRetryPolicy
 from pyagentspec.transforms import (
     ConversationSummarizationTransform as AgentSpecConversationSummarizationTransform,
 )
@@ -70,6 +72,8 @@ def find_datastore_by_schema(pool, schema):
 
 MESSAGE_SUMMARIZATION_CACHE_COLLECTION_NAME = "messages_cache"
 CONVERSATION_SUMMARIZATION_CACHE_COLLECTION_NAME = "conversations_cache"
+AGENTSPEC_LIVE_LLM_GENERATION_CONFIG = AgentSpecLlmGenerationConfig(max_tokens=512)
+AGENTSPEC_LIVE_LLM_RETRY_POLICY = AgentSpecRetryPolicy(max_attempts=0, request_timeout=30.0)
 
 
 @pytest.fixture(scope="session")
@@ -248,7 +252,11 @@ def converted_wayflow_agent_with_message_summarization_transform_from_agentspec(
         },
     )
     summarization_llm_config = AgentSpecVllmConfig(
-        name="vllm", model_id=GEMMA_CONFIG["model_id"], url=GEMMA_CONFIG["host_port"]
+        name="vllm",
+        model_id=GEMMA_CONFIG["model_id"],
+        url=GEMMA_CONFIG["host_port"],
+        default_generation_parameters=AGENTSPEC_LIVE_LLM_GENERATION_CONFIG,
+        retry_policy=AGENTSPEC_LIVE_LLM_RETRY_POLICY,
     )
     agent_spec_transform = AgentSpecMessageSummarizationTransform(
         name="message-summarizer",
@@ -281,7 +289,11 @@ def converted_wayflow_agent_with_conversation_summarization_transform_from_agent
         },
     )
     summarization_llm_config = AgentSpecVllmConfig(
-        name="vllm", model_id=GEMMA_CONFIG["model_id"], url=GEMMA_CONFIG["host_port"]
+        name="vllm",
+        model_id=GEMMA_CONFIG["model_id"],
+        url=GEMMA_CONFIG["host_port"],
+        default_generation_parameters=AGENTSPEC_LIVE_LLM_GENERATION_CONFIG,
+        retry_policy=AGENTSPEC_LIVE_LLM_RETRY_POLICY,
     )
     agent_spec_transform = AgentSpecConversationSummarizationTransform(
         name="conversation-summarizer",

--- a/wayflowcore/tests/utils.py
+++ b/wayflowcore/tests/utils.py
@@ -4,6 +4,7 @@
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
+import errno
 import os
 import signal
 import socket
@@ -166,13 +167,24 @@ def get_available_port(tmp_path: str):
     lock_path = f"{tmp_path}/wayflow_ports.lock"
 
     def _bindable(port: int) -> bool:
-        try:
-            with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
-                s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-                s.bind(("127.0.0.1", port))
-            return True
-        except OSError:
-            return False
+        # Some hosts resolve ``localhost`` to IPv6 for uvicorn. A port can be free
+        # on 127.0.0.1 while already occupied on ::1, so check both.
+        addresses = [
+            (socket.AF_INET, "127.0.0.1"),
+            (socket.AF_INET6, "::1"),
+        ]
+        for family, host in addresses:
+            try:
+                with closing(socket.socket(family, socket.SOCK_STREAM)) as s:
+                    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                    s.bind((host, port))
+            except OSError as exc:
+                if family == socket.AF_INET6 and (
+                    not socket.has_ipv6 or exc.errno in {errno.EAFNOSUPPORT, errno.EADDRNOTAVAIL}
+                ):
+                    continue
+                return False
+        return True
 
     # Acquire an interprocess lock, POSIX only. On non-POSIX, degrade to probing loop.
     if os.name == "posix":


### PR DESCRIPTION
## Summary

  - Move retry classification into provider-agnostic HTTP/transport helpers.
  - Avoid eager imports from optional dependencies during retry handling (like `openai`).
  - Preserve retry behavior for status, timeout, connection, and TLS error shapes.

  ## Test reliability

  - Fix IPv6 localhost port allocation for tests that start local servers, including MCP and A2A coverage.
  - Fix the test retry decorator so it works with failures raised inside `pytest.raises`.
  - Use `sys.executable` for test subprocesses so helper servers run under the correct python interpreter.