### PR TITLE
chore: update dependency constraints

### DIFF
--- a/wayflowcore/constraints/constraints.txt
+++ b/wayflowcore/constraints/constraints.txt
@@ -1,16 +1,17 @@
 deprecated==1.2.18
 jinja2==3.1.6
-jq==1.8.0
+jq==1.12.0
 json_repair==0.63.2
-numpy==1.26.4
+numpy==2.2.6; python_version < "3.14"
+numpy==2.4.2; python_version == "3.14"
 pandas==2.2.3
 PyYAML==6.0.3
 pydantic==2.12.5
 httpx==0.28.1
 mcp==1.28.1
 pyagentspec==26.3.0
-opentelemetry-api==1.36.0
-opentelemetry-sdk==1.36.0
+opentelemetry-api==1.44.0
+opentelemetry-sdk==1.44.0
 litellm==1.84.0; python_version < "3.14"
 fastapi==0.141.1
 anyio==4.11.0

--- a/wayflowcore/constraints/constraints_dev.txt
+++ b/wayflowcore/constraints/constraints_dev.txt
@@ -1,16 +1,17 @@
 deprecated==1.2.18
 jinja2==3.1.6
-jq==1.8.0
+jq==1.12.0
 json_repair==0.63.2
-numpy==1.26.4
+numpy==2.2.6; python_version < "3.14"
+numpy==2.4.2; python_version == "3.14"
 pandas==2.2.3
 PyYAML==6.0.3
 pydantic==2.12.5
 httpx==0.28.1
 mcp==1.28.1
 pyagentspec==26.3.0 # Coordinated 26.3.0 release
-opentelemetry-api==1.36.0
-opentelemetry-sdk==1.36.0
+opentelemetry-api==1.44.0
+opentelemetry-sdk==1.44.0
 litellm==1.84.0; python_version < "3.14"
 fastapi==0.141.1
 anyio==4.11.0

--- a/wayflowcore/constraints/constraints_v26.3.0.txt
+++ b/wayflowcore/constraints/constraints_v26.3.0.txt
@@ -1,16 +1,17 @@
 deprecated==1.2.18
 jinja2==3.1.6
-jq==1.8.0
+jq==1.12.0
 json_repair==0.63.2
-numpy==1.26.4
+numpy==2.2.6; python_version < "3.14"
+numpy==2.4.2; python_version == "3.14"
 pandas==2.2.3
 PyYAML==6.0.3
 pydantic==2.12.5
 httpx==0.28.1
 mcp==1.28.1
 pyagentspec==26.3.0
-opentelemetry-api==1.36.0
-opentelemetry-sdk==1.36.0
+opentelemetry-api==1.44.0
+opentelemetry-sdk==1.44.0
 litellm==1.84.0; python_version < "3.14"
 fastapi==0.141.1
 anyio==4.11.0

--- a/wayflowcore/setup.py
+++ b/wayflowcore/setup.py
@@ -70,13 +70,13 @@ setup(
         "uvicorn>=0.23.1",
         "fastapi>=0.116.2,<1.0.0",
         "litellm>=1.84.0,<2.0; python_version < '3.14'",
+        "opentelemetry-sdk>=1.33.0,<2.0.0",
+        "opentelemetry-api>=1.33.0,<2.0.0",
         # 4rth party dependencies version bounds, for CVE patching
         "annotated-types>=0.6.0",
         "certifi>=2025.4.26",
         "httpcore>=1.0.9",
         "idna>=3.7",
-        "opentelemetry-api>=1.33.0,<2.0.0",
-        "opentelemetry-sdk>=1.33.0,<2.0.0",
         "pydantic_core>=2.33.0",  # warning but no vulnerabilities
         "PyJWT>=2.13.0,<3.0.0",  # Versions <2.13.0 were affected with CVEs; 2.13.0 is required.
         "aiohttp>=3.14.3,<4.0.0",  # Versions <3.14.3 included affected releases; 3.14.3 is required.


### PR DESCRIPTION
Cherry-pick dependency constraint update 820f6a6a4bcf777347e68ec00e539e3690332602.\n\nUpdates jq, NumPy, and OpenTelemetry constraints, and keeps the corresponding 26.3.0 setup dependency bounds aligned.