### PR TITLE
Add OCI embedding serving mode support

### DIFF
--- a/docs/wayflowcore/source/core/api/embeddingmodels.rst
+++ b/docs/wayflowcore/source/core/api/embeddingmodels.rst
@@ -36,6 +36,9 @@ OCI GenAI Embedding Models
 .. _ocigenaiembeddingmodel:
 .. autoclass:: wayflowcore.embeddingmodels.ocigenaimodel.OCIGenAIEmbeddingModel
 
+.. autoclass:: wayflowcore.models.ociclientconfig.ServingMode
+   :no-index:
+
 Ollama Embedding Models
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/wayflowcore/source/core/api/llmmodels.rst
+++ b/docs/wayflowcore/source/core/api/llmmodels.rst
@@ -119,7 +119,7 @@ OCI GenAI Models
 .. _ocigenaimodel:
 .. autoclass:: wayflowcore.models.ocigenaimodel.OCIGenAIModel
 
-.. autoclass:: wayflowcore.models.ocigenaimodel.ServingMode
+.. autoclass:: wayflowcore.models.ociclientconfig.ServingMode
 
 .. autoclass:: wayflowcore.models.ocigenaimodel.ModelProvider
 

--- a/docs/wayflowcore/source/core/changelog.rst
+++ b/docs/wayflowcore/source/core/changelog.rst
@@ -22,6 +22,12 @@ Improvements
   :ref:`OpenAICompatibleModel <openaicompatiblemodel>` and :ref:`VllmModel <vllmmodel>`
   now support Gemma-4 models with native tool-calling.
 
+* **OCI GenAI embedding serving modes**
+
+  :ref:`OCIGenAIEmbeddingModel <ocigenaiembeddingmodel>` now supports both on-demand
+  and dedicated OCI GenAI serving modes. Dedicated mode can be selected explicitly
+  or inferred on a best-effort basis from a dedicated GenAI endpoint OCID.
+
 WayFlow 26.1.2
 --------------
 

--- a/docs/wayflowcore/source/core/howtoguides/embeddingmodels_from_different_providers.rst
+++ b/docs/wayflowcore/source/core/howtoguides/embeddingmodels_from_different_providers.rst
@@ -60,6 +60,14 @@ OCI GenAI Embedding Model
   OCI client config to authenticate the OCI service.
   See the below examples and :ref:`ociclientconfigclassesforauthentication` for the usage and more information.
 
+.. option:: serving_mode: ServingMode, optional
+
+  The OCI serving mode. Use ``ServingMode.ON_DEMAND`` for a model name such as
+  ``cohere.embed-v4.0`` or ``ServingMode.DEDICATED`` for a dedicated GenAI
+  endpoint OCID. When omitted, WayFlow makes a best-effort attempt to infer
+  dedicated mode from a dedicated endpoint OCID and otherwise defaults to
+  on-demand mode.
+
 **Examples**
 
 .. literalinclude:: ../code_examples/example_initialize_embedding_models.py

--- a/wayflowcore/src/wayflowcore/agentspec/components/embeddingmodels.py
+++ b/wayflowcore/src/wayflowcore/agentspec/components/embeddingmodels.py
@@ -17,7 +17,7 @@ from wayflowcore.agentspec.components._pydantic_plugins import (
     PydanticComponentDeserializationPlugin,
     PydanticComponentSerializationPlugin,
 )
-from wayflowcore.models.ocigenaimodel import ServingMode
+from wayflowcore.models.ociclientconfig import ServingMode
 
 
 class PluginEmbeddingConfig(Component, abstract=True):

--- a/wayflowcore/src/wayflowcore/embeddingmodels/__init__.py
+++ b/wayflowcore/src/wayflowcore/embeddingmodels/__init__.py
@@ -4,6 +4,7 @@
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
+from ..models.ociclientconfig import ServingMode  # re-exported for user convenience
 from .embeddingmodel import EmbeddingModel
 from .ocigenaimodel import OCIGenAIEmbeddingModel
 from .ollamamodel import OllamaEmbeddingModel
