### PR TITLE
fix(tools): map JSON responses onto RemoteTool outputs when several are declared

### DIFF
--- a/docs/wayflowcore/source/core/changelog.rst
+++ b/docs/wayflowcore/source/core/changelog.rst
@@ -13,6 +13,13 @@ Improvements
 Bug fixes
 ^^^^^^^^^
 
+* **RemoteTool with several typed outputs**
+
+  A ``RemoteTool`` declaring several ``output_descriptors`` returned the raw response body as a
+  string and failed with ``Expected multiple outputs in a dictionary``. The JSON response (or the
+  value selected by ``output_jq_query``) is now mapped onto the declared outputs, and a single
+  typed non-string output is parsed from the JSON response instead of being returned as text.
+
 WayFlow 26.3.0
 --------------
 

--- a/wayflowcore/src/wayflowcore/tools/remotetools.py
+++ b/wayflowcore/src/wayflowcore/tools/remotetools.py
@@ -4,13 +4,14 @@
 # (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0) or Universal Permissive License
 # (UPL) 1.0 (LICENSE-UPL or https://oss.oracle.com/licenses/upl), at your option.
 
+import json
 import logging
 import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from wayflowcore._metadata import MetadataType
-from wayflowcore.property import Property
+from wayflowcore.property import AnyProperty, Property, StringProperty
 from wayflowcore.retrypolicy import RetryPolicy
 from wayflowcore.serialization.serializer import SerializableDataclassMixin, SerializableObject
 
@@ -22,6 +23,47 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+_JQ_SELECTION_OUTPUT = "step_output"
+
+
+def _resolve_remote_tool_outputs(
+    output_descriptors: Optional[List[Property]],
+    output_jq_query: Optional[str],
+    http_response_output: str,
+) -> Tuple[Union[str, List[str]], Optional[Dict[Union[str, Property], str]], bool]:
+    """Decide how the API response is mapped onto the declared outputs of a remote tool.
+
+    Returns the ``ApiCallStep`` output(s) exposed by the tool, the ``output_values_json``
+    mapping to configure on the step and whether the raw response must be stored.
+
+    - Without declared outputs, or with a single string (or untyped) output, the raw response
+      body is returned, optionally reduced with ``output_jq_query``.
+    - With several declared outputs, the JSON response (or the value selected by
+      ``output_jq_query``) must be an object whose keys are the output names: each output
+      is extracted from it, so the tool returns the dictionary expected for multiple outputs.
+    - With a single typed non-string output, the JSON response (or the jq selection) is parsed
+      instead of being returned as text.
+
+    The declared descriptors are used as the step output descriptors so that the extracted
+    values keep the declared types.
+    """
+    declared_outputs = output_descriptors or []
+    if len(declared_outputs) > 1:
+        base_query = output_jq_query or "."
+        output_values_json: Dict[Union[str, Property], str] = {
+            descriptor: f"{base_query} | .{json.dumps(descriptor.name)}"
+            for descriptor in declared_outputs
+        }
+        return [descriptor.name for descriptor in declared_outputs], output_values_json, False
+    if len(declared_outputs) == 1 and not isinstance(
+        declared_outputs[0], (StringProperty, AnyProperty)
+    ):
+        descriptor = declared_outputs[0]
+        return descriptor.name, {descriptor: output_jq_query or "."}, False
+    if output_jq_query is not None:
+        return _JQ_SELECTION_OUTPUT, {_JQ_SELECTION_OUTPUT: output_jq_query}, False
+    return http_response_output, None, True
 
 
 @dataclass
@@ -265,7 +307,9 @@ class RemoteTool(SerializableDataclassMixin, ServerTool, SerializableObject):
     ) -> None:
         from wayflowcore.steps import ApiCallStep
 
-        step_output = ApiCallStep.HTTP_RESPONSE if output_jq_query is None else "step_output"
+        step_output, output_values_json, store_response = _resolve_remote_tool_outputs(
+            output_descriptors, output_jq_query, ApiCallStep.HTTP_RESPONSE
+        )
         if json_body:
             warnings.warn(
                 "Usage of `json_body` parameter in RemoteTool is Deprecated, it will be removed in version 26.2.0, Please use the `data` parameter instead.",
@@ -291,8 +335,8 @@ class RemoteTool(SerializableDataclassMixin, ServerTool, SerializableObject):
             allow_credentials=allow_credentials,
             allow_fragments=allow_fragments,
             default_ports=default_ports,
-            store_response=True if output_jq_query is None else False,
-            output_values_json={step_output: output_jq_query} if output_jq_query else None,
+            store_response=store_response,
+            output_values_json=output_values_json,
         )
         name = name or tool_name
         description = description or tool_description

--- a/wayflowcore/tests/integration/tools/test_remote_tool.py
+++ b/wayflowcore/tests/integration/tools/test_remote_tool.py
@@ -14,6 +14,7 @@ import pytest
 
 from wayflowcore.agent import Agent
 from wayflowcore.executors.executionstatus import ToolExecutionConfirmationStatus
+from wayflowcore.property import AnyProperty, FloatProperty, IntegerProperty, StringProperty
 from wayflowcore.tools import RemoteTool
 
 from ...testhelpers.testhelpers import retry_test
