### PR TITLE
fix(property): accept object values omitting nested properties with defaults

### DIFF
--- a/docs/wayflowcore/source/core/changelog.rst
+++ b/docs/wayflowcore/source/core/changelog.rst
@@ -13,6 +13,13 @@ Improvements
 Bug fixes
 ^^^^^^^^^
 
+* **Optional nested object properties with defaults**
+
+  ``ObjectProperty`` values that omit a nested property having a ``default_value`` were rejected
+  (``TypeError: The input passed ... is not of the expected type``) when starting a ``Flow`` or
+  passing values between steps. Such values are now accepted, and the omitted nested properties
+  take their declared defaults before the steps receive the value.
+
 WayFlow 26.3.0
 --------------
 

--- a/wayflowcore/src/wayflowcore/executors/_flowexecutor.py
+++ b/wayflowcore/src/wayflowcore/executors/_flowexecutor.py
@@ -467,7 +467,10 @@ class FlowConversationExecutor(ConversationExecutor):
             value = _try_cast_str_value_to_type(value, value_descriptor)
         if value is not None and not value_descriptor.is_value_of_expected_type(value):
             # we cast, data edges should have checked types
-            return _cast_value_into(value, value_descriptor)
+            value = _cast_value_into(value, value_descriptor)
+        if value is not None:
+            # 3. Nested properties omitted from object values take their declared defaults
+            value = value_descriptor._fill_nested_values_with_explicit_defaults(value)
         return value
 
     @staticmethod

--- a/wayflowcore/src/wayflowcore/flow.py
+++ b/wayflowcore/src/wayflowcore/flow.py
@@ -1237,6 +1237,13 @@ class Flow(ConversationalComponent, SerializableObject):
                         f"The input passed: `{inputs[input_name]}` of type `{inputs[input_name].__class__.__name__}` is not of the expected type `{input_descriptor.pretty_str()}`"
                     )
 
+            if input_name in inputs:
+                # Nested properties omitted from object values take their declared defaults,
+                # so the steps receive the normalized value
+                inputs[input_name] = input_descriptor._fill_nested_values_with_explicit_defaults(
+                    inputs[input_name]
+                )
+
         record_event(
             ConversationCreatedEvent(
                 conversational_component=self,

--- a/wayflowcore/src/wayflowcore/property.py
+++ b/wayflowcore/src/wayflowcore/property.py
@@ -1064,11 +1064,17 @@ class ObjectProperty(Property):
     def _check_dict_has_correct_entry(
         value: Dict[str, Any], name: str, property_: Property
     ) -> bool:
-        return name in value and property_.is_value_of_expected_type(value[name])
+        if name not in value:
+            # A nested property with a default value is optional (it is not required
+            # in the JSON schema), so a value omitting it is still valid
+            return property_.has_default
+        return property_.is_value_of_expected_type(value[name])
 
     @staticmethod
     def _check_object_has_correct_attribute(value: Any, name: str, value_type: Property) -> bool:
-        return hasattr(value, name) and value_type.is_value_of_expected_type(getattr(value, name))
+        if not hasattr(value, name):
+            return value_type.has_default
+        return value_type.is_value_of_expected_type(getattr(value, name))
 
     @property
     def _type_default_value(self) -> Any:
@@ -1492,6 +1498,13 @@ def _property_can_be_casted_into_property(from_type: Property, to_type: Property
     )
 
 
+def _get_default_value_of_missing_entry(name: str, property_: Property) -> Any:
+    """Return the default of a nested property missing from an object value, or fail."""
+    if property_.has_default:
+        return property_.default_value
+    raise KeyError(f"Missing required property `{name}` in object value")
+
+
 def _cast_value_into(value: Any, target_type: Property) -> Any:
     casted_value = _try_cast_value_into(value, target_type)
     if target_type.enum is None:
@@ -1548,11 +1561,19 @@ def _try_cast_value_into(value: Any, target_type: Property) -> Any:
                 "Cannot convert non dict object types: %s to %s", value, str(target_type)
             )
             return {
-                prop_name: _cast_value_into(getattr(value, prop_name), property_)
+                prop_name: (
+                    _cast_value_into(getattr(value, prop_name), property_)
+                    if hasattr(value, prop_name)
+                    else _get_default_value_of_missing_entry(prop_name, property_)
+                )
                 for prop_name, property_ in target_type.properties.items()
             }
         return {
-            prop_name: _cast_value_into(value[prop_name], property_)
+            prop_name: (
+                _cast_value_into(value[prop_name], property_)
+                if prop_name in value
+                else _get_default_value_of_missing_entry(prop_name, property_)
+            )
             for prop_name, property_ in target_type.properties.items()
         }
     elif isinstance(target_type, UnionProperty):

--- a/wayflowcore/tests/integration/test_flow.py
+++ b/wayflowcore/tests/integration/test_flow.py
@@ -12,7 +12,15 @@ from wayflowcore import Flow
 from wayflowcore.controlconnection import ControlFlowEdge
 from wayflowcore.dataconnection import DataFlowEdge
 from wayflowcore.executors.executionstatus import FinishedStatus, UserMessageRequestStatus
-from wayflowcore.property import AnyProperty, DictProperty, StringProperty
+from wayflowcore.property import (
+    AnyProperty,
+    BooleanProperty,
+    DictProperty,
+    IntegerProperty,
+    ListProperty,
+    ObjectProperty,
+    StringProperty,
+)
 from wayflowcore.steps import (
     BranchingStep,
     InputMessageStep,
@@ -492,3 +500,83 @@ def test_node_does_not_have_outgoing_edges():
                 ControlFlowEdge(source_step=step_1, destination_step=step_2),
             ],
         )
