### PR TITLE
fix: don't pre-execute a flow past its first InputMessageStep

### DIFF
--- a/wayflowcore/src/wayflowcore/agentserver/a2a/_worker.py
+++ b/wayflowcore/src/wayflowcore/agentserver/a2a/_worker.py
@@ -31,6 +31,39 @@ Context = Any
 """The shape of the context stored in the storage (is not used in our case but is added to be compatible with fasta2a's Worker class"""
 
 
+def _flow_yields_at_input_step_before_any_real_message(flow: WayflowFlow) -> bool:
+    """Whether pre-executing ``flow`` (before any real message has been
+    appended) would run all the way to an ``InputMessageStep`` and yield
+    there.
+
+    Pre-execution always runs on a brand-new conversation, before the
+    caller's first message is ever appended. If that pre-execution reaches
+    and yields at an ``InputMessageStep`` — whether or not other,
+    non-yielding steps ran first — the worker then immediately appends the
+    caller's first message and re-executes, which the ``InputMessageStep``
+    misinterprets as the answer to a question the caller was never actually
+    asked. We only walk a single, unambiguous path (a step with more than one
+    distinct outgoing destination is treated as "can't tell", and we
+    conservatively keep the existing pre-execute behaviour).
+    """
+    visited: set[int] = set()
+    step = flow.begin_step
+    while id(step) not in visited:
+        visited.add(id(step))
+        if isinstance(step, InputMessageStep):
+            return True
+        destinations = {
+            edge.destination_step for edge in flow.control_flow_edges if edge.source_step is step
+        }
+        if len(destinations) != 1:
+            return False
+        (destination,) = destinations
+        if destination is None:
+            return False
+        step = destination
+    return False
+
+
 @dataclass
 class A2AAgentWorker(Worker[Context]):  # type: ignore[misc]
     """A worker that uses a WayFlow conversational component to execute tasks"""
@@ -77,8 +110,12 @@ class A2AAgentWorker(Worker[Context]):  # type: ignore[misc]
             messages = None if conversation is None else conversation.message_list
             conversation = self.assistant.start_conversation(messages=messages)
 
-            if isinstance(self.assistant, WayflowFlow) and any(
-                isinstance(step, InputMessageStep) for step in self.assistant.steps.values()
+            if (
+                isinstance(self.assistant, WayflowFlow)
+                and any(
+                    isinstance(step, InputMessageStep) for step in self.assistant.steps.values()
+                )
+                and not _flow_yields_at_input_step_before_any_real_message(self.assistant)
             ):
                 await conversation.execute_async()
 

--- a/wayflowcore/tests/a2a/test_a2aserver.py
+++ b/wayflowcore/tests/a2a/test_a2aserver.py
@@ -397,11 +397,19 @@ def test_server_returns_error_when_sending_completed_task(a2a_server):
     """
     base_url = a2a_server
 
-    # Create a completed task
+    # Create a completed task: the first message triggers the flow's
+    # InputMessageStep, which must return "input-required" rather than
+    # immediately consuming the trigger message as the user's answer, so a
+    # second message is needed to actually complete the task.
     resp1 = send_text_message(base_url, text="John", blocking=True)
-    assert resp1.json()["result"]["status"]["state"] == "completed"
+    assert resp1.json()["result"]["status"]["state"] == "input-required"
 
     task_id = resp1.json()["result"]["id"]
+    context_id = resp1.json()["result"]["contextId"]
+    send_text_message(base_url, text="John", task_id=task_id, context_id=context_id)
+    resp1b = wait_for_task(base_url, task_id=task_id)
+    assert resp1b.json()["result"]["status"]["state"] == "completed"
+
     resp2 = send_text_message(base_url, text="Johb", task_id=task_id)
     task_error = resp2.json()["error"]
     assert task_error == {

--- a/wayflowcore/tests/a2a/test_worker.py
+++ b/wayflowcore/tests/a2a/test_worker.py
@@ -1,0 +1,97 @@
+# Copyright © 2025 Oracle and/or its affiliates.
+#
+# This software is under the Apache License 2.0
+# (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
+# (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
+
+from wayflowcore.agentserver.a2a._worker import _flow_yields_at_input_step_before_any_real_message
+from wayflowcore.controlconnection import ControlFlowEdge
+from wayflowcore.flow import Flow
+from wayflowcore.steps import BranchingStep, CompleteStep, InputMessageStep, OutputMessageStep
+
+
+def test_reaches_input_step_immediately() -> None:
+    """The flow's only real step is the InputMessageStep (the implicit StartStep
+    leads directly to it), so pre-executing would swallow the caller's first
+    message as the answer to a question never actually surfaced."""
+    input_step = InputMessageStep(name="input_step", message_template="")
+    complete_step = CompleteStep(name="complete_step")
+
+    flow = Flow(
+        begin_step=input_step,
+        control_flow_edges=[
+            ControlFlowEdge(input_step, complete_step),
+        ],
+    )
+
+    assert _flow_yields_at_input_step_before_any_real_message(flow) is True
+
+
+def test_non_yielding_step_before_input_step_still_reaches_immediately() -> None:
+    """A non-yielding step (e.g. one with only a static message) running before
+    the InputMessageStep does not make pre-execution safe: pre-execute always
+    runs before any real message has been appended, so it would still reach
+    and yield at the InputMessageStep on its very first pass, swallowing the
+    caller's first message as the answer. The path is unambiguous (single
+    edge at each hop), so this must still be detected as "reached with no
+    prior work that depends on the caller's message"."""
+    output_step = OutputMessageStep(name="output_step", message_template="hello")
+    input_step = InputMessageStep(name="input_step", message_template="")
+    complete_step = CompleteStep(name="complete_step")
+
+    flow = Flow(
+        begin_step=output_step,
+        control_flow_edges=[
+            ControlFlowEdge(output_step, input_step),
+            ControlFlowEdge(input_step, complete_step),
+        ],
+    )
+
+    assert _flow_yields_at_input_step_before_any_real_message(flow) is True
+
+
+def test_no_input_step_in_flow() -> None:
+    """A flow with no InputMessageStep at all never needs the pre-execute
+    guard; the original pre-execute condition already filters this out before
+    calling the helper, but the helper itself should not claim otherwise."""
+    output_step = OutputMessageStep(name="output_step", message_template="hello")
+    complete_step = CompleteStep(name="complete_step")
+
+    flow = Flow(
+        begin_step=output_step,
+        control_flow_edges=[
+            ControlFlowEdge(output_step, complete_step),
+        ],
+    )
+
+    assert _flow_yields_at_input_step_before_any_real_message(flow) is False
+
+
+def test_branching_before_input_step_is_treated_as_unknown() -> None:
+    """When the step before a potential InputMessageStep has more than one
+    distinct outgoing destination, we can't cheaply tell whether the
+    InputMessageStep is reached with or without prior work, so we
+    conservatively keep the existing pre-execute behaviour."""
+    input_step_a = InputMessageStep(name="input_step_a", message_template="")
+    output_step_b = OutputMessageStep(name="output_step_b", message_template="hello")
+    complete_step = CompleteStep(name="complete_step")
+
+    branching_step = BranchingStep(
+        name="branching_step",
+        branch_name_mapping={"go_to_input": "to_input", "go_to_output": "to_output"},
+    )
+
+    flow = Flow(
+        begin_step=branching_step,
+        control_flow_edges=[
+            ControlFlowEdge(branching_step, input_step_a, source_branch="to_input"),
+            ControlFlowEdge(branching_step, output_step_b, source_branch="to_output"),
+            ControlFlowEdge(
+                branching_step, output_step_b, source_branch=BranchingStep.BRANCH_DEFAULT
+            ),
+            ControlFlowEdge(input_step_a, complete_step),
+            ControlFlowEdge(output_step_b, complete_step),
+        ],
+    )
+
+    assert _flow_yields_at_input_step_before_any_real_message(flow) is False