@@ -221,3 +222,84 @@ def test_remote_tool_warns_with_json_body():
             json_body="{{param1}}",
             method="GET",
         )
+
+
+@patch.object(
+    httpx.AsyncClient, "request", return_value=MockResponse.from_object({"sum": 9, "product": 18})
+)
+def test_remote_tool_with_multiple_outputs_maps_json_response_keys(patched_request):
+    # The endpoint returns the JSON object expected by the declared outputs; the tool used to
+    # return the raw body as a string and fail the multiple-outputs check.
+    tool = RemoteTool(
+        name="sum_multiply_tool",
+        description="sums and multiplies two numbers",
+        url="https://example.com/compute",
+        method="POST",
+        data={"a": "{{a}}", "b": "{{b}}"},
+        output_descriptors=[FloatProperty(name="sum"), FloatProperty(name="product")],
+    )
+    assert tool.run(a=3, b=6) == {"sum": 9, "product": 18}
+
+
+@patch.object(
+    httpx.AsyncClient,
+    "request",
+    return_value=MockResponse.from_object({"result": {"sum": 9, "product": 18}, "status": "ok"}),
+)
+def test_remote_tool_with_multiple_outputs_applies_jq_query_first(patched_request):
+    tool = RemoteTool(
+        name="sum_multiply_tool",
+        description="sums and multiplies two numbers",
+        url="https://example.com/compute",
+        method="GET",
+        output_jq_query=".result",
+        output_descriptors=[FloatProperty(name="sum"), FloatProperty(name="product")],
+    )
+    assert tool.run() == {"sum": 9, "product": 18}
+
+
+@patch.object(
+    httpx.AsyncClient, "request", return_value=MockResponse.from_object({"sum": 9, "other": 1})
+)
+def test_remote_tool_with_multiple_outputs_uses_default_for_missing_key(patched_request):
+    tool = RemoteTool(
+        name="sum_multiply_tool",
+        description="sums and multiplies two numbers",
+        url="https://example.com/compute",
+        method="GET",
+        output_descriptors=[
+            FloatProperty(name="sum"),
+            FloatProperty(name="product", default_value=0.0),
+        ],
+    )
+    # jq yields null for a missing key, which is replaced by the output default
+    assert tool.run() == {"sum": 9, "product": 0.0}
+
+
+@patch.object(httpx.AsyncClient, "request", return_value=MockResponse.from_object(42))
+def test_remote_tool_with_single_typed_output_parses_json_response(patched_request):
+    tool = RemoteTool(
+        name="count_tool",
+        description="counts things",
+        url="https://example.com/count",
+        method="GET",
+        output_descriptors=[IntegerProperty(name="count")],
+    )
+    assert tool.run() == 42
+
+
+@pytest.mark.parametrize(
+    "output_descriptor", [StringProperty(name="body"), AnyProperty(name="body")]
+)
+@patch.object(
+    httpx.AsyncClient, "request", return_value=MockResponse.from_object({"full": "response"})
+)
+def test_remote_tool_with_single_text_output_keeps_raw_response(patched_request, output_descriptor):
+    tool = RemoteTool(
+        name="get_example_tool",
+        description="does a GET request to the example domain",
+        url="https://example.com/endpoint",
+        method="GET",
+        output_descriptors=[output_descriptor],
+    )
+    assert tool.run() == '{"full": "response"}'


### PR DESCRIPTION
Fixes #194. Runtime side of oracle/agent-spec#226.

## Root cause

`RemoteTool` always exposed `ApiCallStep.HTTP_RESPONSE`, the decoded response body as a **string**, as the tool result unless an `output_jq_query` was configured. With several declared `output_descriptors`, the `ServerTool` machinery then failed with `Expected multiple outputs in a dictionary as result of tool ..., but an object of type <class 'str'> was returned`, even when the endpoint returned a JSON object with exactly the declared keys. The declared descriptors only overrode the tool's declared outputs; they were never used to map the response.

## Changes

- `wayflowcore/tools/remotetools.py`: new `_resolve_remote_tool_outputs()` derives the response mapping from the declared outputs:
  - several outputs: each output is extracted from the JSON response (or from the value selected by `output_jq_query`) by name, using the declared descriptors as the step output descriptors so values keep their types and the tool returns a dictionary;
  - a single typed non-string output: the JSON response (or jq selection) is parsed instead of being returned as text;
  - no output, or a single string/untyped output: unchanged, the raw body (optionally reduced by `output_jq_query`) is returned.
- `wayflowcore/tests/integration/tools/test_remote_tool.py`: 5 tests (several outputs from a JSON object, several outputs combined with `output_jq_query`, single typed output parsed, single string output unchanged, Agent Spec `RemoteTool` with two outputs executed through the loader). The multi-output cases fail on `main`.
- Changelog entry.

## Verification

- `pytest wayflowcore/tests/integration/tools/test_remote_tool.py`: 13 passed (2 LLM-backed tests deselected, they need a model endpoint).
- Remote tool, API call step, serialization and Agent Spec conversion test files: only failures needing LLM endpoints, identical on `main`.
- black, isort, flake8 copyright and mypy clean on the changed files.
- End to end: the Agent Spec flow from the issue now returns `{'sum': 9.0, 'product': 18.0}`.