+
+
+def test_flow_input_omitting_nested_properties_with_defaults_is_accepted_and_normalized():
+    # The nested `priority` and `notifications` properties have defaults, so an input omitting
+    # them is valid; the steps receive the value with the defaults filled in
+    request_property = ObjectProperty(
+        name="request",
+        properties={
+            "customer_id": StringProperty(),
+            "profile": ObjectProperty(
+                properties={"name": StringProperty(), "age": IntegerProperty()}
+            ),
+            "tags": ListProperty(item_type=StringProperty()),
+            "priority": StringProperty(default_value="normal"),
+            "notifications": BooleanProperty(default_value=True),
+        },
+        additional_properties=False,
+    )
+    received_requests = []
+
+    def normalize(request):
+        received_requests.append(request)
+        return request
+
+    normalize_tool = ServerTool(
+        name="normalize",
+        description="Normalizes a request",
+        input_descriptors=[request_property],
+        output_descriptors=[request_property],
+        func=normalize,
+    )
+    flow = Flow.from_steps([ToolExecutionStep(normalize_tool, name="normalize_step")])
+
+    conversation = flow.start_conversation(
+        inputs={
+            "request": {
+                "customer_id": "C-1042",
+                "profile": {"name": "Ada", "age": 36},
+                "tags": ["priority", "verified"],
+            }
+        }
+    )
+    status = conversation.execute()
+
+    expected_request = {
+        "customer_id": "C-1042",
+        "profile": {"name": "Ada", "age": 36},
+        "tags": ["priority", "verified"],
+        "priority": "normal",
+        "notifications": True,
+    }
+    assert isinstance(status, FinishedStatus)
+    assert received_requests == [expected_request]
+    assert status.output_values["request"] == expected_request
+
+
+def test_flow_input_omitting_required_nested_property_is_rejected():
+    request_property = ObjectProperty(
+        name="request",
+        properties={
+            "customer_id": StringProperty(),
+            "priority": StringProperty(default_value="normal"),
+        },
+    )
+    flow = Flow.from_steps(
+        [
+            ToolExecutionStep(
+                ServerTool(
+                    name="normalize",
+                    description="Normalizes a request",
+                    input_descriptors=[request_property],
+                    output_descriptors=[request_property],
+                    func=lambda request: request,
+                ),
+                name="normalize_step",
+            )
+        ]
+    )
+    with pytest.raises(TypeError, match="is not of the expected type"):
+        flow.start_conversation(inputs={"request": {"priority": "high"}})

--- a/wayflowcore/tests/integration/test_property.py
+++ b/wayflowcore/tests/integration/test_property.py
@@ -570,3 +570,64 @@ def test_enum_default_case_mismatch_warns():
 def test_enum_default_exact_match_does_not_warn():
     prop = StringProperty(default_value="ALL", enum=("ALL", "NONE"))
     assert prop.default_value == "ALL"
