### PR TITLE
Improve tool decorator ergonomics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,11 @@ module = [
 ignore_errors = true
 
 [[tool.mypy.overrides]]
+module = [ 'tests.tools.test_tool_decorator' ]
+ignore_errors = false
+
+
+[[tool.mypy.overrides]]
 module = [
     'jq.*',
     'IPython.*',

--- a/wayflowcore/src/wayflowcore/search/toolbox.py
+++ b/wayflowcore/src/wayflowcore/search/toolbox.py
@@ -268,7 +268,7 @@ class SearchToolBox(ToolBox, Component, SerializableObject):
         )
 
         args_schema, output_schema = _get_tool_schema_no_parsing(
-            new_signature, tool_description, tool_name
+            new_signature, tool_name
         )
 
         copy_func = functools.partial(func, self._datastore)

--- a/wayflowcore/src/wayflowcore/search/toolbox.py
+++ b/wayflowcore/src/wayflowcore/search/toolbox.py
@@ -267,9 +267,7 @@ class SearchToolBox(ToolBox, Component, SerializableObject):
             parameters=[p for p in signature.parameters.values() if p.name != "datastore"]
         )
 
-        args_schema, output_schema = _get_tool_schema_no_parsing(
-            new_signature, tool_name
-        )
+        args_schema, output_schema = _get_tool_schema_no_parsing(new_signature, tool_name)
 
         copy_func = functools.partial(func, self._datastore)
         functools.update_wrapper(copy_func, func)

--- a/wayflowcore/src/wayflowcore/tools/toolhelpers.py
+++ b/wayflowcore/src/wayflowcore/tools/toolhelpers.py
@@ -455,7 +455,6 @@ def tool(
         and isinstance(func_or_name, str)
         and callable(func)
     ):
-        # if len(args) == 2 and (isinstance(args[0], str) and callable(args[1])):
         # Example case: wrapper with custom tool name
         # def my_callable():
         #     pass
@@ -471,7 +470,6 @@ def tool(
             requires_confirmation,
         )
     elif func_or_name is not None and isinstance(func_or_name, str):
-        # elif len(args) == 1 and isinstance(args[0], str):
         # Example case: decorator with custom tool name
         # @tool("my_callable1")
         # def my_callable():

--- a/wayflowcore/src/wayflowcore/tools/toolhelpers.py
+++ b/wayflowcore/src/wayflowcore/tools/toolhelpers.py
@@ -22,6 +22,7 @@ from typing import (
     Union,
     get_args,
     get_origin,
+    overload,
 )
 
 from wayflowcore.property import JsonSchemaParam, Property
@@ -79,7 +80,9 @@ def _get_partial_schema_from_annotation(arg_type: Type[Any]) -> JsonSchemaParam:
     # Handle Dict[str, X]
     if origin is dict or origin is Dict:
         if len(args) != 2:
-            raise TypeError("Dict must have exactly two type arguments, e.g., Dict[str, int]")
+            raise TypeError(
+                "Dict must have exactly two type arguments, e.g., Dict[str, int]"
+            )
         key_type, value_type = args
         if key_type is not str:
             raise TypeError("JSON object keys must be strings")
@@ -104,7 +107,10 @@ def _get_partial_schema_from_annotation(arg_type: Type[Any]) -> JsonSchemaParam:
         if len(unique_json_types) > 1:
             return {
                 "anyOf": [
-                    {"type": t, "enum": [v for v in args if PRIMITIVE_TYPE_MAP[type(v)] == t]}
+                    {
+                        "type": t,
+                        "enum": [v for v in args if PRIMITIVE_TYPE_MAP[type(v)] == t],
+                    }
                     for t in unique_json_types
                 ]
             }