### PR DESCRIPTION
Fixes #151.

`A2AAgentWorker.run_task` pre-executes a brand-new conversation whenever the assigned flow contains an `InputMessageStep` anywhere, so that any non-interactive steps get a chance to run before the first yield. The problem: pre-execution always runs before the caller's actual first message is ever appended to the conversation. If that pre-execution reaches and yields at the `InputMessageStep` itself, the worker immediately appends the caller's real first message and re-executes -- and the `InputMessageStep` (which tracks a simple "have I already asked" flag) treats that message as the answer to a question the caller was never actually shown, instead of returning `input-required` and giving the caller a real chance to respond.

This reproduces with the repo's own existing `FLOW_THAT_WITH_INPUT_STEP_YIELDS_ONCE` test fixture -- `test_server_returns_error_when_sending_completed_task` currently passes with the very first `message/send` call ("John") landing directly in `state: completed`, with no `input-required` round-trip ever happening.

The fix adds `_flow_yields_at_input_step_before_any_real_message()`, which walks the flow's single unambiguous execution path from its begin step. If that path reaches an `InputMessageStep` (with or without other, non-yielding steps running first) before branching or hitting a dead end, pre-execution is skipped so the caller's first message reaches the `InputMessageStep` in its real initial state. If the path branches or can't be resolved unambiguously, the existing pre-execute behavior is conservatively kept.

I also updated `test_server_returns_error_when_sending_completed_task`, since its first assertion encoded the buggy behavior (`state == "completed"` after a single message) -- it now expects `input-required` after the first message, then completes the task with a follow-up message before continuing with the rest of the test.

Note on scope: issue #155 (StartNode DFE variables not bound when InputMessageNode is first gate) is filed as the same root cause as #151, but on closer inspection it isn't -- `A2AAgentWorker.run_task` never passes `inputs=` to `start_conversation()` at all, regardless of pre-execute timing, so there's no existing convention for conveying typed `StartNode` inputs over the A2A protocol to build on. That looks like a separate feature request needing a maintainer decision on the wire format, not a fix to this bug. I haven't touched it in this PR; happy to help once there's a direction agreed for it.

Verification:
- New unit tests (`tests/a2a/test_worker.py`) directly cover `_flow_yields_at_input_step_before_any_real_message()`: immediate InputMessageStep, a non-yielding step before it, no InputMessageStep at all, and an ambiguous branching case.
- Updated `test_server_returns_error_when_sending_completed_task` passes with the fix, confirmed to fail against unpatched code (`state == "input-required"` vs the old `"completed"`).
- Full `tests/a2a/` suite: no new failures introduced. All Flow/deterministic tests pass; the pre-existing failures that need a real LLM backend (`AGENT_WITH_SERVER_TOOL`, `test_a2aagent.py`, etc.) are identical on a clean `main` checkout with the same test environment, confirmed via direct comparison.
- `black`, `isort`, `mypy` (repo's pinned versions, root `pyproject.toml` config) all clean on the changed files.