### PR TITLE
Support retry for MCP tool resolution

### DIFF
--- a/docs/wayflowcore/source/core/changelog.rst
+++ b/docs/wayflowcore/source/core/changelog.rst
@@ -17,6 +17,21 @@ WayFlow 26.1.2
 New features
 ^^^^^^^^^^^^
 
+* **Configurable retry policies for MCP tools**
+
+  Added ``retry_policy`` to ``MCPTool`` and ``MCPToolBox`` to retry transient
+  missing-tool responses and MCP tool execution failures, including WayFlow
+  Agent Spec plugin serialization support.
+
+  For usage details, see :doc:`the MCP tools guide <howtoguides/howto_mcp>`.
+
+
+WayFlow 26.1.2
+--------------
+
+New features
+^^^^^^^^^^^^
+
 * **Configurable retry policies for remote components**
 
   Added the ``RetryPolicy`` object to configure retries, backoff,

--- a/docs/wayflowcore/source/core/code_examples/howto_mcp.py
+++ b/docs/wayflowcore/source/core/code_examples/howto_mcp.py
@@ -82,6 +82,7 @@ from wayflowcore.executors.executionstatus import FinishedStatus, UserMessageReq
 from wayflowcore.agent import Agent
 from wayflowcore.mcp import MCPTool, MCPToolBox, SSETransport, authless_mcp_enabled
 from wayflowcore.flow import Flow
+from wayflowcore.retrypolicy import RetryPolicy
 from wayflowcore.steps import ToolExecutionStep
 
 mcp_server_url = f"http://localhost:8080/sse" # change to your own URL
@@ -112,6 +113,17 @@ assistant = Agent(
     tools=[mcp_toolbox]
 )
 # .. end-##_Connecting_an_agent_to_the_MCP_server
+# .. start-##_Configuring_toolbox_retry_policy
+mcp_toolbox_with_retries = MCPToolBox(
+    client_transport=mcp_client,
+    tool_filter=["get_user_session", "get_payslips"],
+    retry_policy=RetryPolicy(
+        max_attempts=3,
+        initial_retry_delay=0.25,
+        max_retry_delay=2.0,
+    ),
+)
+# .. end-##_Configuring_toolbox_retry_policy
 from wayflowcore.agentspec import AgentSpecExporter # docs-skiprow
 serialized_assistant = AgentSpecExporter().to_json(assistant) # docs-skiprow
 
@@ -156,6 +168,14 @@ with authless_mcp_enabled():
         name=MCP_TOOL_NAME,
         client_transport=mcp_client
     )
