### PR TITLE
additionalProperties in ObjectProperty

### DIFF
--- a/docs/wayflowcore/source/core/changelog.rst
+++ b/docs/wayflowcore/source/core/changelog.rst
@@ -7,6 +7,12 @@ WayFlow |current_version|
 Improvements
 ^^^^^^^^^^^^
 
+* **Configurable additional object properties**
+
+  ``ObjectProperty`` now supports JSON Schema ``additionalProperties`` configuration.
+  Additional fields can be allowed, rejected, or validated with a property definition,
+  and the configuration is preserved when importing and exporting JSON Schema.
+
 * **Add support for Gemma-4 models with native tool-calling**
   :ref:`OpenAICompatibleModel <openaicompatiblemodel>` and :ref:`VllmModel <vllmmodel>`
   now support Gemma-4 models with native tool-calling.

--- a/wayflowcore/src/wayflowcore/property.py
+++ b/wayflowcore/src/wayflowcore/property.py
@@ -1019,12 +1019,14 @@ class ObjectProperty(Property):
             # https://platform.openai.com/docs/guides/structured-outputs#all-fields-must-be-required
             if self.additional_properties:
                 json_schema["additionalProperties"] = False
-                warnings.warn(
-                    "additionalProperties value different from False is not compatible "
-                    f"with OpenAI APIs; The value will be ignored.",
-                    UserWarning,
-                    stacklevel=2,
-                )
+                if isinstance(self.additional_properties, Property):
+                    # We don't warn if True because it's the default value
+                    warnings.warn(
+                        "additionalProperties are not compatible with OpenAI APIs; "
+                        f"The value will be ignored.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
             json_schema["required"] = list(json_schema["properties"].keys())
             for property_name, property_ in json_schema["properties"].items():
                 if "default" in property_:

--- a/wayflowcore/src/wayflowcore/property.py
+++ b/wayflowcore/src/wayflowcore/property.py
@@ -914,7 +914,7 @@ class ObjectProperty(Property):
         Dictionary of property names and their types. Defaults without any property.
     additional_properties:
         Boolean indicating if the object accepts arbitrary properties, or Property that defines which types
-        of additional properties are accepted.
+        of additional properties are accepted. Default is True.
     """
 
     properties: Dict[str, "Property"] = field(default_factory=dict)

--- a/wayflowcore/src/wayflowcore/property.py
+++ b/wayflowcore/src/wayflowcore/property.py
@@ -342,6 +342,8 @@ class Property(SerializableObject, ABC):
             return AnyProperty(**kwargs)
 
         if "properties" in schema:
+            # JSON Schema allows an object to define named fields and a rule for other fields.
+            additional_properties = schema.get("additionalProperties", True)
             return ObjectProperty(
                 **kwargs,
                 properties={
@@ -351,6 +353,14 @@ class Property(SerializableObject, ABC):
                     )
                     for param_name, param_schema in schema["properties"].items()
                 },
+                additional_properties=(
+                    Property.from_json_schema(
+                        schema=additional_properties,
+                        validate_default_type=validate_default_type,
+                    )
+                    if isinstance(additional_properties, dict)
+                    else additional_properties
+                ),
             )
 
         if "additionalProperties" in schema:
@@ -902,18 +912,46 @@ class ObjectProperty(Property):
               the flow can always execute properly with some defaults if needed.
     properties:
         Dictionary of property names and their types. Defaults without any property.
+    additional_properties:
+        Boolean indicating if the object accepts arbitrary properties, or Property that defines which types
+        of additional properties are accepted.
     """
 
     properties: Dict[str, "Property"] = field(default_factory=dict)
+    additional_properties: Union[bool, Property] = True
 
     def _is_value_of_expected_type(self, value: Any) -> bool:
-        return all(
+        known_properties_are_valid = all(
             (
                 self._check_dict_has_correct_entry(value, prop_name, property_)
                 if isinstance(value, dict)
                 else self._check_object_has_correct_attribute(value, prop_name, property_)
             )
             for prop_name, property_ in self.properties.items()
+        )
+        if not known_properties_are_valid:
+            return False
+
+        # Dictionaries have keys, while Python objects keep their instance attributes in __dict__.
+        # Values without either form have no additional properties to check.
+        all_values = (
+            value.items()
+            if isinstance(value, dict)
+            else vars(value).items() if hasattr(value, "__dict__") else ()
+        )
+        # Named properties were checked above. Only validate the remaining values here.
+        additional_values = (
+            property_value
+            for property_name, property_value in all_values
+            if property_name not in self.properties
+        )
+        if self.additional_properties is False:
+            return not any(True for _ in additional_values)
+        if self.additional_properties is True:
+            return True
+        return all(
+            self.additional_properties.is_value_of_expected_type(property_value)
+            for property_value in additional_values
         )
 
     @staticmethod
@@ -940,15 +978,35 @@ class ObjectProperty(Property):
 
         # if dict, we can try to validate or default each element
         new_dict = {}
+        for prop_name, property_value in value.items():
+            if prop_name in self.properties:
+                new_dict[prop_name] = self.properties[prop_name]._validate_or_return_default_value(
+                    property_value
+                )
+            elif self.additional_properties is True:
+                # Keep arbitrary extra values when they are explicitly allowed.
+                new_dict[prop_name] = property_value
+            elif isinstance(self.additional_properties, Property):
+                # Normalize extra values with the type configured for them.
+                new_dict[prop_name] = self.additional_properties._validate_or_return_default_value(
+                    property_value
+                )
+
         for prop_name, property_ in self.properties.items():
-            new_dict[prop_name] = property_._validate_or_return_default_value(
-                value.get(prop_name, None)
-            )
+            # If the property is not in the new dictionary we fallback to None, if the validation allows it
+            if prop_name not in new_dict:
+                new_dict[prop_name] = property_._validate_or_return_default_value(None)
         return new_dict
 
     def _type_to_json_schema(self, openai_compatible: bool = False) -> JsonSchemaParam:
         json_schema: JsonSchemaParam = {
             "type": "object",
+            # JSON Schema accepts either a boolean or a schema for unknown fields.
+            "additionalProperties": (
+                self.additional_properties.to_json_schema(openai_compatible=openai_compatible)
+                if isinstance(self.additional_properties, Property)
+                else self.additional_properties
+            ),
             "properties": {
                 prop_name: property_.to_json_schema(openai_compatible=openai_compatible)
                 for prop_name, property_ in self.properties.items()
@@ -959,7 +1017,14 @@ class ObjectProperty(Property):
             # as all properties to be included as required (parameters can be made optional by
             # creating a union with the NullProperty):
             # https://platform.openai.com/docs/guides/structured-outputs#all-fields-must-be-required
-            json_schema["additionalProperties"] = False
+            if self.additional_properties:
+                json_schema["additionalProperties"] = False
+                warnings.warn(
+                    "additionalProperties value different from False is not compatible "
+                    f"with OpenAI APIs; The value will be ignored.",
+                    UserWarning,
+                    stacklevel=2,
+                )
             json_schema["required"] = list(json_schema["properties"].keys())
             for property_name, property_ in json_schema["properties"].items():
                 if "default" in property_:

--- a/wayflowcore/src/wayflowcore/serialization/_builtins_serialization_plugin.py
+++ b/wayflowcore/src/wayflowcore/serialization/_builtins_serialization_plugin.py
@@ -612,10 +612,15 @@ def _json_schemas_have_same_type(
             ):
                 return False
     if "additionalProperties" in json_schema_a or "additionalProperties" in json_schema_b:
-        if not _json_schemas_have_same_type(
-            json_schema_a.get("additionalProperties", {}),
-            json_schema_b.get("additionalProperties", {}),
-        ):
+        json_schema_a_ap = json_schema_a.get("additionalProperties", {})
+        json_schema_b_ap = json_schema_b.get("additionalProperties", {})
+        # additionalProperties can be a dictionary containing another JSON schema or a boolean
+        # if both are dictionaries, we recursively check additionalProperties JSON schemas
+        if isinstance(json_schema_a_ap, dict) and isinstance(json_schema_b_ap, dict):
+            if not _json_schemas_have_same_type(json_schema_a_ap, json_schema_b_ap):
+                return False
+        elif json_schema_a_ap != json_schema_b_ap:
+            # if at least one of the two is not a dictionary, they must match exactly
             return False
     return True
 

--- a/wayflowcore/tests/integration/test_property.py
+++ b/wayflowcore/tests/integration/test_property.py
@@ -46,6 +46,7 @@ DESCRIPTIONS_AND_SCHEMAS = [
         ObjectProperty(properties={"some_field": IntegerProperty(description="some_description")}),
         {
             "type": "object",
+            "additionalProperties": True,
             "properties": {
                 "some_field": {
                     "type": "integer",
@@ -110,6 +111,7 @@ DESCRIPTIONS_AND_SCHEMAS = [
             "title": "some_struct",
             "description": "some_description",
             "type": "object",
+            "additionalProperties": True,
             "properties": {
                 "some_field": {
                     "type": "integer",
@@ -244,6 +246,91 @@ def test_mixed_enum_type_is_supported_nested():
     assert property_.is_value_of_expected_type("3") is True
     assert property_.is_value_of_expected_type(1) is True
     assert property_.is_value_of_expected_type(4) is False
+
+
+@pytest.mark.parametrize(
+    "additional_properties,value,is_valid",
+    [
+        (True, {"known": 1, "extra": "any value"}, True),
+        (False, {"known": 1, "extra": "not allowed"}, False),
+        (StringProperty(), {"known": 1, "extra": "valid"}, True),
+        (StringProperty(), {"known": 1, "extra": 1}, False),
+        (
+            ObjectProperty(properties={"a1": StringProperty(), "a2": IntegerProperty()}),
+            {"known": 1, "extra": {"a1": "hey", "a2": 1}},
+            True,
+        ),
+        (
+            ObjectProperty(properties={"a1": StringProperty(), "a2": IntegerProperty()}),
+            {"known": 1, "extra": {"a1": "hey", "a2": "no"}},
+            False,
+        ),
+        (
+            ListProperty(item_type=StringProperty()),
+            {"known": 1, "extra": ["h", "e", "l", "l", "o"]},
+            True,
+        ),
+        (
+            ListProperty(item_type=StringProperty()),
+            {"known": 1, "extra": [2, 1, 3]},
+            False,
+        ),
+        (
+            ListProperty(item_type=ListProperty(item_type=StringProperty())),
+            {"known": 1, "extra": [["h", "e"], ["l", "l", "o"]]},
+            True,
+        ),
+        (
+            ListProperty(item_type=ListProperty(item_type=StringProperty())),
+            {"known": 1, "extra": [[1], ["h", "e", "y"]]},
+            False,
+        ),
+        (
+            ObjectProperty(properties={"some_other_field": IntegerProperty()}),
+            {"known": 1, "extra": MyCustomObject(2)},
+            True,
+        ),
+    ],
+)
+def test_object_property_validates_additional_properties(additional_properties, value, is_valid):
+    property_ = ObjectProperty(
+        properties={"known": IntegerProperty()}, additional_properties=additional_properties
+    )
+    assert property_.is_value_of_expected_type(value) is is_valid
+
+
+@pytest.mark.parametrize(
+    "additional_properties,expected_schema",
+    [
+        (True, True),
+        (False, False),
+        (StringProperty(), {"type": "string"}),
+        (
+            ObjectProperty(
+                properties={"a1": StringProperty(), "a2": IntegerProperty()},
+                additional_properties=False,
+            ),
+            {
+                "type": "object",
+                "properties": {
+                    "a1": {"type": "string"},
+                    "a2": {"type": "integer"},
+                },
+                "additionalProperties": False,
+            },
+        ),
+    ],
+)
+def test_object_property_additional_properties_json_schema_round_trip(
+    additional_properties, expected_schema
+):
+    property_ = ObjectProperty(
+        properties={"known": IntegerProperty()}, additional_properties=additional_properties
+    )
+    schema = property_.to_json_schema()
+
+    assert schema["additionalProperties"] == expected_schema
+    assert Property.from_json_schema(schema) == property_
 
 
 def test_mixed_enum_type_is_supported():


### PR DESCRIPTION
JSON Schema additionalProperties support in ObjectProperty.

JSON schema has an attribute in the `object` type that is called `additionalProperties`. It defines whether properties that are not described in the JSON schema’s `properties` attribute are accepted (and optionally what types are accepted) or not. So far wayflow’s `ObjectProperty` was assuming `True` for this in the validation methods it implements. Some use cases require tighter control on this.