@@ -141,7 +147,7 @@ def _get_tool_schema_no_parsing(
 
     if "self" in tool_signature.parameters.keys():
         raise TypeError(
-            f"The tool decorator cannot be used directly on a class method, use `tool(my_object.my_method)` instead"
+            "The tool decorator cannot be used directly on a class method, use `tool(my_object.my_method)` instead"
         )
 
     # Determining the schema of input parameters
@@ -205,7 +211,9 @@ def _get_tool_schema_from_parsed_signature(
                 f"Description mode is `infer_from_signature` but parameter {param_name} of tool {tool_name} is not Annotated "
                 f"(has type {annotated_param.annotation}). Either annotate the parameter or use the `only_docstring` description mode."
             )
-        param_annotation, param_description = _unpack_annotated_types(annotated_param.annotation)
+        param_annotation, param_description = _unpack_annotated_types(
+            annotated_param.annotation
+        )
         param_schema = _get_partial_schema_from_annotation(param_annotation)
 
         param_schema["description"] = param_description
@@ -220,7 +228,9 @@ def _get_tool_schema_from_parsed_signature(
         raise TypeError(f"Return annotation is not specified for tool {tool_name}")
     output_annotation: Any
     if _is_annotated_type(annotated_output_type):
-        output_annotation, output_description = _unpack_annotated_types(annotated_output_type)
+        output_annotation, output_description = _unpack_annotated_types(
+            annotated_output_type
+        )
     else:
         output_annotation, output_description = annotated_output_type, ""
 
@@ -231,8 +241,55 @@ def _get_tool_schema_from_parsed_signature(
     return args_schema, output_schema
 
 
+@overload
 def tool(
-    *args: Union[str, Callable[..., Any]],
+    func_or_name: str,
+    func: Callable[..., Any],
+    /,
+    description_mode: Literal[
+        DescriptionMode.INFER_FROM_SIGNATURE,
+        DescriptionMode.ONLY_DOCSTRING,
+        DescriptionMode.EXTRACT_FROM_DOCSTRING,
+    ] = DescriptionMode.INFER_FROM_SIGNATURE,
+    output_descriptors: Optional[List[Property]] = None,
+    requires_confirmation: bool = False,
+) -> ServerTool: ...
+
+
+@overload
+def tool(
+    func_or_name: Callable[..., Any],
+    func: None = None,
+    /,
+    description_mode: Literal[
+        DescriptionMode.INFER_FROM_SIGNATURE,
+        DescriptionMode.ONLY_DOCSTRING,
+        DescriptionMode.EXTRACT_FROM_DOCSTRING,
+    ] = DescriptionMode.INFER_FROM_SIGNATURE,
+    output_descriptors: Optional[List[Property]] = None,
+    requires_confirmation: bool = False,
+) -> ServerTool: ...
+
+
+@overload
+def tool(
+    func_or_name: str | None = None,
+    func: None = None,
+    /,
+    description_mode: Literal[
+        DescriptionMode.INFER_FROM_SIGNATURE,
+        DescriptionMode.ONLY_DOCSTRING,
+        DescriptionMode.EXTRACT_FROM_DOCSTRING,
+    ] = DescriptionMode.INFER_FROM_SIGNATURE,
+    output_descriptors: Optional[List[Property]] = None,
+    requires_confirmation: bool = False,
+) -> Callable[[Callable[..., Any]], ServerTool]: ...
+
+
+def tool(
+    func_or_name: Callable[..., Any] | str | None = None,
+    func: Callable[..., Any] | None = None,
+    /,
     description_mode: Literal[
         DescriptionMode.INFER_FROM_SIGNATURE,
         DescriptionMode.ONLY_DOCSTRING,
@@ -392,18 +449,29 @@ def tool(
 
     # When used as a wrapper, `args` can be [tool_name, callable] or [callable]
     # When used as a decorator, `args` can be [tool_name, callable] or [callable]
-    if len(args) == 2 and (isinstance(args[0], str) and callable(args[1])):
+    if (
+        func_or_name is not None
+        and func is not None
+        and isinstance(func_or_name, str)
+        and callable(func)
+    ):
+        # if len(args) == 2 and (isinstance(args[0], str) and callable(args[1])):
         # Example case: wrapper with custom tool name
         # def my_callable():
         #     pass
         # my_tool = tool("my_callable1", my_callable)
         # here args[0] is the tool name, and args[1] the callable
         # we simply return the newly created ServerTool
-        tool_name = args[0]
+        tool_name = func_or_name
         return _make_tool(
-            args[1], tool_name, description_mode, output_descriptors, requires_confirmation
+            func,
+            tool_name,
+            description_mode,
+            output_descriptors,
+            requires_confirmation,
         )
-    elif len(args) == 1 and isinstance(args[0], str):
+    elif func_or_name is not None and isinstance(func_or_name, str):
+        # elif len(args) == 1 and isinstance(args[0], str):
         # Example case: decorator with custom tool name
         # @tool("my_callable1")
         # def my_callable():
@@ -412,15 +480,19 @@ def tool(
         # Upon instantiation, first the `tool` function is called, directly followed
         # by the `_partial_with_name` function being called, thus converting the
         # callable to a ServerTool
-        tool_name = args[0]
+        tool_name = func_or_name
 
         def _partial_with_name(func: Callable[..., Any]) -> ServerTool:
             return _make_tool(
-                func, tool_name, description_mode, output_descriptors, requires_confirmation
+                func,
+                tool_name,
+                description_mode,
+                output_descriptors,
+                requires_confirmation,
             )
 
         return _partial_with_name
-    elif len(args) == 1 and callable(args[0]):
+    elif func_or_name is not None and callable(func_or_name):
         # Example case: wrapper
         # def my_callable():
         #     pass
@@ -428,9 +500,13 @@ def tool(
         # here args[0] is the callable
         # we simply return the newly created ServerTool
         return _make_tool(
-            args[0], None, description_mode, output_descriptors, requires_confirmation
+            func_or_name,
+            None,
+            description_mode,
+            output_descriptors,
+            requires_confirmation,
         )
-    elif len(args) == 0:
+    elif func_or_name is None:
         # Example case: decorator with user-specified description_mode
         # @tool(description_mode='only_docstring')
         # def my_callable(param1: int = 2) -> int:
@@ -477,7 +553,9 @@ def _to_react_template_dict(tool: Tool) -> Dict[str, str]:
                     f"- {parameter_name}: {_find_json_schema_full_type(parameter_info)}"
                 )
                 if "default" in parameter_info:
-                    param_description += f" (Optional, default={parameter_info['default']})"
+                    param_description += (
+                        f" (Optional, default={parameter_info['default']})"
+                    )
                 else:
                     param_description += " (Required)"
                 if "description" in parameter_info:
@@ -485,7 +563,9 @@ def _to_react_template_dict(tool: Tool) -> Dict[str, str]:
                 parameter_descriptions.append(param_description)
 
             formatted_parameter_descriptions = "\n".join(parameter_descriptions)
-            description = tool_as_str + f"Parameters:\n{formatted_parameter_descriptions}"
+            description = (
+                tool_as_str + f"Parameters:\n{formatted_parameter_descriptions}"
+            )
     return {
         "name": tool.name,
         "description": description,

--- a/wayflowcore/src/wayflowcore/tools/toolhelpers.py
+++ b/wayflowcore/src/wayflowcore/tools/toolhelpers.py
@@ -178,7 +178,7 @@ def _get_tool_schema_no_parsing(
         raise TypeError(f"Return annotation is not specified for tool {tool_name}")
     if _is_annotated_type(output_annotation):
         raise TypeError(
-            f"Annotated types are not permitted when using the description mode `only_docstring`. "
+            "Annotated types are not permitted when using the description mode `only_docstring`. "
             f"Return annotation of tool {tool_name} has type `{output_annotation}`"
         )
     output_schema = _get_partial_schema_from_annotation(output_annotation)
@@ -193,7 +193,7 @@ def _get_tool_schema_from_parsed_signature(
 
     if "self" in tool_signature.parameters.keys():
         raise TypeError(
-            f"The tool decorator cannot be used directly on a class method, use `tool(my_object.my_method)` instead"
+            "The tool decorator cannot be used directly on a class method, use `tool(my_object.my_method)` instead"
         )
 
     # Determining the schema of input parameters
@@ -273,7 +273,7 @@ def tool(
 
 @overload
 def tool(
-    func_or_name: str | None = None,
+    func_or_name: str,
     func: None = None,
     /,
     description_mode: Literal[
@@ -287,7 +287,7 @@ def tool(
 
 
 def tool(
-    func_or_name: Callable[..., Any] | str | None = None,
+    func_or_name: Callable[..., Any] | str,
     func: Callable[..., Any] | None = None,
     /,
     description_mode: Literal[
@@ -447,19 +447,14 @@ def tool(
             requires_confirmation=requires_confirmation,
         )
 
-    # When used as a wrapper, `args` can be [tool_name, callable] or [callable]
-    # When used as a decorator, `args` can be [tool_name, callable] or [callable]
-    if (
-        func_or_name is not None
-        and func is not None
-        and isinstance(func_or_name, str)
-        and callable(func)
-    ):
+    # When used as a wrapper, the function arguments can be [tool_name, callable] or [callable]
+    # When used as a decorator, the decorator arguments can be [tool_name, callable] or [callable]
+    if func is not None and isinstance(func_or_name, str) and callable(func):
         # Example case: wrapper with custom tool name
         # def my_callable():
         #     pass
         # my_tool = tool("my_callable1", my_callable)
-        # here args[0] is the tool name, and args[1] the callable
+        # here func_or_name is the tool name, and func the callable
         # we simply return the newly created ServerTool
         tool_name = func_or_name
         return _make_tool(
@@ -469,12 +464,12 @@ def tool(
             output_descriptors,
             requires_confirmation,
         )
-    elif func_or_name is not None and isinstance(func_or_name, str):
+    elif isinstance(func_or_name, str):
         # Example case: decorator with custom tool name
         # @tool("my_callable1")
         # def my_callable():
         #     pass
-        # here args[0] is the tool name
+        # here func_or_name is the tool name
         # Upon instantiation, first the `tool` function is called, directly followed
         # by the `_partial_with_name` function being called, thus converting the
         # callable to a ServerTool
@@ -490,12 +485,12 @@ def tool(
             )
 
         return _partial_with_name
-    elif func_or_name is not None and callable(func_or_name):
+    elif callable(func_or_name):
         # Example case: wrapper
         # def my_callable():
         #     pass
         # my_tool = tool(my_callable)
-        # here args[0] is the callable
+        # here func_or_name is the callable
         # we simply return the newly created ServerTool
         return _make_tool(
             func_or_name,
@@ -504,21 +499,6 @@ def tool(
             output_descriptors,
             requires_confirmation,
         )
-    elif func_or_name is None:
-        # Example case: decorator with user-specified description_mode
-        # @tool(description_mode='only_docstring')
-        # def my_callable(param1: int = 2) -> int:
-        #     """Callable description"""
-        #     return 0
-        # Upon instantiation, first the `tool` function is called, directly followed
-        # by the `_partial_no_name` function being called, thus converting the
-        # callable to a ServerTool
-        def _partial_no_name(func: Callable[..., Any]) -> ServerTool:
-            return _make_tool(
-                func, None, description_mode, output_descriptors, requires_confirmation
-            )
-
-        return _partial_no_name
     else:
         raise ValueError("Invalid usage of the `tool` helper")
 

--- a/wayflowcore/src/wayflowcore/tools/toolhelpers.py
+++ b/wayflowcore/src/wayflowcore/tools/toolhelpers.py
@@ -25,7 +25,6 @@ from typing import (
     get_origin,
     overload,
 )
-from typing_extensions import reveal_type
 
 from wayflowcore.property import JsonSchemaParam, Property
 
@@ -143,7 +142,6 @@ def _unpack_annotated_types(arg_type: Type[Any]) -> Tuple[Type[Any], str]:
 
 def _get_tool_schema_no_parsing(
     tool_signature: inspect.Signature,
-    tool_description: str,
     tool_name: str,
 ) -> Tuple[Dict[str, JsonSchemaParam], JsonSchemaParam]:
 
@@ -189,7 +187,6 @@ def _get_tool_schema_no_parsing(
 
 def _get_tool_schema_from_parsed_signature(
     tool_signature: inspect.Signature,
-    tool_description: str,
     tool_name: str,
 ) -> Tuple[Dict[str, JsonSchemaParam], JsonSchemaParam]:
 
@@ -416,11 +413,11 @@ def tool(
 
         if description_mode == DescriptionMode.ONLY_DOCSTRING:
             args_schema, output_schema = _get_tool_schema_no_parsing(
-                tool_signature, tool_description, tool_name
+                tool_signature, tool_name
             )
         elif description_mode == DescriptionMode.INFER_FROM_SIGNATURE:
             args_schema, output_schema = _get_tool_schema_from_parsed_signature(
-                tool_signature, tool_description, tool_name
+                tool_signature, tool_name
             )
         elif description_mode == DescriptionMode.EXTRACT_FROM_DOCSTRING:
             raise NotImplementedError(

--- a/wayflowcore/src/wayflowcore/tools/toolhelpers.py
+++ b/wayflowcore/src/wayflowcore/tools/toolhelpers.py
@@ -445,10 +445,9 @@ def tool(
         # my_tool = tool("my_callable1", my_callable)
         # here func_or_name is the tool name, and func the callable
         # we simply return the newly created ServerTool
-        tool_name = func_or_name
         return _make_tool(
             func,
-            tool_name,
+            func_or_name,
             description_mode,
             output_descriptors,
             requires_confirmation,
@@ -462,12 +461,10 @@ def tool(
         # Upon instantiation, first the `tool` function is called, directly followed
         # by the `_partial_with_name` function being called, thus converting the
         # callable to a ServerTool
-        tool_name = func_or_name
-
         def _partial_with_name(func: Callable[..., Any]) -> ServerTool:
             return _make_tool(
                 func,
-                tool_name,
+                func_or_name,
                 description_mode,
                 output_descriptors,
                 requires_confirmation,

--- a/wayflowcore/src/wayflowcore/tools/toolhelpers.py
+++ b/wayflowcore/src/wayflowcore/tools/toolhelpers.py
@@ -81,9 +81,7 @@ def _get_partial_schema_from_annotation(arg_type: Type[Any]) -> JsonSchemaParam:
     # Handle Dict[str, X]
     if origin is dict or origin is Dict:
         if len(args) != 2:
-            raise TypeError(
-                "Dict must have exactly two type arguments, e.g., Dict[str, int]"
-            )
+            raise TypeError("Dict must have exactly two type arguments, e.g., Dict[str, int]")
         key_type, value_type = args
         if key_type is not str:
             raise TypeError("JSON object keys must be strings")
@@ -210,9 +208,7 @@ def _get_tool_schema_from_parsed_signature(
                 f"Description mode is `infer_from_signature` but parameter {param_name} of tool {tool_name} is not Annotated "
                 f"(has type {annotated_param.annotation}). Either annotate the parameter or use the `only_docstring` description mode."
             )
-        param_annotation, param_description = _unpack_annotated_types(
-            annotated_param.annotation
-        )
+        param_annotation, param_description = _unpack_annotated_types(annotated_param.annotation)
         param_schema = _get_partial_schema_from_annotation(param_annotation)
 
         param_schema["description"] = param_description
@@ -227,9 +223,7 @@ def _get_tool_schema_from_parsed_signature(
         raise TypeError(f"Return annotation is not specified for tool {tool_name}")
     output_annotation: Any
     if _is_annotated_type(annotated_output_type):
-        output_annotation, output_description = _unpack_annotated_types(
-            annotated_output_type
-        )
+        output_annotation, output_description = _unpack_annotated_types(annotated_output_type)
     else:
         output_annotation, output_description = annotated_output_type, ""
 
@@ -412,9 +406,7 @@ def tool(
         tool_name = tool_name or func.__name__
 
         if description_mode == DescriptionMode.ONLY_DOCSTRING:
-            args_schema, output_schema = _get_tool_schema_no_parsing(
-                tool_signature, tool_name
-            )
+            args_schema, output_schema = _get_tool_schema_no_parsing(tool_signature, tool_name)
         elif description_mode == DescriptionMode.INFER_FROM_SIGNATURE:
             args_schema, output_schema = _get_tool_schema_from_parsed_signature(
                 tool_signature, tool_name
@@ -532,9 +524,7 @@ def _to_react_template_dict(tool: Tool) -> Dict[str, str]:
                     f"- {parameter_name}: {_find_json_schema_full_type(parameter_info)}"
                 )
                 if "default" in parameter_info:
-                    param_description += (
-                        f" (Optional, default={parameter_info['default']})"
-                    )
+                    param_description += f" (Optional, default={parameter_info['default']})"
                 else:
                     param_description += " (Required)"
                 if "description" in parameter_info:
@@ -542,9 +532,7 @@ def _to_react_template_dict(tool: Tool) -> Dict[str, str]:
                 parameter_descriptions.append(param_description)
 
             formatted_parameter_descriptions = "\n".join(parameter_descriptions)
-            description = (
-                tool_as_str + f"Parameters:\n{formatted_parameter_descriptions}"
-            )
+            description = tool_as_str + f"Parameters:\n{formatted_parameter_descriptions}"
     return {
         "name": tool.name,
         "description": description,

--- a/wayflowcore/src/wayflowcore/tools/toolhelpers.py
+++ b/wayflowcore/src/wayflowcore/tools/toolhelpers.py
@@ -19,11 +19,13 @@ from typing import (
     Optional,
     Tuple,
     Type,
+    TypeAlias,
     Union,
     get_args,
     get_origin,
     overload,
 )
+from typing_extensions import reveal_type
 
 from wayflowcore.property import JsonSchemaParam, Property
 
@@ -241,16 +243,22 @@ def _get_tool_schema_from_parsed_signature(
     return args_schema, output_schema
 
 
+DescriptionModeOptions: TypeAlias = Literal[
+    DescriptionMode.INFER_FROM_SIGNATURE,
+    DescriptionMode.ONLY_DOCSTRING,
+    DescriptionMode.EXTRACT_FROM_DOCSTRING,
+    "infer_from_signature",
+    "only_docstring",
+    "extract_from_docstring",
+]
+
+
 @overload
 def tool(
     func_or_name: str,
     func: Callable[..., Any],
     /,
-    description_mode: Literal[
-        DescriptionMode.INFER_FROM_SIGNATURE,
-        DescriptionMode.ONLY_DOCSTRING,
-        DescriptionMode.EXTRACT_FROM_DOCSTRING,
-    ] = DescriptionMode.INFER_FROM_SIGNATURE,
+    description_mode: DescriptionModeOptions = DescriptionMode.INFER_FROM_SIGNATURE,
     output_descriptors: Optional[List[Property]] = None,
     requires_confirmation: bool = False,
 ) -> ServerTool: ...
@@ -261,11 +269,7 @@ def tool(
     func_or_name: Callable[..., Any],
     func: None = None,
     /,
-    description_mode: Literal[
-        DescriptionMode.INFER_FROM_SIGNATURE,
-        DescriptionMode.ONLY_DOCSTRING,
-        DescriptionMode.EXTRACT_FROM_DOCSTRING,
-    ] = DescriptionMode.INFER_FROM_SIGNATURE,
+    description_mode: DescriptionModeOptions = DescriptionMode.INFER_FROM_SIGNATURE,
     output_descriptors: Optional[List[Property]] = None,
     requires_confirmation: bool = False,
 ) -> ServerTool: ...
@@ -273,28 +277,20 @@ def tool(
 
 @overload
 def tool(
-    func_or_name: str,
+    func_or_name: str | None = None,
     func: None = None,
     /,
-    description_mode: Literal[
-        DescriptionMode.INFER_FROM_SIGNATURE,
-        DescriptionMode.ONLY_DOCSTRING,
-        DescriptionMode.EXTRACT_FROM_DOCSTRING,
-    ] = DescriptionMode.INFER_FROM_SIGNATURE,
+    description_mode: DescriptionModeOptions = DescriptionMode.INFER_FROM_SIGNATURE,
     output_descriptors: Optional[List[Property]] = None,
     requires_confirmation: bool = False,
 ) -> Callable[[Callable[..., Any]], ServerTool]: ...
 
 
 def tool(
-    func_or_name: Callable[..., Any] | str,
+    func_or_name: Callable[..., Any] | str | None = None,
     func: Callable[..., Any] | None = None,
     /,
-    description_mode: Literal[
-        DescriptionMode.INFER_FROM_SIGNATURE,
-        DescriptionMode.ONLY_DOCSTRING,
-        DescriptionMode.EXTRACT_FROM_DOCSTRING,
-    ] = DescriptionMode.INFER_FROM_SIGNATURE,
+    description_mode: DescriptionModeOptions = DescriptionMode.INFER_FROM_SIGNATURE,
     output_descriptors: Optional[List[Property]] = None,
     requires_confirmation: bool = False,
 ) -> Union[ServerTool, Callable[[Callable[..., Any]], ServerTool]]:
@@ -401,11 +397,7 @@ def tool(
     def _make_tool(
         func: Callable[..., Any],
         tool_name: Optional[str] = None,
-        description_mode: Literal[
-            DescriptionMode.INFER_FROM_SIGNATURE,
-            DescriptionMode.ONLY_DOCSTRING,
-            DescriptionMode.EXTRACT_FROM_DOCSTRING,
-        ] = DescriptionMode.INFER_FROM_SIGNATURE,
+        description_mode: DescriptionModeOptions = DescriptionMode.INFER_FROM_SIGNATURE,
         output_descriptors: Optional[List[Property]] = None,
         requires_confirmation: bool = False,
     ) -> ServerTool:
@@ -499,6 +491,21 @@ def tool(
             output_descriptors,
             requires_confirmation,
         )
+    elif func_or_name is None:
+        # Example case: decorator with user-specified description_mode
+        # @tool(description_mode='only_docstring')
+        # def my_callable(param1: int = 2) -> int:
+        #     """Callable description"""
+        #     return 0
+        # Upon instantiation, first the `tool` function is called, directly followed
+        # by the `_partial_no_name` function being called, thus converting the
+        # callable to a ServerTool
+        def _partial_no_name(func: Callable[..., Any]) -> ServerTool:
+            return _make_tool(
+                func, None, description_mode, output_descriptors, requires_confirmation
+            )
+
+        return _partial_no_name
     else:
         raise ValueError("Invalid usage of the `tool` helper")
 

--- a/wayflowcore/tests/conftest.py
+++ b/wayflowcore/tests/conftest.py
@@ -102,7 +102,7 @@ if not ollama_embedding_api_url:
 
 compartment_id = os.environ.get("COMPARTMENT_ID")
 if not compartment_id:
-    raise Exception("compartment_id is not set in the environment")
+    raise Exception("COMPARTMENT_ID is not set in the environment")
 
 oracle_http_proxy = os.environ.get("ORACLE_HTTP_PROXY")
 

--- a/wayflowcore/tests/tools/test_tool_decorator.py
+++ b/wayflowcore/tests/tools/test_tool_decorator.py
@@ -1,0 +1,31 @@
+from typing import Any, Callable
+from typing_extensions import assert_type
+from wayflowcore.tools.servertools import ServerTool
+from wayflowcore.tools.toolhelpers import DescriptionMode, tool
+
+
+def test_tool_decorator_result_type_is_correct() -> None:
+    tool_one = tool("tool_one")
+    assert_type(tool_one, Callable[[Callable[..., Any]], ServerTool])
+    assert isinstance(tool_one, Callable)
+
+    def func_two() -> None:
+        """Just a func"""
+
+    tool_two = tool("tool_two", func_two)
+    assert_type(tool_two, ServerTool)
+    assert isinstance(tool_two, ServerTool)
+
+    @tool("tool_three", description_mode=DescriptionMode.ONLY_DOCSTRING)
+    def tool_three() -> None:
+        """tool_three function"""
+
+    @tool
+    def tool_four() -> None:
+        """tool_four function"""
+
+    assert_type(tool_three, ServerTool)
+    assert_type(tool_four, ServerTool)
+
+    assert isinstance(tool_three, ServerTool)
+    assert isinstance(tool_four, ServerTool)

--- a/wayflowcore/tests/tools/test_tool_decorator.py
+++ b/wayflowcore/tests/tools/test_tool_decorator.py
@@ -5,18 +5,30 @@ from wayflowcore.tools.toolhelpers import DescriptionMode, tool
 
 
 def test_tool_decorator_result_type_is_correct() -> None:
+    # Wrapper with different name
     tool_one = tool("tool_one")
     assert_type(tool_one, Callable[[Callable[..., Any]], ServerTool])
     assert isinstance(tool_one, Callable)
 
     def actual_func() -> None:
-        """Another func"""
+        """Actual func"""
 
     func_tool = tool_one(actual_func)
     assert_type(func_tool, ServerTool)
     assert isinstance(func_tool, ServerTool)
     assert func_tool.name == "tool_one"
 
+    # Decorator with different tool name
+
+    @tool("real_function_name")
+    def another_func() -> None:
+        """Another func"""
+
+    assert_type(another_func, ServerTool)
+    assert isinstance(another_func, ServerTool)
+    assert another_func.name == "real_function_name"
+
+    # Wrapper with name and function passed as arguments
     def func_two() -> None:
         """Just a func"""
 
@@ -24,16 +36,18 @@ def test_tool_decorator_result_type_is_correct() -> None:
     assert_type(tool_two, ServerTool)
     assert isinstance(tool_two, ServerTool)
 
+    # Decorator with description mode
     @tool("tool_three", description_mode=DescriptionMode.ONLY_DOCSTRING)
     def tool_three() -> None:
         """tool_three function"""
 
+    assert_type(tool_three, ServerTool)
+    assert isinstance(tool_three, ServerTool)
+
+    # Decorator with no arguments passed
     @tool
     def tool_four() -> None:
         """tool_four function"""
 
-    assert_type(tool_three, ServerTool)
     assert_type(tool_four, ServerTool)
-
-    assert isinstance(tool_three, ServerTool)
     assert isinstance(tool_four, ServerTool)

--- a/wayflowcore/tests/tools/test_tool_decorator.py
+++ b/wayflowcore/tests/tools/test_tool_decorator.py
@@ -9,6 +9,14 @@ def test_tool_decorator_result_type_is_correct() -> None:
     assert_type(tool_one, Callable[[Callable[..., Any]], ServerTool])
     assert isinstance(tool_one, Callable)
 
+    def actual_func() -> None:
+        """Another func"""
+
+    func_tool = tool_one(actual_func)
+    assert_type(func_tool, ServerTool)
+    assert isinstance(func_tool, ServerTool)
+    assert func_tool.name == "tool_one"
+
     def func_two() -> None:
         """Just a func"""
 

--- a/wayflowcore/tests/tools/test_tool_decorator.py
+++ b/wayflowcore/tests/tools/test_tool_decorator.py
@@ -107,6 +107,8 @@ def test_tool_decorator_result_type_is_correct() -> None:
     assert tool_nine.name == "servertool_nine"
     assert not tool_nine.requires_confirmation
 
+    assert tool_nine.description == "tool_nine function"
+
     output_desc_nine = tool_nine.output_descriptors[0]
     assert output_desc_nine.name == "result_nine"
     assert isinstance(output_desc_nine, StringProperty)

--- a/wayflowcore/tests/tools/test_tool_decorator.py
+++ b/wayflowcore/tests/tools/test_tool_decorator.py
@@ -5,7 +5,9 @@
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
 from typing import Any, Callable
+
 from typing_extensions import assert_type
+
 from wayflowcore.property import StringProperty
 from wayflowcore.tools.servertools import ServerTool
 from wayflowcore.tools.toolhelpers import DescriptionMode, tool

--- a/wayflowcore/tests/tools/test_tool_decorator.py
+++ b/wayflowcore/tests/tools/test_tool_decorator.py
@@ -9,7 +9,7 @@ def test_tool_decorator_result_type_is_correct() -> None:
     # Wrapper with different name
     tool_one = tool("tool_one")
     assert_type(tool_one, Callable[[Callable[..., Any]], ServerTool])
-    assert isinstance(tool_one, Callable)
+    assert callable(tool_one)
 
     def actual_func() -> None:
         """Actual func"""

--- a/wayflowcore/tests/tools/test_tool_decorator.py
+++ b/wayflowcore/tests/tools/test_tool_decorator.py
@@ -36,14 +36,16 @@ def test_tool_decorator_result_type_is_correct() -> None:
     tool_two = tool("tool_two", func_two)
     assert_type(tool_two, ServerTool)
     assert isinstance(tool_two, ServerTool)
+    assert tool_two.name == "tool_two"
 
     # Decorator with description mode
     @tool("tool_three", description_mode=DescriptionMode.ONLY_DOCSTRING)
-    def tool_three() -> None:
+    def func_three() -> None:
         """tool_three function"""
 
-    assert_type(tool_three, ServerTool)
-    assert isinstance(tool_three, ServerTool)
+    assert_type(func_three, ServerTool)
+    assert isinstance(func_three, ServerTool)
+    assert func_three.name == "tool_three"
 
     # Decorator with no arguments passed
     @tool
@@ -52,6 +54,7 @@ def test_tool_decorator_result_type_is_correct() -> None:
 
     assert_type(tool_four, ServerTool)
     assert isinstance(tool_four, ServerTool)
+    assert tool_four.name == "tool_four"
 
     # Decorator with only description mode passed
     @tool(description_mode=DescriptionMode.ONLY_DOCSTRING)
@@ -60,6 +63,7 @@ def test_tool_decorator_result_type_is_correct() -> None:
 
     assert_type(tool_five, ServerTool)
     assert isinstance(tool_five, ServerTool)
+    assert tool_five.name == "tool_five"
 
     # Decorator with only description mode passed as a string
     @tool(description_mode="only_docstring")
@@ -68,6 +72,7 @@ def test_tool_decorator_result_type_is_correct() -> None:
 
     assert_type(tool_six, ServerTool)
     assert isinstance(tool_six, ServerTool)
+    assert tool_six.name == "tool_six"
 
     # Decorator with only output_descriptors
     @tool(output_descriptors=[StringProperty("result")])
@@ -77,6 +82,7 @@ def test_tool_decorator_result_type_is_correct() -> None:
 
     assert_type(tool_seven, ServerTool)
     assert isinstance(tool_seven, ServerTool)
+    assert tool_seven.name == "tool_seven"
     output_desc = tool_seven.output_descriptors[0]
     assert output_desc.name == "result"
     assert isinstance(output_desc, StringProperty)
@@ -89,6 +95,7 @@ def test_tool_decorator_result_type_is_correct() -> None:
     assert_type(tool_eight, ServerTool)
     assert isinstance(tool_eight, ServerTool)
     assert tool_eight.requires_confirmation
+    assert tool_eight.name == "tool_eight"
 
     # Decorator with name, output_descriptors and requires_confirmation
     @tool(

--- a/wayflowcore/tests/tools/test_tool_decorator.py
+++ b/wayflowcore/tests/tools/test_tool_decorator.py
@@ -1,3 +1,9 @@
+# Copyright © 2025 Oracle and/or its affiliates.
+#
+# This software is under the Apache License 2.0
+# (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
+# (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
+
 from typing import Any, Callable
 from typing_extensions import assert_type
 from wayflowcore.property import StringProperty

--- a/wayflowcore/tests/tools/test_tool_decorator.py
+++ b/wayflowcore/tests/tools/test_tool_decorator.py
@@ -103,7 +103,10 @@ def test_tool_decorator_result_type_is_correct() -> None:
 
     assert_type(tool_nine, ServerTool)
     assert isinstance(tool_nine, ServerTool)
+
+    assert tool_nine.name == "servertool_nine"
     assert not tool_nine.requires_confirmation
+
     output_desc_nine = tool_nine.output_descriptors[0]
     assert output_desc_nine.name == "result_nine"
     assert isinstance(output_desc_nine, StringProperty)

--- a/wayflowcore/tests/tools/test_tool_decorator.py
+++ b/wayflowcore/tests/tools/test_tool_decorator.py
@@ -1,5 +1,6 @@
 from typing import Any, Callable
 from typing_extensions import assert_type
+from wayflowcore.property import StringProperty
 from wayflowcore.tools.servertools import ServerTool
 from wayflowcore.tools.toolhelpers import DescriptionMode, tool
 
@@ -51,3 +52,58 @@ def test_tool_decorator_result_type_is_correct() -> None:
 
     assert_type(tool_four, ServerTool)
     assert isinstance(tool_four, ServerTool)
+
+    # Decorator with only description mode passed
+    @tool(description_mode=DescriptionMode.ONLY_DOCSTRING)
+    def tool_five() -> None:
+        """tool_five function"""
+
+    assert_type(tool_five, ServerTool)
+    assert isinstance(tool_five, ServerTool)
+
+    # Decorator with only description mode passed as a string
+    @tool(description_mode="only_docstring")
+    def tool_six() -> None:
+        """tool_six function"""
+
+    assert_type(tool_six, ServerTool)
+    assert isinstance(tool_six, ServerTool)
+
+    # Decorator with only output_descriptors
+    @tool(output_descriptors=[StringProperty("result")])
+    def tool_seven() -> str:
+        """tool_seven function"""
+        return "result"
+
+    assert_type(tool_seven, ServerTool)
+    assert isinstance(tool_seven, ServerTool)
+    output_desc = tool_seven.output_descriptors[0]
+    assert output_desc.name == "result"
+    assert isinstance(output_desc, StringProperty)
+
+    # Decorator with only requires_confirmation
+    @tool(requires_confirmation=True)
+    def tool_eight() -> None:
+        """tool_eight function"""
+
+    assert_type(tool_eight, ServerTool)
+    assert isinstance(tool_eight, ServerTool)
+    assert tool_eight.requires_confirmation
+
+    # Decorator with name, output_descriptors and requires_confirmation
+    @tool(
+        "servertool_nine",
+        requires_confirmation=False,
+        output_descriptors=[StringProperty("result_nine")],
+        description_mode="infer_from_signature",
+    )
+    def tool_nine() -> str:
+        """tool_nine function"""
+        return "result"
+
+    assert_type(tool_nine, ServerTool)
+    assert isinstance(tool_nine, ServerTool)
+    assert not tool_nine.requires_confirmation
+    output_desc_nine = tool_nine.output_descriptors[0]
+    assert output_desc_nine.name == "result_nine"
+    assert isinstance(output_desc_nine, StringProperty)


### PR DESCRIPTION
Using the tool decorator is not very ergonomic due to how the function signature is defined.
This PR adds overloads and tests to ensure that using it doesn't yield false positives while typechecking.

<img width="1491" height="138" alt="image" src="https://github.com/user-attachments/assets/a39b2b1c-2ea6-410a-a0ac-e075ff6d2ed6" />