+
+
+def _request_property() -> ObjectProperty:
+    return ObjectProperty(
+        name="request",
+        properties={
+            "customer_id": StringProperty(),
+            "profile": ObjectProperty(
+                properties={"name": StringProperty(), "age": IntegerProperty()}
+            ),
+            "tags": ListProperty(item_type=StringProperty()),
+            "priority": StringProperty(default_value="normal"),
+            "notifications": BooleanProperty(default_value=True),
+        },
+        additional_properties=False,
+    )
+
+
+def test_object_property_accepts_value_omitting_nested_properties_with_defaults():
+    # Nested properties with a default are optional: a value without them is still valid
+    value = {"customer_id": "C-1042", "profile": {"name": "Ada", "age": 36}, "tags": ["verified"]}
+    assert _request_property().is_value_of_expected_type(value) is True
+
+
+def test_object_property_rejects_value_omitting_nested_properties_without_defaults():
+    value = {"customer_id": "C-1042", "tags": ["verified"]}
+    assert _request_property().is_value_of_expected_type(value) is False
+
+
+def test_object_property_accepts_object_omitting_attributes_with_defaults():
+    @dataclass
+    class Request:
+        customer_id: str
+        profile: Any
+        tags: List[str]
+
+    value = Request(customer_id="C-1042", profile={"name": "Ada", "age": 36}, tags=[])
+    assert _request_property().is_value_of_expected_type(value) is True
+
+
+def test_casting_object_value_fills_nested_defaults():
+    from wayflowcore.property import _cast_value_into
+
+    casted_value = _cast_value_into(
+        {"customer_id": 1042, "profile": {"name": "Ada", "age": 36}, "tags": ["verified"]},
+        _request_property(),
+    )
+    assert casted_value == {
+        "customer_id": "1042",
+        "profile": {"name": "Ada", "age": 36},
+        "tags": ["verified"],
+        "priority": "normal",
+        "notifications": True,
+    }
+
+
+def test_casting_object_value_missing_required_nested_property_raises():
+    from wayflowcore.property import _cast_value_into
+
+    with pytest.raises(KeyError, match="customer_id"):
+        _cast_value_into({"profile": {"name": "Ada", "age": 36}, "tags": []}, _request_property())


### PR DESCRIPTION
Fixes #195. Runtime side of oracle/agent-spec#241.

## Root cause

`ObjectProperty.is_value_of_expected_type()` rejected any dictionary (or object) missing one of the declared nested properties, even when that property had a `default_value` and was therefore optional in the JSON schema (`_check_dict_has_correct_entry` / `_check_object_has_correct_attribute`). `Flow.start_conversation()` then tried to cast the value, and the `ObjectProperty` branch of `_cast_value_into` indexed `value[prop_name]` unconditionally, so the missing key surfaced as `TypeError: The input passed ... is not of the expected type ObjectProperty(...)`.

## Changes

- `wayflowcore/property.py`: a missing nested property is valid when it has a default; casting an object value fills the defaults of missing nested properties (`_get_default_value_of_missing_entry`, still `KeyError` for a missing required property).
- `wayflowcore/flow.py` and `wayflowcore/executors/_flowexecutor.py`: `Flow.start_conversation` and step-input resolution call the existing `_fill_nested_values_with_explicit_defaults`, so steps receive the normalized value.
- `tests/integration/test_property.py` (5 tests) and `tests/integration/test_flow.py` (2 tests): type check and cast of object values omitting defaulted nested properties, rejection when a required one is missing, and the flow from the report end to end. They fail on `main`.
- Changelog entry.

## Verification

- `pytest wayflowcore/tests/integration/test_property.py wayflowcore/tests/integration/test_flow.py`: 131 passed.
- Data connection, template, input/output, descriptor, tool execution, variable step and serializable object test files: 465 passed, 1 failure needing an LLM endpoint (identical on `main`).
- black, isort, flake8 copyright and mypy clean on the changed files.
- End to end: the tool receives `{..., 'priority': 'normal', 'notifications': True}` and the flow output matches the payload expected by the conformance test.