+# .. start-##_Configuring_direct_tool_retry_policy
+with authless_mcp_enabled():
+    mcp_tool_with_retries = MCPTool(
+        name=MCP_TOOL_NAME,
+        client_transport=mcp_client,
+        retry_policy=RetryPolicy(max_attempts=3),
+    )
+# .. end-##_Configuring_direct_tool_retry_policy
 
 assistant = Flow.from_steps([
     ToolExecutionStep(name="mcp_tool_step", tool=mcp_tool)

--- a/docs/wayflowcore/source/core/code_examples/howto_mcp.py
+++ b/docs/wayflowcore/source/core/code_examples/howto_mcp.py
@@ -88,6 +88,7 @@ from wayflowcore.steps import ToolExecutionStep
 mcp_server_url = f"http://localhost:8080/sse" # change to your own URL
 # We will see below how to connect a specific tool to an assistant, e.g.
 MCP_TOOL_NAME = "get_user_session"
+MCP_TOOLBOX_TOOL_FILTER = ["get_user_session", "get_payslips"]
 # And see how to build an agent that can answer questions, e.g.
 USER_QUERY = "What was the payment date of the last payslip for the current user?"
 # .. end-##_Imports_for_this_guide
@@ -102,6 +103,8 @@ llm: VllmModel  # docs-skiprow
 mcp_server_url: str # docs-skiprow
 USER_QUERY: str # docs-skiprow
 (llm, mcp_server_url, USER_QUERY, MCP_TOOL_NAME) = _update_globals(["llm_small", "sse_mcp_server", "mcp_user_query", "mcp_example_tool_name"]) # docs-skiprow # type: ignore
+if MCP_TOOL_NAME != "get_user_session": # docs-skiprow
+    MCP_TOOLBOX_TOOL_FILTER = [MCP_TOOL_NAME] # docs-skiprow
 
 # .. start-##_Connecting_an_agent_to_the_MCP_server
 mcp_client = SSETransport(url=mcp_server_url)
@@ -116,12 +119,17 @@ assistant = Agent(
 # .. start-##_Configuring_toolbox_retry_policy
 mcp_toolbox_with_retries = MCPToolBox(
     client_transport=mcp_client,
-    tool_filter=["get_user_session", "get_payslips"],
+    tool_filter=MCP_TOOLBOX_TOOL_FILTER,
     retry_policy=RetryPolicy(
         max_attempts=3,
         initial_retry_delay=0.25,
         max_retry_delay=2.0,
     ),
+)
+
+assistant = Agent(
+    llm=llm,
+    tools=[mcp_toolbox_with_retries]
 )
 # .. end-##_Configuring_toolbox_retry_policy
 from wayflowcore.agentspec import AgentSpecExporter # docs-skiprow
@@ -178,7 +186,7 @@ with authless_mcp_enabled():
 # .. end-##_Configuring_direct_tool_retry_policy
 
 assistant = Flow.from_steps([
-    ToolExecutionStep(name="mcp_tool_step", tool=mcp_tool)
+    ToolExecutionStep(name="mcp_tool_step", tool=mcp_tool_with_retries)
 ])
 # .. end-##_Connecting_a_flow_to_the_MCP_server
 from wayflowcore.agentspec import AgentSpecExporter, AgentSpecLoader # docs-skiprow

--- a/docs/wayflowcore/source/core/howtoguides/howto_mcp.rst
+++ b/docs/wayflowcore/source/core/howtoguides/howto_mcp.rst
@@ -106,6 +106,31 @@ Here you will use the toolbox (see the section on Flows to see how to use the ``
 Specify the :ref:`transport <clienttransport>` to use to handle the connection to the server and create the toolbox.
 You can then equip an agent with the toolbox similarly to tools.
 
+If the MCP server composes tools from external MCP servers and can temporarily
+return a partial tool list during health or remount events, declare the expected
+tools with ``tool_filter`` and configure ``retry_policy``.
+When an expected tool is missing from a successful ``list_tools`` response,
+WayFlow retries the tool-list resolution before failing. The same policy is
+propagated to generated ``MCPTool`` instances for transient tool execution
+failures.
+
+.. literalinclude:: ../code_examples/howto_mcp.py
+    :language: python
+    :start-after: # .. start-##_Configuring_toolbox_retry_policy
+    :end-before: # .. end-##_Configuring_toolbox_retry_policy
+
+.. note::
+   Tool-list missing-tool retry only applies when WayFlow knows which tools are
+   expected, for example through ``tool_filter`` or a direct ``MCPTool(name=...)``.
+   If ``tool_filter`` is ``None``, WayFlow cannot determine whether a successful
+   tool-list response is incomplete.
+
+.. note::
+   The MCP tool retry policy is separate from transport-level retry. It handles
+   successful tool-list responses that are missing expected tools and transient
+   tool execution failures. Configure ``retry_policy`` on the transport when you
+   need lower-level HTTP client retry or request timeout behavior.
+
 .. note::
    ``authless_mcp_enabled()`` disables authorization for local/testing only—do not use in production.
    Keep it scoped around the code that creates MCP tools or toolboxes.
@@ -153,6 +178,13 @@ Create the flow using the MCP tool:
 Here you specify the client transport as with the MCP ToolBox, as well as the name of the specific tool
 you want to use. Additionally, you can override the tool description (exposed by the MCP server) by
 specifying the ``description`` parameter.
+You can also pass ``retry_policy`` to retry direct tool resolution and transient
+tool execution failures.
+
+.. literalinclude:: ../code_examples/howto_mcp.py
+    :language: python
+    :start-after: # .. start-##_Configuring_direct_tool_retry_policy
+    :end-before: # .. end-##_Configuring_direct_tool_retry_policy
 
 .. tip::
 

--- a/wayflowcore/src/wayflowcore/agentserver/openairesponses/services/_wayflowconversion.py
+++ b/wayflowcore/src/wayflowcore/agentserver/openairesponses/services/_wayflowconversion.py
@@ -74,12 +74,16 @@ class _TokenCounterListener(EventListener):
 
 
 class _TextStreamingListener(EventListener):
-    """Listener that catches all the text generation wayflow events and enqueues openai responses events for the server to yield"""
+    """Convert Wayflow message stream events into OpenAI Responses text events."""
 
     def __init__(self, queue: MemoryObjectSendStream[ResponseStreamEvent]) -> None:
         self.queue = queue
         self.counter = 0
         self.current_item_id = ""
+        # Track visible text output items so internal tool-only streams do not
+        # create empty OpenAI items and fallback text is not emitted twice.
+        self.current_output_item_is_open = False
+        self.streamed_text_outputs: List[str] = []
 
     def _enqueue(self, content: Any) -> None:
         try:
@@ -89,73 +93,157 @@ class _TextStreamingListener(EventListener):
             # buffer full
             logger.warning("Async event queue is full, dropping an event: %s", content)
 
+    def _start_output_item(self, initial_text: str = "") -> None:
+        """Open the current Responses output item once there is visible text to expose."""
+        if self.current_output_item_is_open:
+            return
+        self.current_output_item_is_open = True
+        self._enqueue(
+            ResponseOutputItemAddedEvent(
+                output_index=0,
+                item=OutputMessage(
+                    content=[
+                        OutputTextContent(
+                            text=initial_text,
+                            type="output_text",
+                            annotations=[],
+                        )
+                    ],
+                    role="assistant",
+                    status="in_progress",
+                    id=self.current_item_id,
+                    type="message",
+                ),
+                sequence_number=0,
+                type="response.output_item.added",
+            )
+        )
+
+    def _stream_text_delta(self, text: str) -> None:
+        """Emit a text delta for the current output item, opening it lazily if needed."""
+        if not text:
+            return
+        self._start_output_item()
+        self._enqueue(
+            ResponseTextDeltaEvent(
+                content_index=0,
+                delta=text,
+                item_id=self.current_item_id,
+                logprobs=[],
+                output_index=0,
+                sequence_number=0,
+                type="response.output_text.delta",
+            )
+        )
+
+    def _complete_output_item(self, text: str) -> None:
+        """Finalize the current text output item and remember what was streamed."""
+        self._enqueue(
+            ResponseTextDoneEvent(
+                content_index=0,
+                item_id=self.current_item_id,
+                logprobs=[],
+                output_index=0,
+                sequence_number=0,
+                text=text,
+                type="response.output_text.done",
+            )
+        )
+        self._enqueue(
+            ResponseOutputItemDoneEvent(
+                item=OutputMessage(
+                    content=[
+                        OutputTextContent(
+                            text=text,
+                            type="output_text",
+                            annotations=[],
+                        )
+                    ],
+                    role="assistant",
+                    status="completed",
+                    id=self.current_item_id,
+                    type="message",
+                ),
+                output_index=0,
+                sequence_number=0,
+                type="response.output_item.done",
+            )
+        )
+        self.streamed_text_outputs.append(text)
+
     def __call__(self, event: Event) -> None:
         if isinstance(event, ConversationMessageStreamChunkEvent):
-            self._enqueue(
-                ResponseTextDeltaEvent(
-                    content_index=0,
-                    delta=event.chunk,
-                    item_id=self.current_item_id,
-                    logprobs=[],
-                    output_index=0,
-                    sequence_number=0,
-                    type="response.output_text.delta",
-                )
-            )
+            self._stream_text_delta(event.chunk)
         elif isinstance(event, ConversationMessageStreamStartedEvent):
             self.current_item_id = IdGenerator.get_or_generate_id()
-            self._enqueue(
-                ResponseOutputItemAddedEvent(
-                    output_index=0,
-                    item=OutputMessage(
-                        content=[
-                            OutputTextContent(
-                                text=event.message.content,
-                                type="output_text",
-                                annotations=[],
-                            )
-                        ],
-                        role="assistant",
-                        status="in_progress",
-                        id=self.current_item_id,
-                        type="message",
-                    ),
-                    sequence_number=0,
-                    type="response.output_item.added",
-                )
-            )
+            self.current_output_item_is_open = False
+            # Some Wayflow stream spans are internal tool-call generations. Delay
+            # creating the OpenAI output item until we see user-visible text.
+            if event.message.content:
+                self._start_output_item(initial_text=event.message.content)
         elif isinstance(event, ConversationMessageStreamEndedEvent):
-            self._enqueue(
-                ResponseTextDoneEvent(
-                    content_index=0,
-                    item_id=self.current_item_id,
-                    logprobs=[],
-                    output_index=0,
-                    sequence_number=0,
-                    text=event.message.content,
-                    type="response.output_text.done",
-                )
-            )
-            self._enqueue(
-                ResponseOutputItemDoneEvent(
-                    item=OutputMessage(
-                        content=[
-                            OutputTextContent(
-                                text=event.message.content,
-                                type="output_text",
-                                annotations=[],
-                            )
-                        ],
-                        role="assistant",
-                        status="completed",
-                        id=self.current_item_id,
-                        type="message",
-                    ),
-                    output_index=0,
-                    sequence_number=0,
-                    type="response.output_item.done",
-                )
-            )
+            # Tool requests have no assistant text of their own. Internal tools
+            # like talk_to_user are converted to visible messages after the
+            # stream ends, so the service emits that final text separately.
+            if event.message.tool_requests is not None and not self.current_output_item_is_open:
+                return
+            final_text = event.message.content
+            if final_text and not self.current_output_item_is_open:
+                self._stream_text_delta(final_text)
+            if self.current_output_item_is_open:
+                self._complete_output_item(final_text)
+
+
+def _create_output_text_stream_events(
+    text: str, item_id: Optional[str] = None
+) -> List[ResponseStreamEvent]:
+    """Create a complete Responses text stream for text finalized outside LLM streaming."""
+    item_id = item_id or IdGenerator.get_or_generate_id()
+    item = OutputMessage(
+        content=[OutputTextContent(text=text, type="output_text", annotations=[])],
+        role="assistant",
+        status="completed",
+        id=item_id,
+        type="message",
+    )
+    return [
+        ResponseOutputItemAddedEvent(
+            output_index=0,
+            item=OutputMessage(
+                content=[OutputTextContent(text="", type="output_text", annotations=[])],
+                role="assistant",
+                status="in_progress",
+                id=item_id,
+                type="message",
+            ),
+            sequence_number=0,
+            type="response.output_item.added",
+        ),
+        ResponseTextDeltaEvent(
+            content_index=0,
+            delta=text,
+            item_id=item_id,
+            logprobs=[],
+            output_index=0,
+            sequence_number=0,
+            type="response.output_text.delta",
+        ),
+        ResponseTextDoneEvent(
+            content_index=0,
+            item_id=item_id,
+            logprobs=[],
+            output_index=0,
+            sequence_number=0,
+            text=text,
+            type="response.output_text.done",
+        ),
+        ResponseOutputItemDoneEvent(
+            item=item,
+            output_index=0,
+            sequence_number=0,
+            type="response.output_item.done",
+        ),
+    ]
 
 
 def _convert_wayflow_token_usage_into_oai_token_usage(token_usage: TokenUsage) -> ResponseUsage:

--- a/wayflowcore/src/wayflowcore/agentserver/openairesponses/services/wayflowservice.py
+++ b/wayflowcore/src/wayflowcore/agentserver/openairesponses/services/wayflowservice.py
@@ -21,7 +21,11 @@ from wayflowcore.conversationalcomponent import ConversationalComponent
 from wayflowcore.datastore import Datastore, InMemoryDatastore
 from wayflowcore.datastore._relational import RelationalDatastore
 from wayflowcore.events import register_event_listeners
-from wayflowcore.executors.executionstatus import ExecutionStatus, ToolRequestStatus
+from wayflowcore.executors.executionstatus import (
+    ExecutionStatus,
+    ToolRequestStatus,
+    UserMessageRequestStatus,
+)
 from wayflowcore.idgeneration import IdGenerator
 from wayflowcore.serialization import serialize
 
@@ -46,6 +50,7 @@ from ..models.openairesponsespydanticmodels import (
 from ._wayflowconversion import (
     _convert_tool_request_status_into_function_tool_call_items,
     _convert_wayflow_token_usage_into_oai_token_usage,
+    _create_output_text_stream_events,
     _create_response_args_from_wayflow_status,
     _get_conversation_new_input_messages,
     _TextStreamingListener,
@@ -275,6 +280,15 @@ class WayFlowOpenAIResponsesService(OpenAIResponsesService):
             raise raised_exception
 
         outputs, error = _create_response_args_from_wayflow_status(status)
+
+        if isinstance(status, UserMessageRequestStatus):
+            final_text = status.message.content
+            if final_text and final_text not in yielding_listener.streamed_text_outputs:
+                # The agent may produce the final user-visible response through
+                # the internal talk_to_user tool. That conversion happens after
+                # LLM streaming, so emit the completed text here for streaming clients.
+                for event in _create_output_text_stream_events(final_text):
+                    yield event
 
         if isinstance(status, ToolRequestStatus):
             for idx, item in enumerate(

--- a/wayflowcore/src/wayflowcore/agentspec/components/mcp.py
+++ b/wayflowcore/src/wayflowcore/agentspec/components/mcp.py
@@ -7,7 +7,6 @@
 from typing import List, Literal, Optional, Union
 
 from pyagentspec.mcp.clienttransport import ClientTransport, RemoteTransport, StdioTransport
-from pyagentspec.retrypolicy import RetryPolicy
 from pyagentspec.tools import ServerTool
 from pyagentspec.tools.tool import Tool
 from pydantic import ConfigDict, Field, SerializeAsAny
@@ -138,9 +137,6 @@ class PluginMCPTool(ServerTool):
     client_transport: SerializeAsAny[ClientTransport]
     """Transport to use for establishing and managing connections to the MCP server."""
 
-    retry_policy: Optional[RetryPolicy] = None
-    """Optional retry policy for MCP tool-list resolution and tool execution."""
-
 
 class PluginMCPToolBox(PluginToolBox):
     """
@@ -153,9 +149,6 @@ class PluginMCPToolBox(PluginToolBox):
 
     client_transport: SerializeAsAny[ClientTransport]
     """Transport to use for establishing and managing connections to the MCP server."""
-
-    retry_policy: Optional[RetryPolicy] = None
-    """Optional retry policy for MCP tool-list resolution and tool execution."""
 
     tool_filter: Optional[List[Union[PluginMCPToolSpec, str]]] = None
     """

--- a/wayflowcore/src/wayflowcore/agentspec/components/mcp.py
+++ b/wayflowcore/src/wayflowcore/agentspec/components/mcp.py
@@ -7,6 +7,7 @@
 from typing import List, Literal, Optional, Union
 
 from pyagentspec.mcp.clienttransport import ClientTransport, RemoteTransport, StdioTransport
+from pyagentspec.retrypolicy import RetryPolicy
 from pyagentspec.tools import ServerTool
 from pyagentspec.tools.tool import Tool
 from pydantic import ConfigDict, Field, SerializeAsAny
@@ -137,6 +138,9 @@ class PluginMCPTool(ServerTool):
     client_transport: SerializeAsAny[ClientTransport]
     """Transport to use for establishing and managing connections to the MCP server."""
 
+    retry_policy: Optional[RetryPolicy] = None
+    """Optional retry policy for MCP tool-list resolution and tool execution."""
+
 
 class PluginMCPToolBox(PluginToolBox):
     """
@@ -149,6 +153,9 @@ class PluginMCPToolBox(PluginToolBox):
 
     client_transport: SerializeAsAny[ClientTransport]
     """Transport to use for establishing and managing connections to the MCP server."""
+
+    retry_policy: Optional[RetryPolicy] = None
+    """Optional retry policy for MCP tool-list resolution and tool execution."""
 
     tool_filter: Optional[List[Union[PluginMCPToolSpec, str]]] = None
     """

--- a/wayflowcore/src/wayflowcore/exceptions.py
+++ b/wayflowcore/src/wayflowcore/exceptions.py
@@ -70,6 +70,20 @@ class MaxNumTrialsExceededException(ValueError):
 class NoSuchToolFoundOnMCPServerError(ValueError):
     """Error thrown when MCP server returns no tools with a given signature"""
 
+    def __init__(
+        self,
+        message: str,
+        missing_tool_names: list[str] | None = None,
+        expected_tool_names: list[str] | None = None,
+        exposed_tool_names: list[str] | None = None,
+        attempts: int | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.missing_tool_names = missing_tool_names or []
+        self.expected_tool_names = expected_tool_names or []
+        self.exposed_tool_names = exposed_tool_names or []
+        self.attempts = attempts
+
 
 class DataclassFieldDeserializationError(ValueError):
     """Error thrown when the deserialization of a field of a dataclass fails"""

--- a/wayflowcore/src/wayflowcore/mcp/mcphelpers.py
+++ b/wayflowcore/src/wayflowcore/mcp/mcphelpers.py
@@ -320,6 +320,8 @@ async def _invoke_mcp_tool_call_async(
     output_descriptors: List[Property],
     retry_policy: Optional[RetryPolicy] = None,
 ) -> Any:
+    """Call an MCP tool and apply retry policy to retryable execution failures."""
+
     async def operation() -> Any:
         with _catch_and_raise_mcp_connection_errors():
             result: types.CallToolResult = await session.call_tool(
@@ -344,6 +346,8 @@ async def _invoke_mcp_tool_call_async(
 
 
 def _is_missing_mcp_tool_error(exc: BaseException) -> bool:
+    """Return whether an MCP error means the requested tool is temporarily missing."""
+
     if not isinstance(exc, McpError):
         return False
 
@@ -354,10 +358,14 @@ def _is_missing_mcp_tool_error(exc: BaseException) -> bool:
 
 
 def _classify_mcp_tool_call_for_retry(exc: Exception, policy: RetryPolicy) -> RetryClassification:
+    """Classify MCP tool-call failures that are safe to retry under the policy."""
+
     retry_classification = _classify_http_exception_for_retry(exc, policy)
     if retry_classification is not None:
         return retry_classification
 
+    # MCP clients often wrap transport errors in domain exceptions, so inspect
+    # the whole exception chain before deciding the failure is not retryable.
     pending: List[BaseException] = [exc]
     seen: set[int] = set()
     while pending:
@@ -384,6 +392,8 @@ def _classify_mcp_tool_call_for_retry(exc: Exception, policy: RetryPolicy) -> Re
 
 
 async def _get_server_signatures_from_mcp_server(session: ClientSession) -> types.ListToolsResult:
+    """Fetch the raw MCP tool list from the server with connection errors normalized."""
+
     with _catch_and_raise_mcp_connection_errors():
         return await session.list_tools()
 
@@ -391,6 +401,8 @@ async def _get_server_signatures_from_mcp_server(session: ClientSession) -> type
 def _classify_missing_mcp_tool_for_retry(
     exc: Exception, policy: RetryPolicy
 ) -> RetryClassification:
+    """Retry only semantic MCP tool-list misses detected during validation."""
+
     if isinstance(exc, NoSuchToolFoundOnMCPServerError):
         return None, None
     return None
@@ -401,6 +413,8 @@ def _raise_if_expected_tools_missing(
     expected_signatures_by_name: Dict[str, Optional[Tool]],
     attempts: Optional[int],
 ) -> None:
+    """Raise with diagnostics if expected tools are absent from the MCP tool list."""
+
     expected_tool_names = list(expected_signatures_by_name or {})
     if not expected_tool_names:
         return
@@ -431,6 +445,8 @@ async def _get_validated_server_signatures_from_mcp_server(
     expected_signatures_by_name: Dict[str, Optional[Tool]],
     attempts: Optional[int],
 ) -> types.ListToolsResult:
+    """Fetch MCP tool signatures and validate that all expected tools are exposed."""
+
     remote_mcp_signature = await _get_server_signatures_from_mcp_server(session)
     _raise_if_expected_tools_missing(
         remote_mcp_signature,
@@ -445,7 +461,11 @@ async def _get_validated_server_signatures_with_retry(
     expected_signatures_by_name: Dict[str, Optional[Tool]],
     retry_policy: Optional[RetryPolicy],
 ) -> types.ListToolsResult:
+    """Fetch MCP tool signatures with semantic retry for missing expected tools."""
+
     if not expected_signatures_by_name or retry_policy is None:
+        # A partial list can only be identified when callers declare which tools
+        # they expect. For "list all tools", preserve the single-call behavior.
         return await _get_validated_server_signatures_from_mcp_server(
             session,
             expected_signatures_by_name,

--- a/wayflowcore/src/wayflowcore/mcp/mcphelpers.py
+++ b/wayflowcore/src/wayflowcore/mcp/mcphelpers.py
@@ -36,6 +36,7 @@ from mcp import types as types
 from mcp.server.fastmcp import Context
 from mcp.server.session import ServerSessionT
 from mcp.shared.context import LifespanContextT, RequestT
+from mcp.shared.exceptions import McpError
 
 from wayflowcore.events.event import ToolExecutionStreamingChunkReceivedEvent
 from wayflowcore.events.eventlistener import record_event
@@ -45,6 +46,14 @@ from wayflowcore.mcp._session_persistence import (
     get_mcp_async_runtime,
 )
 from wayflowcore.mcp.clienttransport import ClientTransport, ClientTransportWithAuth
+from wayflowcore.models._requesthelpers import (
+    RetryClassification,
+    _classify_http_exception_for_retry,
+    _get_http_headers_from_exception,
+    _get_http_status_code_from_exception,
+    _get_retry_after_value_from_headers,
+    execute_async_with_retry,
+)
 from wayflowcore.property import (
     DictProperty,
     JsonSchemaParam,
@@ -53,6 +62,7 @@ from wayflowcore.property import (
     Property,
     UnionProperty,
 )
+from wayflowcore.retrypolicy import RetryPolicy
 from wayflowcore.tools.servertools import ServerTool
 from wayflowcore.tools.tools import Tool
 from wayflowcore.tracing.span import ToolExecutionSpan, get_current_span
@@ -308,22 +318,157 @@ async def _invoke_mcp_tool_call_async(
     tool_name: str,
     tool_args: Dict[str, Any],
     output_descriptors: List[Property],
+    retry_policy: Optional[RetryPolicy] = None,
 ) -> Any:
-    with _catch_and_raise_mcp_connection_errors():
-        result: types.CallToolResult = await session.call_tool(
-            tool_name, tool_args, progress_callback=_mcp_progress_handler
-        )
+    async def operation() -> Any:
+        with _catch_and_raise_mcp_connection_errors():
+            result: types.CallToolResult = await session.call_tool(
+                tool_name, tool_args, progress_callback=_mcp_progress_handler
+            )
 
-        output = _try_handle_structured_content_from_tool_result(result, output_descriptors)
-        if output is not None:
-            return output
+            output = _try_handle_structured_content_from_tool_result(result, output_descriptors)
+            if output is not None:
+                return output
 
-        return _extract_text_content_from_tool_result(result)
+            return _extract_text_content_from_tool_result(result)
+
+    if retry_policy is None:
+        return await operation()
+
+    return await execute_async_with_retry(
+        operation,
+        retry_policy=retry_policy,
+        classify_exception=_classify_mcp_tool_call_for_retry,
+        retry_budget_exhausted_message="MCP tool execution retry budget exhausted",
+    )
+
+
+def _is_missing_mcp_tool_error(exc: BaseException) -> bool:
+    if not isinstance(exc, McpError):
+        return False
+
+    message = exc.error.message.lower()
+    return "tool" in message and (
+        "not found" in message or "unknown" in message or "does not exist" in message
+    )
+
+
+def _classify_mcp_tool_call_for_retry(exc: Exception, policy: RetryPolicy) -> RetryClassification:
+    retry_classification = _classify_http_exception_for_retry(exc, policy)
+    if retry_classification is not None:
+        return retry_classification
+
+    pending: List[BaseException] = [exc]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+
+        status_code = _get_http_status_code_from_exception(current)
+        if status_code == 404:
+            return status_code, _get_retry_after_value_from_headers(
+                _get_http_headers_from_exception(current)
+            )
+
+        if _is_missing_mcp_tool_error(current):
+            return None, None
+
+        if current.__context__ is not None:
+            pending.append(current.__context__)
+        if current.__cause__ is not None:
+            pending.append(current.__cause__)
+
+    return None
 
 
 async def _get_server_signatures_from_mcp_server(session: ClientSession) -> types.ListToolsResult:
     with _catch_and_raise_mcp_connection_errors():
         return await session.list_tools()
+
+
+def _classify_missing_mcp_tool_for_retry(
+    exc: Exception, policy: RetryPolicy
+) -> RetryClassification:
+    if isinstance(exc, NoSuchToolFoundOnMCPServerError):
+        return None, None
+    return None
+
+
+def _raise_if_expected_tools_missing(
+    remote_mcp_signature: types.ListToolsResult,
+    expected_signatures_by_name: Dict[str, Optional[Tool]],
+    attempts: Optional[int],
+) -> None:
+    expected_tool_names = list(expected_signatures_by_name or {})
+    if not expected_tool_names:
+        return
+
+    exposed_tool_names = sorted({exposed_tool.name for exposed_tool in remote_mcp_signature.tools})
+    exposed_tool_names_set = set(exposed_tool_names)
+    missing_tool_names = [
+        expected_tool_name
+        for expected_tool_name in expected_tool_names
+        if expected_tool_name not in exposed_tool_names_set
+    ]
+    if not missing_tool_names:
+        return
+
+    attempts_msg = f" after {attempts} tool-list attempt(s)" if attempts is not None else ""
+    raise NoSuchToolFoundOnMCPServerError(
+        f"Expected MCP tool(s) {missing_tool_names} but they were missing from the "
+        f"list of exposed tools{attempts_msg}. Exposed tools: {exposed_tool_names}",
+        missing_tool_names=missing_tool_names,
+        expected_tool_names=expected_tool_names,
+        exposed_tool_names=exposed_tool_names,
+        attempts=attempts,
+    )
+
+
+async def _get_validated_server_signatures_from_mcp_server(
+    session: ClientSession,
+    expected_signatures_by_name: Dict[str, Optional[Tool]],
+    attempts: Optional[int],
+) -> types.ListToolsResult:
+    remote_mcp_signature = await _get_server_signatures_from_mcp_server(session)
+    _raise_if_expected_tools_missing(
+        remote_mcp_signature,
+        expected_signatures_by_name,
+        attempts,
+    )
+    return remote_mcp_signature
+
+
+async def _get_validated_server_signatures_with_retry(
+    session: ClientSession,
+    expected_signatures_by_name: Dict[str, Optional[Tool]],
+    retry_policy: Optional[RetryPolicy],
+) -> types.ListToolsResult:
+    if not expected_signatures_by_name or retry_policy is None:
+        return await _get_validated_server_signatures_from_mcp_server(
+            session,
+            expected_signatures_by_name,
+            1 if expected_signatures_by_name else None,
+        )
+
+    attempts = 0
+
+    async def operation() -> types.ListToolsResult:
+        nonlocal attempts
+        attempts += 1
+        return await _get_validated_server_signatures_from_mcp_server(
+            session,
+            expected_signatures_by_name,
+            attempts,
+        )
+
+    return await execute_async_with_retry(
+        operation,
+        retry_policy=retry_policy,
+        classify_exception=_classify_missing_mcp_tool_for_retry,
+        retry_budget_exhausted_message="MCP tool-list resolution retry budget exhausted",
+    )
 
 
 def _try_convert_mcp_output_schema_to_properties(
@@ -386,29 +531,16 @@ async def get_server_tools_from_mcp_server(
     session: ClientSession,
     expected_signatures_by_name: Dict[str, Optional[Tool]],
     client_transport: ClientTransport,
+    retry_policy: Optional[RetryPolicy] = None,
 ) -> List[ServerTool]:
     from wayflowcore.mcp.tools import MCPTool
 
     processed_tool_signatures: List[ServerTool] = []
-    remote_mcp_signature = await _get_server_signatures_from_mcp_server(session)
-
-    if missing_tool_name := next(
-        (
-            expected_tool_name
-            for expected_tool_name in expected_signatures_by_name or {}
-            if expected_tool_name
-            not in (
-                exposed_tool_names := {
-                    exposed_tool.name for exposed_tool in remote_mcp_signature.tools
-                }
-            )
-        ),
-        None,
-    ):
-        raise NoSuchToolFoundOnMCPServerError(
-            f"Expected tool '{missing_tool_name}' but tool was missing from the list of exposed tools. "
-            f"Exposed tools: {exposed_tool_names}"
-        )
+    remote_mcp_signature = await _get_validated_server_signatures_with_retry(
+        session,
+        expected_signatures_by_name,
+        retry_policy,
+    )
 
     for exposed_tool in remote_mcp_signature.tools:
         exposed_tool_name = exposed_tool.name
@@ -478,18 +610,33 @@ async def get_server_tools_from_mcp_server(
                 client_transport=client_transport,
                 _validate_tool_exist_on_server=False,
                 requires_confirmation=requires_confirmation,
+                retry_policy=retry_policy,
             )
         )
     return processed_tool_signatures
 
 
 async def _get_tool_on_server(
-    session: ClientSession, name: str, client_transport: ClientTransport
+    session: ClientSession,
+    name: str,
+    client_transport: ClientTransport,
+    retry_policy: Optional[RetryPolicy] = None,
 ) -> Tool:
     try:
-        tools = await get_server_tools_from_mcp_server(session, {name: None}, client_transport)
+        tools = await get_server_tools_from_mcp_server(
+            session,
+            {name: None},
+            client_transport,
+            retry_policy=retry_policy,
+        )
     except NoSuchToolFoundOnMCPServerError as e:
-        tools = []
+        raise NoSuchToolFoundOnMCPServerError(
+            f"Cannot find a tool named {name} on the MCP server. {e}",
+            missing_tool_names=e.missing_tool_names,
+            expected_tool_names=e.expected_tool_names,
+            exposed_tool_names=e.exposed_tool_names,
+            attempts=e.attempts,
+        ) from e
     except Exception as e:
         raise ConnectionError(f"Cannot connect to the MCP server {client_transport}") from e
 

--- a/wayflowcore/src/wayflowcore/mcp/tools.py
+++ b/wayflowcore/src/wayflowcore/mcp/tools.py
@@ -50,8 +50,8 @@ class MCPTool(ServerTool, SerializableDataclassMixin, SerializableObject):
     Optional retry policy for MCP tool-list resolution and tool execution.
 
     For tool-list resolution, only the attempt and backoff fields of
-    :class:`RetryPolicy` are used. For tool execution, the retry policy is also
-    used to classify retryable HTTP errors.
+    ``RetryPolicy`` are used. For tool execution, the retry policy is also used
+    to classify retryable HTTP errors.
     """
 
     def __init__(
@@ -253,7 +253,7 @@ class MCPToolBox(ToolBox, DataclassComponent):
     Optional retry policy for MCP tool-list resolution and tool execution.
 
     For tool-list resolution, only the attempt and backoff fields of
-    :class:`RetryPolicy` are used. Generated ``MCPTool`` instances also use this
+    ``RetryPolicy`` are used. Generated ``MCPTool`` instances also use this
     policy while executing MCP tool calls.
     """
 

--- a/wayflowcore/src/wayflowcore/mcp/tools.py
+++ b/wayflowcore/src/wayflowcore/mcp/tools.py
@@ -22,6 +22,7 @@ from wayflowcore.mcp.mcphelpers import (
     get_server_tools_from_mcp_server,
 )
 from wayflowcore.property import Property
+from wayflowcore.retrypolicy import RetryPolicy
 from wayflowcore.serialization.context import DeserializationContext, SerializationContext
 from wayflowcore.serialization.serializer import SerializableDataclassMixin, SerializableObject
 from wayflowcore.tools.servertools import ServerTool
@@ -44,6 +45,15 @@ class MCPTool(ServerTool, SerializableDataclassMixin, SerializableObject):
     client_transport: ClientTransport
     """Transport to use for establishing and managing connections to the MCP server."""
 
+    retry_policy: Optional[RetryPolicy] = None
+    """
+    Optional retry policy for MCP tool-list resolution and tool execution.
+
+    For tool-list resolution, only the attempt and backoff fields of
+    :class:`RetryPolicy` are used. For tool execution, the retry policy is also
+    used to classify retryable HTTP errors.
+    """
+
     def __init__(
         self,
         name: str,
@@ -56,8 +66,12 @@ class MCPTool(ServerTool, SerializableDataclassMixin, SerializableObject):
         __metadata_info__: Optional[MetadataType] = None,
         id: Optional[str] = None,
         requires_confirmation: bool = False,
+        retry_policy: Optional[RetryPolicy] = None,
     ):
         self.client_transport = client_transport
+        self.retry_policy = retry_policy
+        if self.retry_policy is not None and not isinstance(self.retry_policy, RetryPolicy):
+            raise TypeError("retry_policy must be a wayflowcore.retrypolicy.RetryPolicy instance")
         _validate_auth(self.client_transport)
 
         should_validate_tool = _validate_server_exists and _validate_tool_exist_on_server
@@ -76,7 +90,13 @@ class MCPTool(ServerTool, SerializableDataclassMixin, SerializableObject):
 
         if should_validate_tool:
             # 2. Perform the call (from the portal)
-            tool = mcp_runtime.call(_get_tool_on_server, session, name, self.client_transport)
+            tool = mcp_runtime.call(
+                _get_tool_on_server,
+                session,
+                name,
+                self.client_transport,
+                self.retry_policy,
+            )
 
             if description is None:
                 description = tool.description
@@ -129,7 +149,12 @@ class MCPTool(ServerTool, SerializableDataclassMixin, SerializableObject):
         )
 
         return await mcp_runtime.call_async(
-            _invoke_mcp_tool_call_async, session, self.name, kwargs, self.output_descriptors
+            _invoke_mcp_tool_call_async,
+            session,
+            self.name,
+            kwargs,
+            self.output_descriptors,
+            self.retry_policy,
         )
 
     def run(self, *args: Any, **kwargs: Any) -> Any:
@@ -138,7 +163,12 @@ class MCPTool(ServerTool, SerializableDataclassMixin, SerializableObject):
         session = mcp_runtime.get_or_create_session(self.client_transport)
 
         return mcp_runtime.call(
-            _invoke_mcp_tool_call_async, session, self.name, kwargs, self.output_descriptors
+            _invoke_mcp_tool_call_async,
+            session,
+            self.name,
+            kwargs,
+            self.output_descriptors,
+            self.retry_policy,
         )
 
     def _serialize_to_dict(self, serialization_context: "SerializationContext") -> Dict[str, Any]:
@@ -153,6 +183,7 @@ class MCPTool(ServerTool, SerializableDataclassMixin, SerializableObject):
                 "output_descriptors",
                 "client_transport",
                 "requires_confirmation",
+                "retry_policy",
             ]
         }
 
@@ -162,19 +193,22 @@ class MCPTool(ServerTool, SerializableDataclassMixin, SerializableObject):
     ) -> "SerializableObject":
         from wayflowcore.serialization.serializer import autodeserialize_any_from_dict
 
+        field_names = [
+            "name",
+            "description",
+            "input_descriptors",
+            "output_descriptors",
+            "client_transport",
+            "requires_confirmation",
+            "retry_policy",
+        ]
         return MCPTool(
             **{
                 attr_name: autodeserialize_any_from_dict(
                     input_dict[attr_name], deserialization_context
                 )
-                for attr_name in [
-                    "name",
-                    "description",
-                    "input_descriptors",
-                    "output_descriptors",
-                    "client_transport",
-                    "requires_confirmation",
-                ]
+                for attr_name in field_names
+                if attr_name in input_dict
             },
             # deserialization should not require to be able to reach the server
             _validate_server_exists=False,
@@ -214,9 +248,20 @@ class MCPToolBox(ToolBox, DataclassComponent):
         * Input descriptors can be provided with description of each input. The names and types should match the remote tool schema.
     """
 
+    retry_policy: Optional[RetryPolicy] = None
+    """
+    Optional retry policy for MCP tool-list resolution and tool execution.
+
+    For tool-list resolution, only the attempt and backoff fields of
+    :class:`RetryPolicy` are used. Generated ``MCPTool`` instances also use this
+    policy while executing MCP tool calls.
+    """
+
     _validate_mcp_client_transport: InitVar[bool] = field(default=True, compare=False)
 
     def __post_init__(self, _validate_mcp_client_transport: bool) -> None:
+        if self.retry_policy is not None and not isinstance(self.retry_policy, RetryPolicy):
+            raise TypeError("retry_policy must be a wayflowcore.retrypolicy.RetryPolicy instance")
         if _validate_mcp_client_transport:
             _validate_auth(self.client_transport)
 
@@ -236,6 +281,7 @@ class MCPToolBox(ToolBox, DataclassComponent):
             session=session,
             expected_signatures_by_name=expected_signatures_by_name,
             client_transport=self.client_transport,
+            retry_policy=self.retry_policy,
         )
 
     async def _get_tools_inner_async(self) -> Sequence[ServerTool]:

--- a/wayflowcore/src/wayflowcore/serialization/_builtins_deserialization_plugin.py
+++ b/wayflowcore/src/wayflowcore/serialization/_builtins_deserialization_plugin.py
@@ -719,6 +719,9 @@ class WayflowBuiltinsDeserializationPlugin(WayflowDeserializationPlugin):
                 id=agentspec_component.id,
                 _validate_server_exists=False,
                 _validate_tool_exist_on_server=False,
+                retry_policy=self._convert_retry_policy_to_runtime(
+                    getattr(agentspec_component, "retry_policy", None)
+                ),
             )
         elif isinstance(agentspec_component, AgentSpecPluginConstantValuesNode):
             # Map PluginConstantValuesNode -> RuntimeConstantValuesStep
@@ -1740,6 +1743,9 @@ class WayflowBuiltinsDeserializationPlugin(WayflowDeserializationPlugin):
                 tool_filter=tool_filter,
                 **self._get_component_arguments(agentspec_component),
                 requires_confirmation=agentspec_component.requires_confirmation,
+                retry_policy=self._convert_retry_policy_to_runtime(
+                    getattr(agentspec_component, "retry_policy", None)
+                ),
             )
         elif isinstance(agentspec_component, AgentSpecAgentNode):
             return RuntimeAgentExecutionStep(

--- a/wayflowcore/src/wayflowcore/serialization/_builtins_serialization_plugin.py
+++ b/wayflowcore/src/wayflowcore/serialization/_builtins_serialization_plugin.py
@@ -178,6 +178,9 @@ from wayflowcore.agentspec.components.datastores.oracle_datastore import (
     PluginOracleDatabaseDatastore as AgentSpecPluginOracleDatabaseDatastore,
 )
 from wayflowcore.agentspec.components.flow import ExtendedFlow as AgentSpecExtendedFlow
+from wayflowcore.agentspec.components.mcp import PluginMCPTool as AgentSpecPluginMCPTool
+from wayflowcore.agentspec.components.mcp import PluginMCPToolBox as AgentSpecPluginMCPToolBox
+from wayflowcore.agentspec.components.mcp import PluginMCPToolSpec as AgentSpecPluginMCPToolSpec
 from wayflowcore.agentspec.components.mcp import (
     PluginSSEmTLSTransport as AgentSpecPluginSSEmTLSTransport,
 )
@@ -1526,7 +1529,7 @@ class WayflowBuiltinsSerializationPlugin(WayflowSerializationPlugin):
             )
         # other cases: mcpservertool, server, client tools
         if isinstance(runtime_tool, RuntimeMCPTool):
-            return AgentSpecMCPTool(
+            mcp_tool_kwargs = dict(
                 name=runtime_tool.name,
                 description=runtime_tool.description,
                 metadata=metadata,
@@ -1546,6 +1549,12 @@ class WayflowBuiltinsSerializationPlugin(WayflowSerializationPlugin):
                 requires_confirmation=runtime_tool.requires_confirmation,
                 id=runtime_tool.id,
             )
+            if runtime_tool.retry_policy is not None:
+                return AgentSpecPluginMCPTool(
+                    **mcp_tool_kwargs,
+                    retry_policy=self._retrypolicy_convert_to_agentspec(runtime_tool.retry_policy),
+                )
+            return AgentSpecMCPTool(**mcp_tool_kwargs)
         elif isinstance(runtime_tool, RuntimeServerTool):
             return AgentSpecServerTool(
                 name=runtime_tool.name,
@@ -1992,21 +2001,26 @@ class WayflowBuiltinsSerializationPlugin(WayflowSerializationPlugin):
         conversion_context: "WayflowToAgentSpecConversionContext",
         runtime_mcptoolspec: RuntimeTool,
         referenced_objects: Optional[Dict[str, Any]] = None,
-    ) -> AgentSpecMCPToolSpec:
+        use_plugin_model: bool = False,
+    ) -> Union[AgentSpecMCPToolSpec, AgentSpecPluginMCPToolSpec]:
 
-        return AgentSpecMCPToolSpec(
-            name=runtime_mcptoolspec.name,
-            description=runtime_mcptoolspec.description,
-            inputs=[
-                _runtime_property_to_pyagentspec_property(input_)
-                for input_ in runtime_mcptoolspec.input_descriptors or []
-            ],
-            outputs=[
-                _runtime_property_to_pyagentspec_property(output)
-                for output in runtime_mcptoolspec.output_descriptors or []
-            ],
-            requires_confirmation=runtime_mcptoolspec.requires_confirmation,
-            metadata=_create_agentspec_metadata_from_runtime_component(runtime_mcptoolspec),
+        agentspec_model = AgentSpecPluginMCPToolSpec if use_plugin_model else AgentSpecMCPToolSpec
+        return cast(
+            Union[AgentSpecMCPToolSpec, AgentSpecPluginMCPToolSpec],
+            agentspec_model(
+                name=runtime_mcptoolspec.name,
+                description=runtime_mcptoolspec.description,
+                inputs=[
+                    _runtime_property_to_pyagentspec_property(input_)
+                    for input_ in runtime_mcptoolspec.input_descriptors or []
+                ],
+                outputs=[
+                    _runtime_property_to_pyagentspec_property(output)
+                    for output in runtime_mcptoolspec.output_descriptors or []
+                ],
+                requires_confirmation=runtime_mcptoolspec.requires_confirmation,
+                metadata=_create_agentspec_metadata_from_runtime_component(runtime_mcptoolspec),
+            ),
         )
 
     def _toolbox_convert_to_agentspec(
@@ -2016,13 +2030,17 @@ class WayflowBuiltinsSerializationPlugin(WayflowSerializationPlugin):
         referenced_objects: Optional[Dict[str, Any]] = None,
     ) -> AgentSpecToolBox:
         if isinstance(runtime_toolbox, RuntimeMCPToolBox):
+            use_plugin_model = runtime_toolbox.retry_policy is not None
             tool_filter = (
                 [
                     (
                         tool_
                         if isinstance(tool_, str)
                         else self._mcptoolspec_convert_to_agentspec(
-                            conversion_context, tool_, referenced_objects
+                            conversion_context,
+                            tool_,
+                            referenced_objects,
+                            use_plugin_model=use_plugin_model,
                         )
                     )
                     for tool_ in runtime_toolbox.tool_filter
@@ -2030,7 +2048,7 @@ class WayflowBuiltinsSerializationPlugin(WayflowSerializationPlugin):
                 if runtime_toolbox.tool_filter is not None
                 else None
             )
-            return AgentSpecMCPToolBox(
+            mcp_toolbox_kwargs = dict(
                 name=runtime_toolbox.name,
                 client_transport=self._mcp_clienttransport_convert_to_agentspec(
                     conversion_context,
@@ -2042,6 +2060,14 @@ class WayflowBuiltinsSerializationPlugin(WayflowSerializationPlugin):
                 description=runtime_toolbox.description,
                 requires_confirmation=runtime_toolbox.requires_confirmation or False,
             )
+            if runtime_toolbox.retry_policy is not None:
+                return AgentSpecPluginMCPToolBox(
+                    **mcp_toolbox_kwargs,
+                    retry_policy=self._retrypolicy_convert_to_agentspec(
+                        runtime_toolbox.retry_policy
+                    ),
+                )
+            return AgentSpecMCPToolBox(**mcp_toolbox_kwargs)
         if isinstance(runtime_toolbox, RuntimeSearchToolBox):
             return AgentSpecPluginSearchToolBox(
                 name=runtime_toolbox.name,

--- a/wayflowcore/src/wayflowcore/serialization/_builtins_serialization_plugin.py
+++ b/wayflowcore/src/wayflowcore/serialization/_builtins_serialization_plugin.py
@@ -178,8 +178,6 @@ from wayflowcore.agentspec.components.datastores.oracle_datastore import (
     PluginOracleDatabaseDatastore as AgentSpecPluginOracleDatabaseDatastore,
 )
 from wayflowcore.agentspec.components.flow import ExtendedFlow as AgentSpecExtendedFlow
-from wayflowcore.agentspec.components.mcp import PluginMCPTool as AgentSpecPluginMCPTool
-from wayflowcore.agentspec.components.mcp import PluginMCPToolBox as AgentSpecPluginMCPToolBox
 from wayflowcore.agentspec.components.mcp import PluginMCPToolSpec as AgentSpecPluginMCPToolSpec
 from wayflowcore.agentspec.components.mcp import (
     PluginSSEmTLSTransport as AgentSpecPluginSSEmTLSTransport,
@@ -1547,13 +1545,13 @@ class WayflowBuiltinsSerializationPlugin(WayflowSerializationPlugin):
                     referenced_objects,
                 ),
                 requires_confirmation=runtime_tool.requires_confirmation,
+                retry_policy=(
+                    self._retrypolicy_convert_to_agentspec(runtime_tool.retry_policy)
+                    if runtime_tool.retry_policy is not None
+                    else None
+                ),
                 id=runtime_tool.id,
             )
-            if runtime_tool.retry_policy is not None:
-                return AgentSpecPluginMCPTool(
-                    **mcp_tool_kwargs,
-                    retry_policy=self._retrypolicy_convert_to_agentspec(runtime_tool.retry_policy),
-                )
             return AgentSpecMCPTool(**mcp_tool_kwargs)
         elif isinstance(runtime_tool, RuntimeServerTool):
             return AgentSpecServerTool(
@@ -2030,7 +2028,6 @@ class WayflowBuiltinsSerializationPlugin(WayflowSerializationPlugin):
         referenced_objects: Optional[Dict[str, Any]] = None,
     ) -> AgentSpecToolBox:
         if isinstance(runtime_toolbox, RuntimeMCPToolBox):
-            use_plugin_model = runtime_toolbox.retry_policy is not None
             tool_filter = (
                 [
                     (
@@ -2040,7 +2037,6 @@ class WayflowBuiltinsSerializationPlugin(WayflowSerializationPlugin):
                             conversion_context,
                             tool_,
                             referenced_objects,
-                            use_plugin_model=use_plugin_model,
                         )
                     )
                     for tool_ in runtime_toolbox.tool_filter
@@ -2059,14 +2055,12 @@ class WayflowBuiltinsSerializationPlugin(WayflowSerializationPlugin):
                 id=runtime_toolbox.id,
                 description=runtime_toolbox.description,
                 requires_confirmation=runtime_toolbox.requires_confirmation or False,
+                retry_policy=(
+                    self._retrypolicy_convert_to_agentspec(runtime_toolbox.retry_policy)
+                    if runtime_toolbox.retry_policy is not None
+                    else None
+                ),
             )
-            if runtime_toolbox.retry_policy is not None:
-                return AgentSpecPluginMCPToolBox(
-                    **mcp_toolbox_kwargs,
-                    retry_policy=self._retrypolicy_convert_to_agentspec(
-                        runtime_toolbox.retry_policy
-                    ),
-                )
             return AgentSpecMCPToolBox(**mcp_toolbox_kwargs)
         if isinstance(runtime_toolbox, RuntimeSearchToolBox):
             return AgentSpecPluginSearchToolBox(

--- a/wayflowcore/tests/agentserver/test_wayflow_server.py
+++ b/wayflowcore/tests/agentserver/test_wayflow_server.py
@@ -8,13 +8,22 @@ import json
 from pathlib import Path
 from typing import Any, Dict, Union
 
+import anyio
 import httpx
 import pytest
 
+from wayflowcore.agentserver.openairesponses.services._wayflowconversion import (
+    _create_output_text_stream_events,
+    _TextStreamingListener,
+)
+from wayflowcore.events.event import (
+    ConversationMessageStreamEndedEvent,
+    ConversationMessageStreamStartedEvent,
+)
 from wayflowcore.messagelist import Message, MessageType
 from wayflowcore.models import OpenAIAPIType, OpenAICompatibleModel, StreamChunkType
 from wayflowcore.models.llmmodel import LlmCompletion, Prompt
-from wayflowcore.tools import ToolResult
+from wayflowcore.tools import ToolRequest, ToolResult
 
 from ..testhelpers.testhelpers import retry_test
 from .conftest import _get_api_key_headers, get_all_server_fixtures_name
@@ -582,11 +591,64 @@ def _stream_request_and_return_output(
 
     response = response_completed[0].get("response")
 
+    # Validate deltas against the full event stream; response.completed only
+    # carries the final response object and cannot contain text delta events.
     deltas = [
-        e.get("delta") for e in response_completed if e.get("type") == "response.output_text.delta"
+        e.get("delta") for e in non_empty_events if e.get("type") == "response.output_text.delta"
     ]
     assert all(d in str(response) for d in deltas)
     return response
+
+
+async def _collect_text_streaming_listener_events(events):
+    send_stream, receive_stream = anyio.create_memory_object_stream(100)
+    try:
+        listener = _TextStreamingListener(queue=send_stream)
+        for event in events:
+            listener(event)
+        await send_stream.aclose()
+        return [event async for event in receive_stream]
+    finally:
+        await receive_stream.aclose()
+
+
+@pytest.mark.anyio
+async def test_text_streaming_listener_ignores_internal_tool_request_streams() -> None:
+    events = await _collect_text_streaming_listener_events(
+        [
+            ConversationMessageStreamStartedEvent(
+                message=Message(content="", message_type=MessageType.AGENT)
+            ),
+            ConversationMessageStreamEndedEvent(
+                message=Message(
+                    content="",
+                    message_type=MessageType.TOOL_REQUEST,
+                    tool_requests=[
+                        ToolRequest(
+                            name="talk_to_user",
+                            args={"text": "Visible response"},
+                            tool_request_id="call_1",
+                        )
+                    ],
+                )
+            ),
+        ],
+    )
+
+    assert events == []
+
+
+def test_create_output_text_stream_events_emits_visible_text_delta() -> None:
+    events = _create_output_text_stream_events("Visible response", item_id="item_1")
+
+    assert [event.type for event in events] == [
+        "response.output_item.added",
+        "response.output_text.delta",
+        "response.output_text.done",
+        "response.output_item.done",
+    ]
+    assert events[1].delta == "Visible response"
+    assert events[2].text == "Visible response"
 
 
 @retry_test(max_attempts=10)  # not uniform

--- a/wayflowcore/tests/agentspec/test_mcptool.py
+++ b/wayflowcore/tests/agentspec/test_mcptool.py
@@ -4,6 +4,7 @@
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 import json
+import warnings
 
 import pytest
 from pyagentspec.adapters._agentspecloader import (
@@ -13,7 +14,11 @@ from pyagentspec.versioning import AgentSpecVersionEnum
 
 from wayflowcore import Agent
 from wayflowcore.agentspec import AgentSpecExporter, AgentSpecLoader
-from wayflowcore.agentspec.components.mcp import PluginMCPTool, PluginStdioTransport
+from wayflowcore.agentspec.components.mcp import (
+    PluginMCPTool,
+    PluginMCPToolBox,
+    PluginStdioTransport,
+)
 from wayflowcore.agentspec.runtimeloader import _DEFAULT_BLOCKED_COMPONENTS
 from wayflowcore.mcp import (
     MCPTool,
@@ -27,6 +32,7 @@ from wayflowcore.mcp import (
 )
 from wayflowcore.mcp._session_persistence import AsyncRuntime
 from wayflowcore.property import StringProperty
+from wayflowcore.retrypolicy import RetryPolicy
 from wayflowcore.warnings import SecurityWarning
 
 
@@ -98,6 +104,62 @@ def test_mcp_tool_can_be_converted_to_agentspec_and_back(
     assert len(all_agent_tools) == len(all_reloaded_agent_tools)
     for key, value in all_agent_tools.items():
         assert value == all_reloaded_agent_tools[key]
+
+
+def test_mcp_toolbox_retry_policy_exports_to_agentspec_plugin_and_round_trips() -> None:
+    toolbox = MCPToolBox(
+        client_transport=SSETransport(url="https://example.com/sse"),
+        tool_filter=["expected_tool"],
+        retry_policy=RetryPolicy(max_attempts=4),
+        _validate_mcp_client_transport=False,
+    )
+
+    with warnings.catch_warnings(record=True) as captured_warnings:
+        warnings.simplefilter("always")
+        agentspec_toolbox = AgentSpecExporter().to_component(toolbox)
+
+    assert not [warning for warning in captured_warnings if "retry_policy" in str(warning.message)]
+    assert isinstance(agentspec_toolbox, PluginMCPToolBox)
+    assert agentspec_toolbox.retry_policy is not None
+    assert agentspec_toolbox.retry_policy.max_attempts == 4
+
+    with pytest.warns(match="without authentication"):
+        with authless_mcp_enabled():
+            deserialized_toolbox = AgentSpecLoader().load_component(agentspec_toolbox)
+
+    assert isinstance(deserialized_toolbox, MCPToolBox)
+    assert deserialized_toolbox.retry_policy is not None
+    assert deserialized_toolbox.retry_policy.max_attempts == 4
+
+
+def test_mcp_tool_retry_policy_exports_to_agentspec_plugin_and_round_trips() -> None:
+    with pytest.warns(match="without authentication"):
+        with authless_mcp_enabled():
+            mcp_tool = MCPTool(
+                name="expected_tool",
+                description="Expected tool",
+                input_descriptors=[],
+                client_transport=SSETransport(url="https://example.com/sse"),
+                _validate_server_exists=False,
+                retry_policy=RetryPolicy(max_attempts=5),
+            )
+
+    with warnings.catch_warnings(record=True) as captured_warnings:
+        warnings.simplefilter("always")
+        agentspec_tool = AgentSpecExporter().to_component(mcp_tool)
+
+    assert not [warning for warning in captured_warnings if "retry_policy" in str(warning.message)]
+    assert isinstance(agentspec_tool, PluginMCPTool)
+    assert agentspec_tool.retry_policy is not None
+    assert agentspec_tool.retry_policy.max_attempts == 5
+
+    with pytest.warns(match="without authentication"):
+        with authless_mcp_enabled():
+            deserialized_tool = AgentSpecLoader().load_component(agentspec_tool)
+
+    assert isinstance(deserialized_tool, MCPTool)
+    assert deserialized_tool.retry_policy is not None
+    assert deserialized_tool.retry_policy.max_attempts == 5
 
 
 def _make_agent_with_mcp_stdio_transport(remotely_hosted_llm):

--- a/wayflowcore/tests/agentspec/test_mcptool.py
+++ b/wayflowcore/tests/agentspec/test_mcptool.py
@@ -10,15 +10,13 @@ import pytest
 from pyagentspec.adapters._agentspecloader import (
     _DEFAULT_BLOCKED_COMPONENTS as _AGENTSPEC_DEFAULT_BLOCKED_COMPONENTS,
 )
+from pyagentspec.mcp import MCPTool as AgentSpecMCPTool
+from pyagentspec.mcp import MCPToolBox as AgentSpecMCPToolBox
 from pyagentspec.versioning import AgentSpecVersionEnum
 
 from wayflowcore import Agent
 from wayflowcore.agentspec import AgentSpecExporter, AgentSpecLoader
-from wayflowcore.agentspec.components.mcp import (
-    PluginMCPTool,
-    PluginMCPToolBox,
-    PluginStdioTransport,
-)
+from wayflowcore.agentspec.components.mcp import PluginMCPTool, PluginStdioTransport
 from wayflowcore.agentspec.runtimeloader import _DEFAULT_BLOCKED_COMPONENTS
 from wayflowcore.mcp import (
     MCPTool,
@@ -106,7 +104,7 @@ def test_mcp_tool_can_be_converted_to_agentspec_and_back(
         assert value == all_reloaded_agent_tools[key]
 
 
-def test_mcp_toolbox_retry_policy_exports_to_agentspec_plugin_and_round_trips() -> None:
+def test_mcp_toolbox_retry_policy_exports_to_native_agentspec_and_round_trips() -> None:
     toolbox = MCPToolBox(
         client_transport=SSETransport(url="https://example.com/sse"),
         tool_filter=["expected_tool"],
@@ -119,7 +117,7 @@ def test_mcp_toolbox_retry_policy_exports_to_agentspec_plugin_and_round_trips() 
         agentspec_toolbox = AgentSpecExporter().to_component(toolbox)
 
     assert not [warning for warning in captured_warnings if "retry_policy" in str(warning.message)]
-    assert isinstance(agentspec_toolbox, PluginMCPToolBox)
+    assert isinstance(agentspec_toolbox, AgentSpecMCPToolBox)
     assert agentspec_toolbox.retry_policy is not None
     assert agentspec_toolbox.retry_policy.max_attempts == 4
 
@@ -132,7 +130,7 @@ def test_mcp_toolbox_retry_policy_exports_to_agentspec_plugin_and_round_trips() 
     assert deserialized_toolbox.retry_policy.max_attempts == 4
 
 
-def test_mcp_tool_retry_policy_exports_to_agentspec_plugin_and_round_trips() -> None:
+def test_mcp_tool_retry_policy_exports_to_native_agentspec_and_round_trips() -> None:
     with pytest.warns(match="without authentication"):
         with authless_mcp_enabled():
             mcp_tool = MCPTool(
@@ -149,7 +147,7 @@ def test_mcp_tool_retry_policy_exports_to_agentspec_plugin_and_round_trips() -> 
         agentspec_tool = AgentSpecExporter().to_component(mcp_tool)
 
     assert not [warning for warning in captured_warnings if "retry_policy" in str(warning.message)]
-    assert isinstance(agentspec_tool, PluginMCPTool)
+    assert isinstance(agentspec_tool, AgentSpecMCPTool)
     assert agentspec_tool.retry_policy is not None
     assert agentspec_tool.retry_policy.max_attempts == 5
 

--- a/wayflowcore/tests/mcptools/test_mcp_tools.py
+++ b/wayflowcore/tests/mcptools/test_mcp_tools.py
@@ -8,7 +8,7 @@ import logging
 import re
 import time
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Dict, Generator, List, Tuple, cast
+from typing import Any, Awaitable, Callable, Dict, Generator, List, Tuple, cast
 from unittest.mock import patch
 
 import anyio
@@ -49,7 +49,7 @@ from wayflowcore.mcp import (
 from wayflowcore.mcp._auth import headless_auth_flow_handler
 from wayflowcore.mcp._session_persistence import AsyncRuntime, get_mcp_async_runtime
 from wayflowcore.mcp.mcphelpers import (
-    _invoke_mcp_tool_call_async,
+    _classify_mcp_tool_call_for_retry,
     _reset_mcp_contextvar,
     get_server_tools_from_mcp_server,
     mcp_streaming_tool,
@@ -221,7 +221,7 @@ def run_toolbox_test(transport: ClientTransport) -> None:
     assert mcp_tool.input_descriptors == [IntegerProperty(name="a"), IntegerProperty(name="b")]
 
 
-def _mcp_tool_signature(name: str) -> mcp_types.Tool:
+def _make_mcp_tool_signature(name: str) -> mcp_types.Tool:
     return mcp_types.Tool(
         name=name,
         description=f"{name} description",
@@ -245,7 +245,7 @@ class _ListToolsSession:
         self.calls += 1
         return mcp_types.ListToolsResult(
             tools=[
-                _mcp_tool_signature(tool_name)
+                _make_mcp_tool_signature(tool_name)
                 for tool_name in self.tool_names_by_attempt[attempt_index]
             ]
         )
@@ -271,7 +271,26 @@ class _CallToolSession:
         return mcp_types.CallToolResult(content=[mcp_types.TextContent(type="text", text=outcome)])
 
 
-def _http_status_error(status_code: int) -> httpx.HTTPStatusError:
+class _RunAsyncRuntime:
+    """Test double for MCPTool.run_async runtime calls using a fixed session."""
+
+    def __init__(self, session: _CallToolSession) -> None:
+        self.session = session
+
+    def get_or_create_session(self, _transport: ClientTransport) -> object:
+        return self.session
+
+    async def call_async(
+        self,
+        async_fn: Callable[..., Awaitable[Any]],
+        /,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        return await async_fn(*args, **kwargs)
+
+
+def _make_http_status_error(status_code: int) -> httpx.HTTPStatusError:
     request = httpx.Request("POST", "https://mcp.example.com/mcp")
     response = httpx.Response(status_code, request=request)
     return httpx.HTTPStatusError(
@@ -281,7 +300,8 @@ def _http_status_error(status_code: int) -> httpx.HTTPStatusError:
     )
 
 
-def test_mcp_tool_list_resolution_retry_recovers_missing_expected_tool(with_mcp_enabled):
+@pytest.mark.anyio
+async def test_mcp_tool_list_resolution_retry_recovers_missing_expected_tool(with_mcp_enabled):
     session = _ListToolsSession([["b_tool", "c_tool"], ["a_tool", "b_tool", "c_tool"]])
     retry_policy = RetryPolicy(
         max_attempts=1,
@@ -291,8 +311,7 @@ def test_mcp_tool_list_resolution_retry_recovers_missing_expected_tool(with_mcp_
     )
 
     with authless_mcp_enabled():
-        tools = anyio.run(
-            get_server_tools_from_mcp_server,
+        tools = await get_server_tools_from_mcp_server(
             cast(ClientSession, session),
             {"a_tool": None},
             SSETransport(url="anything"),
@@ -304,7 +323,8 @@ def test_mcp_tool_list_resolution_retry_recovers_missing_expected_tool(with_mcp_
     assert cast(MCPTool, tools[0]).retry_policy is retry_policy
 
 
-def test_mcp_tool_list_resolution_retry_exhaustion_has_missing_tool_metadata(
+@pytest.mark.anyio
+async def test_mcp_tool_list_resolution_retry_exhaustion_has_missing_tool_metadata(
     with_mcp_enabled,
 ):
     session = _ListToolsSession([["b_tool", "c_tool"], ["b_tool", "c_tool"]])
@@ -316,8 +336,7 @@ def test_mcp_tool_list_resolution_retry_exhaustion_has_missing_tool_metadata(
     )
 
     with pytest.raises(NoSuchToolFoundOnMCPServerError) as exc_info:
-        anyio.run(
-            get_server_tools_from_mcp_server,
+        await get_server_tools_from_mcp_server(
             cast(ClientSession, session),
             {"a_tool": None},
             SSETransport(url="anything"),
@@ -331,7 +350,8 @@ def test_mcp_tool_list_resolution_retry_exhaustion_has_missing_tool_metadata(
     assert exc_info.value.attempts == 2
 
 
-def test_mcp_tool_list_resolution_does_not_retry_without_expected_tools(with_mcp_enabled):
+@pytest.mark.anyio
+async def test_mcp_tool_list_resolution_does_not_retry_without_expected_tools(with_mcp_enabled):
     session = _ListToolsSession([["b_tool"], ["a_tool", "b_tool"]])
     retry_policy = RetryPolicy(
         max_attempts=1,
@@ -341,8 +361,7 @@ def test_mcp_tool_list_resolution_does_not_retry_without_expected_tools(with_mcp
     )
 
     with authless_mcp_enabled():
-        tools = anyio.run(
-            get_server_tools_from_mcp_server,
+        tools = await get_server_tools_from_mcp_server(
             cast(ClientSession, session),
             {},
             SSETransport(url="anything"),
@@ -354,8 +373,11 @@ def test_mcp_tool_list_resolution_does_not_retry_without_expected_tools(with_mcp
     assert cast(MCPTool, tools[0]).retry_policy is retry_policy
 
 
-def test_mcp_tool_call_retry_recovers_from_transient_404() -> None:
-    session = _CallToolSession([_http_status_error(404), "tool result"])
+@pytest.mark.anyio
+async def test_mcp_tool_call_retry_recovers_from_transient_404(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _CallToolSession([_make_http_status_error(404), "tool result"])
     retry_policy = RetryPolicy(
         max_attempts=1,
         initial_retry_delay=0.001,
@@ -363,30 +385,102 @@ def test_mcp_tool_call_retry_recovers_from_transient_404() -> None:
         jitter=None,
     )
 
-    result = anyio.run(
-        _invoke_mcp_tool_call_async,
-        cast(ClientSession, session),
-        "a_tool",
-        {},
-        [StringProperty()],
-        retry_policy,
+    monkeypatch.setattr(
+        "wayflowcore.mcp.tools.get_mcp_async_runtime",
+        lambda: _RunAsyncRuntime(session),
     )
+
+    with pytest.warns(SecurityWarning, match="without authentication"):
+        with authless_mcp_enabled():
+            tool = MCPTool(
+                name="a_tool",
+                description="a_tool description",
+                input_descriptors=[],
+                output_descriptors=[StringProperty()],
+                client_transport=SSETransport(url="anything"),
+                _validate_server_exists=False,
+                retry_policy=retry_policy,
+            )
+
+    result = await tool.run_async()
 
     assert session.calls == 2
     assert result == "tool result"
 
 
-def test_mcp_tool_call_does_not_retry_without_retry_policy() -> None:
-    session = _CallToolSession([_http_status_error(404), "tool result"])
+@pytest.mark.anyio
+async def test_mcp_tool_call_passes_arguments_to_public_run_async(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _CallToolSession(["tool result"])
+    received_arguments: List[Dict[str, Any]] = []
+    original_call_tool = session.call_tool
+
+    async def call_tool_with_argument_capture(
+        name: str,
+        arguments: Dict[str, Any],
+        progress_callback: Any = None,
+    ) -> mcp_types.CallToolResult:
+        received_arguments.append(arguments)
+        return await original_call_tool(name, arguments, progress_callback)
+
+    session.call_tool = call_tool_with_argument_capture  # type: ignore[method-assign]
+
+    monkeypatch.setattr(
+        "wayflowcore.mcp.tools.get_mcp_async_runtime",
+        lambda: _RunAsyncRuntime(session),
+    )
+
+    with pytest.warns(SecurityWarning, match="without authentication"):
+        with authless_mcp_enabled():
+            tool = MCPTool(
+                name="a_tool",
+                description="a_tool description",
+                input_descriptors=[StringProperty(name="query")],
+                output_descriptors=[StringProperty()],
+                client_transport=SSETransport(url="anything"),
+                _validate_server_exists=False,
+                retry_policy=RetryPolicy(max_attempts=1),
+            )
+
+    result = await tool.run_async(query="hello")
+
+    assert result == "tool result"
+    assert received_arguments == [{"query": "hello"}]
+
+
+def test_mcp_tool_call_retry_classification_detects_wrapped_404() -> None:
+    retry_policy = RetryPolicy(max_attempts=1)
+    wrapped_error = RuntimeError("MCP call failed")
+    wrapped_error.__cause__ = _make_http_status_error(404)
+
+    assert _classify_mcp_tool_call_for_retry(wrapped_error, retry_policy) == (404, None)
+
+
+@pytest.mark.anyio
+async def test_mcp_tool_call_does_not_retry_without_retry_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _CallToolSession([_make_http_status_error(404), "tool result"])
+
+    monkeypatch.setattr(
+        "wayflowcore.mcp.tools.get_mcp_async_runtime",
+        lambda: _RunAsyncRuntime(session),
+    )
+
+    with pytest.warns(SecurityWarning, match="without authentication"):
+        with authless_mcp_enabled():
+            tool = MCPTool(
+                name="a_tool",
+                description="a_tool description",
+                input_descriptors=[],
+                output_descriptors=[StringProperty()],
+                client_transport=SSETransport(url="anything"),
+                _validate_server_exists=False,
+            )
 
     with pytest.raises(httpx.HTTPStatusError):
-        anyio.run(
-            _invoke_mcp_tool_call_async,
-            cast(ClientSession, session),
-            "a_tool",
-            {},
-            [StringProperty()],
-        )
+        await tool.run_async()
 
     assert session.calls == 1
 

--- a/wayflowcore/tests/mcptools/test_mcp_tools.py
+++ b/wayflowcore/tests/mcptools/test_mcp_tools.py
@@ -8,13 +8,15 @@ import logging
 import re
 import time
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Generator, List, Tuple, cast
+from typing import Any, Dict, Generator, List, Tuple, cast
 from unittest.mock import patch
 
 import anyio
 import httpx
 import pytest
 from anyio import to_thread
+from mcp import ClientSession
+from mcp import types as mcp_types
 
 from wayflowcore import Agent, Flow
 from wayflowcore.auth import AuthChallengeResult
@@ -22,6 +24,7 @@ from wayflowcore.controlconnection import ControlFlowEdge
 from wayflowcore.conversation import _register_conversation
 from wayflowcore.events.event import Event, ToolExecutionStreamingChunkReceivedEvent
 from wayflowcore.events.eventlistener import EventListener, register_event_listeners
+from wayflowcore.exceptions import NoSuchToolFoundOnMCPServerError
 from wayflowcore.executors._agentexecutor import AgentConversationExecutor
 from wayflowcore.executors.executionstatus import (
     AuthChallengeRequestStatus,
@@ -45,7 +48,12 @@ from wayflowcore.mcp import (
 )
 from wayflowcore.mcp._auth import headless_auth_flow_handler
 from wayflowcore.mcp._session_persistence import AsyncRuntime, get_mcp_async_runtime
-from wayflowcore.mcp.mcphelpers import _reset_mcp_contextvar, mcp_streaming_tool
+from wayflowcore.mcp.mcphelpers import (
+    _invoke_mcp_tool_call_async,
+    _reset_mcp_contextvar,
+    get_server_tools_from_mcp_server,
+    mcp_streaming_tool,
+)
 from wayflowcore.property import (
     AnyProperty,
     BooleanProperty,
@@ -56,6 +64,7 @@ from wayflowcore.property import (
     StringProperty,
     UnionProperty,
 )
+from wayflowcore.retrypolicy import RetryPolicy
 from wayflowcore.serialization import autodeserialize, serialize
 from wayflowcore.steps import MapStep, OutputMessageStep, ToolExecutionStep
 from wayflowcore.steps.flowexecutionstep import FlowExecutionStep
@@ -210,6 +219,218 @@ def run_toolbox_test(transport: ClientTransport) -> None:
     mcp_tool = next(t for t in tools if t.name == "fooza_tool")
     assert mcp_tool.run(a=1, b=2) == "7"
     assert mcp_tool.input_descriptors == [IntegerProperty(name="a"), IntegerProperty(name="b")]
+
+
+def _mcp_tool_signature(name: str) -> mcp_types.Tool:
+    return mcp_types.Tool(
+        name=name,
+        description=f"{name} description",
+        inputSchema={"type": "object", "properties": {}},
+    )
+
+
+class _ListToolsSession:
+    """Test double for ClientSession.list_tools with per-attempt tool snapshots.
+
+    This models an MCP server that can return a partial tool list on early calls
+    and a different tool set after retries.
+    """
+
+    def __init__(self, tool_names_by_attempt: List[List[str]]) -> None:
+        self.tool_names_by_attempt = tool_names_by_attempt
+        self.calls = 0
+
+    async def list_tools(self) -> mcp_types.ListToolsResult:
+        attempt_index = min(self.calls, len(self.tool_names_by_attempt) - 1)
+        self.calls += 1
+        return mcp_types.ListToolsResult(
+            tools=[
+                _mcp_tool_signature(tool_name)
+                for tool_name in self.tool_names_by_attempt[attempt_index]
+            ]
+        )
+
+
+class _CallToolSession:
+    """Test double for ClientSession.call_tool with per-attempt outcomes."""
+
+    def __init__(self, outcomes_by_attempt: List[Any]) -> None:
+        self.outcomes_by_attempt = outcomes_by_attempt
+        self.calls = 0
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: Dict[str, Any],
+        progress_callback: Any = None,
+    ) -> mcp_types.CallToolResult:
+        outcome = self.outcomes_by_attempt[self.calls]
+        self.calls += 1
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return mcp_types.CallToolResult(content=[mcp_types.TextContent(type="text", text=outcome)])
+
+
+def _http_status_error(status_code: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://mcp.example.com/mcp")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError(
+        f"HTTP status {status_code}",
+        request=request,
+        response=response,
+    )
+
+
+def test_mcp_tool_list_resolution_retry_recovers_missing_expected_tool(with_mcp_enabled):
+    session = _ListToolsSession([["b_tool", "c_tool"], ["a_tool", "b_tool", "c_tool"]])
+    retry_policy = RetryPolicy(
+        max_attempts=1,
+        initial_retry_delay=0.001,
+        max_retry_delay=0.001,
+        jitter=None,
+    )
+
+    with authless_mcp_enabled():
+        tools = anyio.run(
+            get_server_tools_from_mcp_server,
+            cast(ClientSession, session),
+            {"a_tool": None},
+            SSETransport(url="anything"),
+            retry_policy,
+        )
+
+    assert session.calls == 2
+    assert [tool.name for tool in tools] == ["a_tool"]
+    assert cast(MCPTool, tools[0]).retry_policy is retry_policy
+
+
+def test_mcp_tool_list_resolution_retry_exhaustion_has_missing_tool_metadata(
+    with_mcp_enabled,
+):
+    session = _ListToolsSession([["b_tool", "c_tool"], ["b_tool", "c_tool"]])
+    retry_policy = RetryPolicy(
+        max_attempts=1,
+        initial_retry_delay=0.001,
+        max_retry_delay=0.001,
+        jitter=None,
+    )
+
+    with pytest.raises(NoSuchToolFoundOnMCPServerError) as exc_info:
+        anyio.run(
+            get_server_tools_from_mcp_server,
+            cast(ClientSession, session),
+            {"a_tool": None},
+            SSETransport(url="anything"),
+            retry_policy,
+        )
+
+    assert session.calls == 2
+    assert exc_info.value.missing_tool_names == ["a_tool"]
+    assert exc_info.value.expected_tool_names == ["a_tool"]
+    assert exc_info.value.exposed_tool_names == ["b_tool", "c_tool"]
+    assert exc_info.value.attempts == 2
+
+
+def test_mcp_tool_list_resolution_does_not_retry_without_expected_tools(with_mcp_enabled):
+    session = _ListToolsSession([["b_tool"], ["a_tool", "b_tool"]])
+    retry_policy = RetryPolicy(
+        max_attempts=1,
+        initial_retry_delay=0.001,
+        max_retry_delay=0.001,
+        jitter=None,
+    )
+
+    with authless_mcp_enabled():
+        tools = anyio.run(
+            get_server_tools_from_mcp_server,
+            cast(ClientSession, session),
+            {},
+            SSETransport(url="anything"),
+            retry_policy,
+        )
+
+    assert session.calls == 1
+    assert [tool.name for tool in tools] == ["b_tool"]
+    assert cast(MCPTool, tools[0]).retry_policy is retry_policy
+
+
+def test_mcp_tool_call_retry_recovers_from_transient_404() -> None:
+    session = _CallToolSession([_http_status_error(404), "tool result"])
+    retry_policy = RetryPolicy(
+        max_attempts=1,
+        initial_retry_delay=0.001,
+        max_retry_delay=0.001,
+        jitter=None,
+    )
+
+    result = anyio.run(
+        _invoke_mcp_tool_call_async,
+        cast(ClientSession, session),
+        "a_tool",
+        {},
+        [StringProperty()],
+        retry_policy,
+    )
+
+    assert session.calls == 2
+    assert result == "tool result"
+
+
+def test_mcp_tool_call_does_not_retry_without_retry_policy() -> None:
+    session = _CallToolSession([_http_status_error(404), "tool result"])
+
+    with pytest.raises(httpx.HTTPStatusError):
+        anyio.run(
+            _invoke_mcp_tool_call_async,
+            cast(ClientSession, session),
+            "a_tool",
+            {},
+            [StringProperty()],
+        )
+
+    assert session.calls == 1
+
+
+def test_direct_mcp_tool_passes_retry_policy(
+    monkeypatch: pytest.MonkeyPatch,
+    with_mcp_enabled,
+) -> None:
+    retry_policy = RetryPolicy(max_attempts=3)
+
+    class FakeRuntime:
+        def get_or_create_session(self, transport: ClientTransport) -> object:
+            return object()
+
+        def call(self, async_fn, /, *args, **kwargs):
+            return anyio.run(async_fn, *args, **kwargs)
+
+    async def fake_get_tool_on_server(
+        session: ClientSession,
+        name: str,
+        client_transport: ClientTransport,
+        received_retry_policy: RetryPolicy | None = None,
+    ) -> Tool:
+        assert name == "a_tool"
+        assert received_retry_policy is retry_policy
+        return Tool(
+            name="a_tool",
+            description="a_tool description",
+            input_descriptors=[],
+            output_descriptors=[StringProperty()],
+        )
+
+    monkeypatch.setattr("wayflowcore.mcp.tools.get_mcp_async_runtime", lambda: FakeRuntime())
+    monkeypatch.setattr("wayflowcore.mcp.tools._get_tool_on_server", fake_get_tool_on_server)
+
+    with authless_mcp_enabled():
+        tool = MCPTool(
+            name="a_tool",
+            client_transport=SSETransport(url="anything"),
+            retry_policy=retry_policy,
+        )
+
+    assert tool.retry_policy is retry_policy
+    assert tool.name == "a_tool"
 
 
 @pytest.mark.parametrize(

--- a/wayflowcore/tests/serialization/test_tool_serialization.py
+++ b/wayflowcore/tests/serialization/test_tool_serialization.py
@@ -10,6 +10,7 @@ import pytest
 
 from wayflowcore.agent import Agent
 from wayflowcore.flow import Flow
+from wayflowcore.mcp import MCPTool, MCPToolBox, SSETransport, authless_mcp_enabled
 from wayflowcore.property import IntegerProperty, NullProperty, StringProperty, UnionProperty
 from wayflowcore.retrypolicy import RetryPolicy
 from wayflowcore.serialization import autodeserialize, deserialize, serialize
@@ -251,6 +252,44 @@ def test_remote_tool_retry_policy_round_trips(remote_tool):
     assert isinstance(deserialized_tool, RemoteTool)
     assert deserialized_tool.retry_policy is not None
     assert deserialized_tool.retry_policy.max_attempts == 4
+
+
+def test_mcp_toolbox_retry_policy_round_trips() -> None:
+    toolbox = MCPToolBox(
+        client_transport=SSETransport(url="https://example.com/sse"),
+        tool_filter=["expected_tool"],
+        retry_policy=RetryPolicy(max_attempts=4),
+        _validate_mcp_client_transport=False,
+    )
+
+    with pytest.warns(match="without authentication"):
+        with authless_mcp_enabled():
+            deserialized_toolbox = autodeserialize(serialize(toolbox))
+
+    assert isinstance(deserialized_toolbox, MCPToolBox)
+    assert deserialized_toolbox.retry_policy is not None
+    assert deserialized_toolbox.retry_policy.max_attempts == 4
+
+
+def test_mcp_tool_retry_policy_round_trips() -> None:
+    with pytest.warns(match="without authentication"):
+        with authless_mcp_enabled():
+            mcp_tool = MCPTool(
+                name="expected_tool",
+                description="Expected tool",
+                input_descriptors=[],
+                client_transport=SSETransport(url="https://example.com/sse"),
+                _validate_server_exists=False,
+                retry_policy=RetryPolicy(max_attempts=5),
+            )
+
+    with pytest.warns(match="without authentication"):
+        with authless_mcp_enabled():
+            deserialized_tool = autodeserialize(serialize(mcp_tool))
+
+    assert isinstance(deserialized_tool, MCPTool)
+    assert deserialized_tool.retry_policy is not None
+    assert deserialized_tool.retry_policy.max_attempts == 5
 
 
 def test_serialize_agent_with_remote_tools(remotely_hosted_llm, remote_tool):


### PR DESCRIPTION
https://github.com/oracle/wayflow/issues/161

Adds optional retry_policy support to MCPTool and MCPToolBox so clients can retry transient MCP tool resolution and execution failures.

This keeps the default behavior unchanged: no retry is performed unless a retry policy is explicitly configured. Missing-tool retries during list_tools() resolution only apply when WayFlow knows which tools are expected, such as through tool_filter or direct MCPTool(name=...).

Changes include:

- Add retry_policy: Optional[RetryPolicy] to MCPTool and MCPToolBox
- Retry expected-tool resolution when MCP list_tools() returns a partial response
- Retry transient MCP call_tool() execution failures, including tool-missing/404-style failures