@@ -14,6 +15,7 @@ from .vllmmodel import VllmEmbeddingModel
 __all__ = [
     "EmbeddingModel",
     "OCIGenAIEmbeddingModel",
+    "ServingMode",
     "OllamaEmbeddingModel",
     "OpenAICompatibleEmbeddingModel",
     "OpenAIEmbeddingModel",

--- a/wayflowcore/src/wayflowcore/embeddingmodels/ocigenaimodel.py
+++ b/wayflowcore/src/wayflowcore/embeddingmodels/ocigenaimodel.py
@@ -3,6 +3,7 @@
 # This software is under the Apache License 2.0
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
+import re
 import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 
@@ -14,7 +15,11 @@ from wayflowcore.models._requesthelpers import (
     _classify_oci_service_error_for_retry,
     execute_sync_with_retry,
 )
-from wayflowcore.models.ociclientconfig import OCIClientConfig, _client_config_to_oci_client_kwargs
+from wayflowcore.models.ociclientconfig import (
+    OCIClientConfig,
+    ServingMode,
+    _client_config_to_oci_client_kwargs,
+)
 from wayflowcore.retrypolicy import RetryPolicy
 from wayflowcore.serialization.context import DeserializationContext, SerializationContext
 from wayflowcore.serialization.serializer import (
@@ -31,6 +36,23 @@ else:
     oci = LazyLoader("oci")
 
 
+_OCID_RESOURCE_TYPE_RE = re.compile(r"^ocid\d+\.(?P<resource_type>[^.]+)\.")
+
+
+def _detect_serving_mode_from_model_id(model_id: str) -> ServingMode:
+    """Infer serving mode from an OCI GenAI embedding inference identifier.
+
+    Examples
+    --------
+    ``cohere.embed-v4.0`` -> ``ServingMode.ON_DEMAND``
+    ``ocid1.generativeaiendpoint.oc1...`` -> ``ServingMode.DEDICATED``
+    """
+    match = _OCID_RESOURCE_TYPE_RE.match(model_id)
+    if match and match.group("resource_type") == "generativeaiendpoint":
+        return ServingMode.DEDICATED
+    return ServingMode.ON_DEMAND
+
+
 class OCIGenAIEmbeddingModel(EmbeddingModel, SerializableObject):
     """Embedding model for Oracle OCI Generative AI service.
 
@@ -42,6 +64,10 @@ class OCIGenAIEmbeddingModel(EmbeddingModel, SerializableObject):
         OCI client configuration with authentication details.
     compartment_id:
         The compartment OCID
+    serving_mode:
+        OCI serving mode for the model. Either ``ServingMode.ON_DEMAND`` or
+        ``ServingMode.DEDICATED``. When set to None, a best-effort attempt is
+        made to auto-detect the serving mode based on the ``model_id``.
 
     Examples
     --------
@@ -103,6 +129,7 @@ class OCIGenAIEmbeddingModel(EmbeddingModel, SerializableObject):
         name: Optional[str] = None,
         description: Optional[str] = None,
         retry_policy: Optional[RetryPolicy] = None,
+        serving_mode: Optional[ServingMode] = None,
     ):
         super().__init__(
             __metadata_info__=__metadata_info__, id=id, name=name, description=description
@@ -150,6 +177,7 @@ class OCIGenAIEmbeddingModel(EmbeddingModel, SerializableObject):
             raise ValueError("Compartment id should not be ``None``.")
 
         self._model_id = model_id
+        self.serving_mode = serving_mode or _detect_serving_mode_from_model_id(model_id)
         self.retry_policy = retry_policy
 
         # The client is set in a lazy manner to prevent the model from crashing before being
@@ -175,12 +203,25 @@ class OCIGenAIEmbeddingModel(EmbeddingModel, SerializableObject):
         return self._lazy_client
 
     def embed(self, data: List[str]) -> List[List[float]]:
+        if self.serving_mode == ServingMode.ON_DEMAND:
+            serving_mode = oci.generative_ai_inference.models.OnDemandServingMode(
+                model_id=self._model_id
+            )
+        elif self.serving_mode == ServingMode.DEDICATED:
+            serving_mode = oci.generative_ai_inference.models.DedicatedServingMode(
+                endpoint_id=self._model_id
+            )
+        else:
+            raise ValueError(
+                f"Invalid `serving_mode` specified for OCIGenAIEmbeddingModel. "
+                f"Valid options are {ServingMode.ON_DEMAND} and {ServingMode.DEDICATED}, "
+                f"but got {self.serving_mode} instead."
+            )
+
         embed_text_details = oci.generative_ai_inference.models.EmbedTextDetails(
             inputs=data,
             compartment_id=self.compartment_id,
-            serving_mode=oci.generative_ai_inference.models.OnDemandServingMode(
-                model_id=self._model_id
-            ),
+            serving_mode=serving_mode,
         )
         response = self._embed_with_retry(embed_text_details)
         # Cast the embeddings to the expected return type (mainly for mypy)
@@ -197,6 +238,7 @@ class OCIGenAIEmbeddingModel(EmbeddingModel, SerializableObject):
             "id": self.id,
             "name": self.name,
             "description": self.description,
+            "serving_mode": self.serving_mode.value,
         }
         serialized_dict["retry_policy"] = cast(
             Any,
@@ -245,6 +287,7 @@ class OCIGenAIEmbeddingModel(EmbeddingModel, SerializableObject):
         name = input_dict.get("name", None)
         description = input_dict.get("description", None)
         retry_policy = input_dict.get("retry_policy")
+        serving_mode = input_dict.get("serving_mode")
 
         if not service_endpoint or not compartment_id:
             raise ValueError(
@@ -278,6 +321,7 @@ class OCIGenAIEmbeddingModel(EmbeddingModel, SerializableObject):
             id=id,
             name=name,
             description=description,
+            serving_mode=(ServingMode(serving_mode) if serving_mode is not None else None),
             retry_policy=(
                 deserialize_from_dict(RetryPolicy, retry_policy, deserialization_context)
                 if retry_policy is not None

--- a/wayflowcore/src/wayflowcore/embeddingmodels/ocigenaimodel.py
+++ b/wayflowcore/src/wayflowcore/embeddingmodels/ocigenaimodel.py
@@ -3,7 +3,6 @@
 # This software is under the Apache License 2.0
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
-import re
 import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 
@@ -19,6 +18,7 @@ from wayflowcore.models.ociclientconfig import (
     OCIClientConfig,
     ServingMode,
     _client_config_to_oci_client_kwargs,
+    _detect_serving_mode_from_model_id,
 )
 from wayflowcore.retrypolicy import RetryPolicy
 from wayflowcore.serialization.context import DeserializationContext, SerializationContext
@@ -34,23 +34,6 @@ if TYPE_CHECKING:
     import oci  # type: ignore
 else:
     oci = LazyLoader("oci")
-
-
-_OCID_RESOURCE_TYPE_RE = re.compile(r"^ocid\d+\.(?P<resource_type>[^.]+)\.")
-
-
-def _detect_serving_mode_from_model_id(model_id: str) -> ServingMode:
-    """Infer serving mode from an OCI GenAI embedding inference identifier.
-
-    Examples
-    --------
-    ``cohere.embed-v4.0`` -> ``ServingMode.ON_DEMAND``
-    ``ocid1.generativeaiendpoint.oc1...`` -> ``ServingMode.DEDICATED``
-    """
-    match = _OCID_RESOURCE_TYPE_RE.match(model_id)
-    if match and match.group("resource_type") == "generativeaiendpoint":
-        return ServingMode.DEDICATED
-    return ServingMode.ON_DEMAND
 
 
 class OCIGenAIEmbeddingModel(EmbeddingModel, SerializableObject):

--- a/wayflowcore/src/wayflowcore/models/__init__.py
+++ b/wayflowcore/src/wayflowcore/models/__init__.py
@@ -21,8 +21,9 @@ from .ociclientconfig import (
     OCIClientConfigWithSecurityToken,
     OCIClientConfigWithUserAuthentication,
     OCIUserAuthenticationConfig,
+    ServingMode,
 )
-from .ocigenaimodel import ModelProvider, OciAPIType, OCIGenAIModel, ServingMode
+from .ocigenaimodel import ModelProvider, OciAPIType, OCIGenAIModel
 from .ollamamodel import OllamaModel
 from .openaiapitype import OpenAIAPIType
 from .openaicompatiblemodel import OpenAICompatibleModel

--- a/wayflowcore/src/wayflowcore/models/llmmodelfactory.py
+++ b/wayflowcore/src/wayflowcore/models/llmmodelfactory.py
@@ -26,8 +26,8 @@ class LlmModelFactory:
         model_type = config_copy.pop("model_type")
 
         from .geminimodel import GeminiApiKeyAuth, GeminiCloudAuth, GeminiModel
-        from .ociclientconfig import OCIClientConfig
-        from .ocigenaimodel import OCIGenAIModel, ServingMode
+        from .ociclientconfig import OCIClientConfig, ServingMode
+        from .ocigenaimodel import OCIGenAIModel
         from .ollamamodel import OllamaModel
         from .openaicompatiblemodel import OpenAICompatibleModel
         from .openaimodel import OpenAIModel

--- a/wayflowcore/src/wayflowcore/models/ociclientconfig.py
+++ b/wayflowcore/src/wayflowcore/models/ociclientconfig.py
@@ -38,6 +38,13 @@ class _OCIAuthType(str, Enum):
     RESOURCE_PRINCIPAL = "RESOURCE_PRINCIPAL"
 
 
+class ServingMode(str, Enum):
+    """The serving mode in which an OCI Generative AI model is hosted."""
+
+    ON_DEMAND = "ON_DEMAND"
+    DEDICATED = "DEDICATED"
+
+
 @dataclass
 class OCIClientConfig(SerializableObject, ABC):
     """Base abstract class for OCI client config"""

--- a/wayflowcore/src/wayflowcore/models/ociclientconfig.py
+++ b/wayflowcore/src/wayflowcore/models/ociclientconfig.py
@@ -6,6 +6,7 @@
 
 import logging
 import os
+import re
 import warnings
 from abc import ABC
 from copy import deepcopy
@@ -43,6 +44,24 @@ class ServingMode(str, Enum):
 
     ON_DEMAND = "ON_DEMAND"
     DEDICATED = "DEDICATED"
+
+
+_OCID_RESOURCE_TYPE_RE = re.compile(r"^ocid\d+\.(?P<resource_type>[^.]+)\.")
+_DEDICATED_RESOURCE_TYPES = {"generativeaimodel", "generativeaiendpoint"}
+
+
+def _detect_serving_mode_from_model_id(model_id: str) -> ServingMode:
+    """Infer OCI GenAI serving mode from a model or endpoint identifier.
+
+    Examples
+    --------
+    ``cohere.embed-v4.0`` -> ``ServingMode.ON_DEMAND``
+    ``ocid1.generativeaiendpoint.oc1...`` -> ``ServingMode.DEDICATED``
+    """
+    match = _OCID_RESOURCE_TYPE_RE.match(model_id)
+    if match and match.group("resource_type") in _DEDICATED_RESOURCE_TYPES:
+        return ServingMode.DEDICATED
+    return ServingMode.ON_DEMAND
 
 
 @dataclass

--- a/wayflowcore/src/wayflowcore/models/ocigenaimodel.py
+++ b/wayflowcore/src/wayflowcore/models/ocigenaimodel.py
@@ -60,6 +60,7 @@ from .llmgenerationconfig import LlmGenerationConfig
 from .llmmodel import LlmCompletion, LlmModel, Prompt
 from .ociclientconfig import (
     OCIClientConfig,
+    ServingMode,
     _client_config_to_oci_client_kwargs,
     _client_config_to_oci_openai_client_auth,
     _convert_arguments_into_client_config,
@@ -77,15 +78,6 @@ if TYPE_CHECKING:
     from wayflowcore.templates import PromptTemplate
 else:
     oci = LazyLoader("oci")
-
-
-class ServingMode(str, Enum):
-    """
-    The serving mode in which the model is hosted
-    """
-
-    ON_DEMAND = "ON_DEMAND"
-    DEDICATED = "DEDICATED"
 
 
 def _detect_serving_mode_from_model_id(model_id: str) -> ServingMode:

--- a/wayflowcore/src/wayflowcore/models/ocigenaimodel.py
+++ b/wayflowcore/src/wayflowcore/models/ocigenaimodel.py
@@ -64,6 +64,7 @@ from .ociclientconfig import (
     _client_config_to_oci_client_kwargs,
     _client_config_to_oci_openai_client_auth,
     _convert_arguments_into_client_config,
+    _detect_serving_mode_from_model_id,
 )
 
 logger = logging.getLogger(__name__)
@@ -78,13 +79,6 @@ if TYPE_CHECKING:
     from wayflowcore.templates import PromptTemplate
 else:
     oci = LazyLoader("oci")
-
-
-def _detect_serving_mode_from_model_id(model_id: str) -> ServingMode:
-    # dedicated model_ids have some specific shape
-    if "generativeaimodel" in model_id:
-        return ServingMode.DEDICATED
-    return ServingMode.ON_DEMAND
 
 
 def _classify_oci_retry_exception(

--- a/wayflowcore/src/wayflowcore/serialization/_builtins_deserialization_plugin.py
+++ b/wayflowcore/src/wayflowcore/serialization/_builtins_deserialization_plugin.py
@@ -378,8 +378,8 @@ from wayflowcore.models.ociclientconfig import (
 from wayflowcore.models.ociclientconfig import (
     OCIClientConfigWithSecurityToken as RuntimeOCIClientConfigWithSecurityToken,
 )
+from wayflowcore.models.ociclientconfig import ServingMode as RuntimeServingMode
 from wayflowcore.models.ocigenaimodel import ModelProvider as RuntimeModelProvider
-from wayflowcore.models.ocigenaimodel import ServingMode as RuntimeServingMode
 from wayflowcore.models.openaiapitype import OpenAIAPIType as RuntimeOpenAIAPIType
 from wayflowcore.models.openaicompatiblemodel import (
     OpenAICompatibleModel as RuntimeOpenAICompatibleModel,
@@ -792,7 +792,7 @@ class WayflowBuiltinsDeserializationPlugin(WayflowDeserializationPlugin):
             return RuntimeOCIGenAIEmbeddingModel(
                 model_id=agentspec_component.model_id,
                 compartment_id=agentspec_component.compartment_id,
-                # serving_mode=agentspec_component.serving_mode, not supported yet
+                serving_mode=agentspec_component.serving_mode,
                 config=client_config,
                 retry_policy=self._convert_retry_policy_to_runtime(
                     agentspec_component.retry_policy

--- a/wayflowcore/src/wayflowcore/serialization/_builtins_serialization_plugin.py
+++ b/wayflowcore/src/wayflowcore/serialization/_builtins_serialization_plugin.py
@@ -1056,6 +1056,7 @@ class WayflowBuiltinsSerializationPlugin(WayflowSerializationPlugin):
                     runtime_ociclientconfig=runtime_embedding_model.config,
                     referenced_objects=referenced_objects,
                 ),
+                serving_mode=runtime_embedding_model.serving_mode,
                 retry_policy=(
                     self._retrypolicy_convert_to_agentspec(runtime_embedding_model.retry_policy)
                     if runtime_embedding_model.retry_policy is not None

--- a/wayflowcore/tests/models/test_ocigenaimodel.py
+++ b/wayflowcore/tests/models/test_ocigenaimodel.py
@@ -461,6 +461,13 @@ def test_oci_model_raises_warning_when_parameters_are_not_supported(grok_oci_llm
             "GENERIC",
             True,
         ),
+        (
+            "ocid2.generativeaiendpoint.oc1.us-chicago-1.aaaaaaa",
+            None,
+            ModelProvider.META,
+            "GENERIC",
+            True,
+        ),
     ],
 )
 def test_model_uses_proper_provider(

--- a/wayflowcore/tests/test_embeddingmodels.py
+++ b/wayflowcore/tests/test_embeddingmodels.py
@@ -20,6 +20,7 @@ from wayflowcore.embeddingmodels.openaicompatiblemodel import (
 )
 from wayflowcore.embeddingmodels.openaimodel import OpenAIEmbeddingModel
 from wayflowcore.embeddingmodels.vllmmodel import VllmEmbeddingModel
+from wayflowcore.models.ocigenaimodel import ServingMode
 from wayflowcore.serialization.serializer import autodeserialize, serialize, serialize_to_dict
 
 from .conftest import e5large_api_url, ollama_embedding_api_url
@@ -115,8 +116,12 @@ def mock_oci_modules(monkeypatch):
                 (object,),
                 {"endpoint": kwargs.get("service_endpoint", "https://mock-endpoint")},
             )
+            # Keep the request so tests can inspect the selected serving mode.
+            self.last_embed_text_details = None
 
         def embed_text(self, embed_text_details):
+            # Record the request before returning the mocked embedding response.
+            self.last_embed_text_details = embed_text_details
             # Return mock embeddings based on the input
             return MockEmbeddingResponse(embed_text_details.inputs)
 
@@ -132,11 +137,19 @@ def mock_oci_modules(monkeypatch):
         def __init__(self, model_id):
             self.model_id = model_id
 
+    # Create a mock for DedicatedServingMode
+    class MockDedicatedServingMode:
+        def __init__(self, endpoint_id):
+            self.endpoint_id = endpoint_id
+
     # Apply all the patches
     monkeypatch.setattr("oci.generative_ai_inference.GenerativeAiInferenceClient", MockGenAIClient)
     monkeypatch.setattr("oci.generative_ai_inference.models.EmbedTextDetails", MockEmbedTextDetails)
     monkeypatch.setattr(
         "oci.generative_ai_inference.models.OnDemandServingMode", MockOnDemandServingMode
+    )
+    monkeypatch.setattr(
+        "oci.generative_ai_inference.models.DedicatedServingMode", MockDedicatedServingMode
     )
 
     # Mock oci.config.from_file to return a dict with the compartment_id
@@ -161,6 +174,7 @@ def mock_oci_modules(monkeypatch):
         "client_class": MockGenAIClient,
         "embed_text_details_class": MockEmbedTextDetails,
         "on_demand_mode_class": MockOnDemandServingMode,
+        "dedicated_mode_class": MockDedicatedServingMode,
     }
 
 
@@ -695,6 +709,7 @@ def test_ocigenai_embedding_model_serialization(request, mock_oci_modules):
     assert serialized_dict["model_id"] == model_id
     assert "service_endpoint" in serialized_dict
     assert "compartment_id" in serialized_dict
+    assert serialized_dict["serving_mode"] == ServingMode.ON_DEMAND.value
 
     # Test YAML serialization
     yaml_str = serialize(original_model)
@@ -702,6 +717,33 @@ def test_ocigenai_embedding_model_serialization(request, mock_oci_modules):
 
     # Note: We skip deserialization for OCI as mentioned in the original test
     # as it requires special handling
+
+
+def test_ocigenai_embedding_model_dedicated_serving_mode(request, mock_oci_modules):
+    endpoint_id = "ocid2.generativeaiendpoint.oc1.phx.example"
+    model = OCIGenAIEmbeddingModel(
+        model_id=endpoint_id,
+        config=request.getfixturevalue("oci_client_config"),
+        compartment_id="test_compartment",
+    )
+
+    assert model.serving_mode == ServingMode.DEDICATED
+    model.embed(["hello"])
+
+    assert model._client.last_embed_text_details.serving_mode.endpoint_id == endpoint_id
+
+
+def test_ocigenai_embedding_model_explicit_serving_mode(request, mock_oci_modules):
+    model = OCIGenAIEmbeddingModel(
+        model_id="cohere.embed-v4.0",
+        config=request.getfixturevalue("oci_client_config"),
+        compartment_id="test_compartment",
+        serving_mode=ServingMode.DEDICATED,
+    )
+
+    assert model.serving_mode == ServingMode.DEDICATED
+    serialized = serialize_to_dict(model)
+    assert serialized["serving_mode"] == ServingMode.DEDICATED.value
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds on-demand and dedicated serving modes to `OCIGenAIEmbeddingModel`.

