### PR TITLE
fix(mcp): report server timeouts clearly and honor Agent Spec read timeouts

### DIFF
--- a/docs/wayflowcore/source/core/changelog.rst
+++ b/docs/wayflowcore/source/core/changelog.rst
@@ -13,6 +13,15 @@ Improvements
 Bug fixes
 ^^^^^^^^^
 
+* **Clear errors when an MCP server does not answer**
+
+  When an MCP server accepted the connection but never answered, the request timeout surfaced
+  as an opaque ``ExceptionGroup`` (or was masked by a secondary ``AttributeError`` while
+  inspecting the MCP error). Timeouts are now reported as a ``TimeoutError`` that names the
+  remedy, and MCP error messages are read defensively. The ``read_timeout_seconds`` of the client
+  transport ``session_parameters`` is now converted to and from Agent Spec instead of being
+  dropped, so Agent Spec configurations can shorten the default 60 seconds timeout.
+
 WayFlow 26.3.0
 --------------
 

--- a/wayflowcore/src/wayflowcore/mcp/_session_persistence.py
+++ b/wayflowcore/src/wayflowcore/mcp/_session_persistence.py
@@ -28,6 +28,7 @@ from anyio import from_thread, to_thread
 from anyio.streams import memory
 from exceptiongroup import ExceptionGroup
 from mcp import ClientSession
+from mcp.shared.exceptions import McpError
 from typing_extensions import TypeAlias
 
 from wayflowcore._utils.singleton import Singleton
@@ -78,6 +79,31 @@ class ConnectionCompletedStatus:
     has been fully completed."""
 
 
+def _get_mcp_error_message(exc: BaseException) -> str:
+    """Return the message of an MCP error, whatever shape the SDK gives to its ``error`` attribute.
+
+    ``McpError.error`` is an ``ErrorData`` in the MCP SDK, but some code paths and SDK versions
+    attach a plain string instead; accessing ``.message`` on it would mask the original error.
+    """
+    error = getattr(exc, "error", None)
+    message = getattr(error, "message", None)
+    if message is None:
+        message = error if isinstance(error, str) else str(exc)
+    return str(message)
+
+
+def _is_mcp_timeout_error(exc: BaseException) -> bool:
+    """Whether the exception means the MCP server did not answer within the read timeout."""
+    if isinstance(exc, (TimeoutError, httpx.TimeoutException)):
+        return True
+    if not isinstance(exc, McpError):
+        return False
+    error_code = getattr(getattr(exc, "error", None), "code", None)
+    if error_code == httpx.codes.REQUEST_TIMEOUT:
+        return True
+    return "timed out" in _get_mcp_error_message(exc).lower()
+
+
 def _translate_mcp_connection_error(exc: BaseException) -> Optional[BaseException]:
     """
     If `exc` (or any sub-exception in an ExceptionGroup) looks like an MCP connection/auth
@@ -92,6 +118,12 @@ def _translate_mcp_connection_error(exc: BaseException) -> Optional[BaseExceptio
     elif isinstance(exc, httpx.ConnectError):
         return ConnectionError(
             "Could not connect to the remote MCP server. Make sure it is running and reachable."
+        )
+    elif _is_mcp_timeout_error(exc):
+        return TimeoutError(
+            "The MCP server did not answer in time. Make sure it is running and responsive, "
+            "or increase `read_timeout_seconds` in the client transport `session_parameters`. "
+            f"Full error: {_get_mcp_error_message(exc)}"
         )
     elif isinstance(exc, httpx.HTTPStatusError):
         status = exc.response.status_code if exc.response is not None else None
@@ -376,6 +408,7 @@ class AsyncRuntime(metaclass=Singleton):
             _raise_if_translatable_mcp_error(exc)
             raise exc
         elif isinstance(status, BaseException):
+            _raise_if_translatable_mcp_error(status)
             raise status
         else:
             raise ValueError(f"Unrecognized status: {type(status)}")

--- a/wayflowcore/src/wayflowcore/mcp/mcphelpers.py
+++ b/wayflowcore/src/wayflowcore/mcp/mcphelpers.py
@@ -42,6 +42,7 @@ from wayflowcore.events.event import ToolExecutionStreamingChunkReceivedEvent
 from wayflowcore.events.eventlistener import record_event
 from wayflowcore.exceptions import NoSuchToolFoundOnMCPServerError
 from wayflowcore.mcp._session_persistence import (
+    _get_mcp_error_message,
     _raise_if_translatable_mcp_error,
     get_mcp_async_runtime,
 )
@@ -351,7 +352,9 @@ def _is_missing_mcp_tool_error(exc: BaseException) -> bool:
     if not isinstance(exc, McpError):
         return False
 
-    message = exc.error.message.lower()
+    # `error` is not always an ErrorData (some paths attach a plain string), so read the
+    # message defensively instead of masking the original error with an AttributeError
+    message = _get_mcp_error_message(exc).lower()
     return "tool" in message and (
         "not found" in message or "unknown" in message or "does not exist" in message
     )

--- a/wayflowcore/src/wayflowcore/serialization/_builtins_deserialization_plugin.py
+++ b/wayflowcore/src/wayflowcore/serialization/_builtins_deserialization_plugin.py
@@ -344,6 +344,7 @@ from wayflowcore.flow import Flow as RuntimeFlow
 from wayflowcore.managerworkers import ManagerWorkers as RuntimeManagerWorkers
 from wayflowcore.mcp import MCPTool as RuntimeMCPTool
 from wayflowcore.mcp import MCPToolBox as RuntimeMCPToolBox
+from wayflowcore.mcp.clienttransport import SessionParameters as RuntimeSessionParameters
 from wayflowcore.mcp.clienttransport import SSEmTLSTransport as RuntimeSSEmTLSTransport
 from wayflowcore.mcp.clienttransport import SSETransport as RuntimeSSETransport
 from wayflowcore.mcp.clienttransport import StdioTransport as RuntimeStdioTransport
@@ -1649,12 +1650,18 @@ class WayflowBuiltinsDeserializationPlugin(WayflowDeserializationPlugin):
                         cwd=agentspec_component.cwd,
                         encoding=agentspec_component.encoding,
                         encoding_error_handler=agentspec_component.encoding_error_handler,
+                        session_parameters=self._convert_session_parameters_to_runtime(
+                            agentspec_component
+                        ),
                     )
                 return RuntimeStdioTransport(
                     command=agentspec_component.command,
                     args=agentspec_component.args,
                     env=agentspec_component.env,
                     cwd=agentspec_component.cwd,
+                    session_parameters=self._convert_session_parameters_to_runtime(
+                        agentspec_component
+                    ),
                 )
 
             class SupportsTimeoutKwargs(TypedDict, total=False):
@@ -1662,8 +1669,12 @@ class WayflowBuiltinsDeserializationPlugin(WayflowDeserializationPlugin):
                 sse_read_timeout: float
                 id: str
                 retry_policy: Optional[RuntimeRetryPolicy]
+                session_parameters: RuntimeSessionParameters
 
-            kwargs: SupportsTimeoutKwargs = dict(id=agentspec_component.id)
+            kwargs: SupportsTimeoutKwargs = dict(
+                id=agentspec_component.id,
+                session_parameters=self._convert_session_parameters_to_runtime(agentspec_component),
+            )
             if hasattr(agentspec_component, "retry_policy"):
                 kwargs["retry_policy"] = self._convert_retry_policy_to_runtime(
                     agentspec_component.retry_policy
@@ -2515,6 +2526,21 @@ class WayflowBuiltinsDeserializationPlugin(WayflowDeserializationPlugin):
             raise ValueError(
                 f"Agent Spec LlmConfig '{agentspec_component.__class__.__name__}' is not supported yet."
             )
+
+    @staticmethod
+    def _convert_session_parameters_to_runtime(
+        agentspec_component: AgentSpecClientTransport,
+    ) -> RuntimeSessionParameters:
+        """Convert the Agent Spec MCP session parameters (read timeout) to the runtime ones."""
+        session_parameters = getattr(agentspec_component, "session_parameters", None)
+        if session_parameters is None:
+            return RuntimeSessionParameters()
+        read_timeout_seconds = session_parameters.read_timeout_seconds
+        if float(read_timeout_seconds).is_integer():
+            # Agent Spec stores the timeout as a float; keep integral values as int so that
+            # exporting and re-importing a transport gives back an identical configuration
+            read_timeout_seconds = int(read_timeout_seconds)
+        return RuntimeSessionParameters(read_timeout_seconds=read_timeout_seconds)
 
     def _convert_retry_policy_to_runtime(
         self, agentspec_component: Optional[AgentSpecRetryPolicy]

--- a/wayflowcore/src/wayflowcore/serialization/_builtins_serialization_plugin.py
+++ b/wayflowcore/src/wayflowcore/serialization/_builtins_serialization_plugin.py
@@ -85,6 +85,7 @@ from pyagentspec.managerworkers import ManagerWorkers as AgentSpecManagerWorkers
 from pyagentspec.mcp import MCPToolBox as AgentSpecMCPToolBox
 from pyagentspec.mcp import MCPToolSpec as AgentSpecMCPToolSpec
 from pyagentspec.mcp.clienttransport import ClientTransport as AgentSpecClientTransport
+from pyagentspec.mcp.clienttransport import SessionParameters as AgentSpecSessionParameters
 from pyagentspec.mcp.clienttransport import SSEmTLSTransport as AgentSpecSSEmTLSTransport
 from pyagentspec.mcp.clienttransport import SSETransport as AgentSpecSSETransport
 from pyagentspec.mcp.clienttransport import StdioTransport as AgentSpecStdioTransport
@@ -389,7 +390,9 @@ from wayflowcore.models.ociclientconfig import (
 from wayflowcore.models.ociclientconfig import (
     OCIClientConfigWithUserAuthentication as RuntimeOCIClientConfigWithUserAuthentication,
 )
-from wayflowcore.models.openaicompatiblemodel import EMPTY_API_KEY
+from wayflowcore.models.openaicompatiblemodel import (
+    EMPTY_API_KEY,
+)
 from wayflowcore.models.openaicompatiblemodel import (
     OpenAICompatibleModel as RuntimeOpenAICompatibleModel,
 )
@@ -2093,14 +2096,12 @@ class WayflowBuiltinsSerializationPlugin(WayflowSerializationPlugin):
         runtime_clienttransport: RuntimeClientTransport,
         referenced_objects: Optional[Dict[str, Any]] = None,
     ) -> AgentSpecClientTransport:
-        if (
-            hasattr(runtime_clienttransport, "session_parameters")
-            and runtime_clienttransport.session_parameters != RuntimeSessionParameters()
-        ):
-            warn(
-                "Client transport `session_parameters` parameter is not supported yet for serialization.",
-                UserWarning,
-            )
+        runtime_session_parameters = getattr(
+            runtime_clienttransport, "session_parameters", RuntimeSessionParameters()
+        )
+        agentspec_session_parameters = AgentSpecSessionParameters(
+            read_timeout_seconds=runtime_session_parameters.read_timeout_seconds
+        )
         if hasattr(runtime_clienttransport, "auth") and runtime_clienttransport.auth:
             warn(
                 "Client transport `auth` parameter is not supported yet for serialization.",
@@ -2114,6 +2115,7 @@ class WayflowBuiltinsSerializationPlugin(WayflowSerializationPlugin):
                 env=runtime_clienttransport.env,
                 cwd=runtime_clienttransport.cwd,
                 id=runtime_clienttransport.id,
+                session_parameters=agentspec_session_parameters,
             )
             if has_default_value_for_attribute(
                 runtime_clienttransport, "encoding"
@@ -2150,6 +2152,7 @@ class WayflowBuiltinsSerializationPlugin(WayflowSerializationPlugin):
                     else None
                 ),
                 id=runtime_clienttransport.id,
+                session_parameters=agentspec_session_parameters,
                 **mtls_kwargs,
             )
 

--- a/wayflowcore/tests/agentspec/test_mcptool.py
+++ b/wayflowcore/tests/agentspec/test_mcptool.py
@@ -12,6 +12,8 @@ from pyagentspec.adapters._agentspecloader import (
 )
 from pyagentspec.mcp import MCPTool as AgentSpecMCPTool
 from pyagentspec.mcp import MCPToolBox as AgentSpecMCPToolBox
+from pyagentspec.mcp import SessionParameters as AgentSpecSessionParameters
+from pyagentspec.mcp import StreamableHTTPTransport as AgentSpecStreamableHTTPTransport
 from pyagentspec.versioning import AgentSpecVersionEnum
 
 from wayflowcore import Agent
@@ -29,6 +31,7 @@ from wayflowcore.mcp import (
     authless_mcp_enabled,
 )
 from wayflowcore.mcp._session_persistence import AsyncRuntime
+from wayflowcore.mcp.clienttransport import SessionParameters
 from wayflowcore.property import StringProperty
 from wayflowcore.retrypolicy import RetryPolicy
 from wayflowcore.warnings import SecurityWarning
@@ -283,3 +286,52 @@ def test_agentspec_loader_authless_context_approves_reloaded_toolbox_transport(
         assert (
             runtime.get_or_create_session(reloaded_agent._toolboxes[0].client_transport) is session
         )
+
+
+def test_mcp_transport_session_parameters_round_trip_to_agentspec() -> None:
+    # `read_timeout_seconds` used to be dropped with a "not supported" warning on export and
+    # ignored on import, so the 60 seconds default always applied at runtime
+    toolbox = MCPToolBox(
+        client_transport=StreamableHTTPTransport(
+            url="https://example.com/mcp",
+            session_parameters=SessionParameters(read_timeout_seconds=7),
+        ),
+        _validate_mcp_client_transport=False,
+    )
+
+    with warnings.catch_warnings(record=True) as captured_warnings:
+        warnings.simplefilter("always")
+        agentspec_toolbox = AgentSpecExporter().to_component(toolbox)
+
+    assert not [
+        warning for warning in captured_warnings if "session_parameters" in str(warning.message)
+    ]
+    assert isinstance(agentspec_toolbox, AgentSpecMCPToolBox)
+    assert agentspec_toolbox.client_transport.session_parameters.read_timeout_seconds == 7
+
+    with pytest.warns(match="without authentication"):
+        with authless_mcp_enabled():
+            deserialized_toolbox = AgentSpecLoader().load_component(agentspec_toolbox)
+
+    assert isinstance(deserialized_toolbox, MCPToolBox)
+    assert deserialized_toolbox.client_transport.session_parameters.read_timeout_seconds == 7
+
+
+def test_agentspec_mcp_transport_read_timeout_is_applied_to_runtime_transport() -> None:
+    agentspec_tool = AgentSpecMCPTool(
+        name="search",
+        description="Searches documents",
+        inputs=[],
+        client_transport=AgentSpecStreamableHTTPTransport(
+            name="transport",
+            url="https://example.com/mcp",
+            session_parameters=AgentSpecSessionParameters(read_timeout_seconds=3),
+        ),
+    )
+
+    with pytest.warns(match="without authentication"):
+        with authless_mcp_enabled():
+            runtime_tool = AgentSpecLoader().load_component(agentspec_tool)
+
+    assert isinstance(runtime_tool, MCPTool)
+    assert runtime_tool.client_transport.session_parameters.read_timeout_seconds == 3

--- a/wayflowcore/tests/mcptools/test_mcp_tools.py
+++ b/wayflowcore/tests/mcptools/test_mcp_tools.py
@@ -6,6 +6,8 @@
 
 import logging
 import re
+import socket
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Awaitable, Callable, Dict, Generator, List, Tuple, cast
@@ -15,8 +17,10 @@ import anyio
 import httpx
 import pytest
 from anyio import to_thread
+from exceptiongroup import ExceptionGroup
 from mcp import ClientSession
 from mcp import types as mcp_types
+from mcp.shared.exceptions import McpError
 
 from wayflowcore import Agent, Flow
 from wayflowcore.auth import AuthChallengeResult
@@ -49,11 +53,14 @@ from wayflowcore.mcp import (
 from wayflowcore.mcp._auth import headless_auth_flow_handler
 from wayflowcore.mcp._session_persistence import (
     AsyncRuntime,
+    _translate_mcp_connection_error,
     get_mcp_async_runtime,
     shutdown_mcp_async_runtime,
 )
+from wayflowcore.mcp.clienttransport import SessionParameters
 from wayflowcore.mcp.mcphelpers import (
     _classify_mcp_tool_call_for_retry,
+    _is_missing_mcp_tool_error,
     _reset_mcp_contextvar,
     get_server_tools_from_mcp_server,
     mcp_streaming_tool,
@@ -2134,3 +2141,93 @@ def test_oauth_works_on_managerworkers_when_worker_uses_mcp_tool(
         last_tool_result_message.tool_result is not None
         and "random_string_" in last_tool_result_message.tool_result.content
     )
+
+
+def _mcp_timeout_error() -> McpError:
+    return McpError(
+        mcp_types.ErrorData(
+            code=httpx.codes.REQUEST_TIMEOUT,
+            message="Timed out while waiting for response to ClientRequest. Waited 60.0 seconds.",
+        )
+    )
+
+
+def test_missing_mcp_tool_error_detection_tolerates_string_error_payload() -> None:
+    # Some code paths attach a plain string to `McpError.error`; detection must not raise
+    # `AttributeError: 'str' object has no attribute 'message'` and mask the original error
+    error = McpError(mcp_types.ErrorData(code=-32602, message="placeholder"))
+    error.error = "Tool 'lookup' not found"  # type: ignore[assignment]
+
+    assert _is_missing_mcp_tool_error(error) is True
+    assert _classify_mcp_tool_call_for_retry(error, RetryPolicy(max_attempts=1)) == (None, None)
+
+    timeout_error = _mcp_timeout_error()
+    timeout_error.error = "Timed out while waiting for response"  # type: ignore[assignment]
+    assert _is_missing_mcp_tool_error(timeout_error) is False
+    assert _classify_mcp_tool_call_for_retry(timeout_error, RetryPolicy(max_attempts=1)) is None
+
+
+def test_mcp_request_timeout_is_translated_to_a_clear_timeout_error() -> None:
+    # The MCP SDK raises McpError(REQUEST_TIMEOUT) inside anyio task groups when the server
+    # does not answer; the user must get a TimeoutError naming the remedy, not an ExceptionGroup
+    grouped_error = ExceptionGroup(
+        "unhandled errors in a TaskGroup",
+        [ExceptionGroup("unhandled errors in a TaskGroup", [_mcp_timeout_error()])],
+    )
+
+    for error in (_mcp_timeout_error(), grouped_error, TimeoutError(), httpx.ReadTimeout("slow")):
+        translated = _translate_mcp_connection_error(error)
+        assert isinstance(translated, TimeoutError), error
+        assert "did not answer in time" in str(translated)
+        assert "read_timeout_seconds" in str(translated)
+    assert "Waited 60.0 seconds" in str(_translate_mcp_connection_error(grouped_error))
+
+
+@pytest.fixture
+def unresponsive_server_url():
+    # Accepts TCP connections but never answers, like a hung MCP server
+    server = socket.socket()
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(("127.0.0.1", 0))
+    server.listen(8)
+    accepted: List[socket.socket] = []
+
+    def accept_forever() -> None:
+        while True:
+            try:
+                connection, _ = server.accept()
+            except OSError:
+                return
+            accepted.append(connection)
+
+    thread = threading.Thread(target=accept_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.getsockname()[1]}/mcp"
+    finally:
+        shutdown_mcp_async_runtime()
+        server.close()
+        for connection in accepted:
+            connection.close()
+
+
+def test_mcp_tool_call_against_unresponsive_server_raises_timeout_error(
+    with_mcp_enabled, unresponsive_server_url
+) -> None:
+    transport = StreamableHTTPTransport(
+        url=unresponsive_server_url,
+        timeout=1,
+        session_parameters=SessionParameters(read_timeout_seconds=1),
+    )
+    tool = MCPTool(
+        name="search",
+        description="Searches documents",
+        input_descriptors=[StringProperty(name="query")],
+        client_transport=transport,
+        _validate_server_exists=False,
+    )
+
+    start = time.monotonic()
+    with pytest.raises(TimeoutError, match="did not answer in time"):
+        tool.run(query="hello")
+    assert time.monotonic() - start < 30


### PR DESCRIPTION
Fixes #196. Runtime side of oracle/agent-spec#225.

## Root cause

When an MCP server accepted the connection but never answered, the request timeout raised by the MCP SDK (`McpError` with code `REQUEST_TIMEOUT`) surfaced after the default 60 s as an opaque "unhandled errors in a TaskGroup" `ExceptionGroup`, because `_translate_mcp_connection_error()` had no timeout branch. The Agent Spec `session_parameters.read_timeout_seconds` of client transports was dropped at import (with a "not supported" warning), so configurations could not shorten that timeout. The retry classification in `mcphelpers._is_missing_mcp_tool_error` read `exc.error.message` unconditionally, which masks the original error with `AttributeError: 'str' object has no attribute 'message'` when the error payload is a plain string.

## Changes

- `wayflowcore/mcp/_session_persistence.py`: `_translate_mcp_connection_error()` maps MCP request timeouts, `TimeoutError` and `httpx` timeouts to a `TimeoutError` naming the remedy (increase `read_timeout_seconds` in the transport session parameters); non-grouped session errors are translated as well.
- `wayflowcore/mcp/mcphelpers.py`: MCP error messages are read defensively through `_get_mcp_error_message()`.
- `serialization/_builtins_deserialization_plugin.py` and `_builtins_serialization_plugin.py`: `session_parameters.read_timeout_seconds` is converted to the runtime transport on import and exported back (integral values kept as `int` so round trips stay exact); the "not supported" warning is removed.
- `tests/mcptools/test_mcp_tools.py` (3 tests, including an unresponsive-server integration test that completes in about a second) and `tests/agentspec/test_mcptool.py` (2 tests for the round trip of `read_timeout_seconds`).
- Changelog entry.

## Verification

- MCP tools, Agent Spec MCP tool, conversion coverage, retry policy, toolbox and serialization test files: 118 passed; 9 agent tests fail because they need an LLM endpoint (identical on `main`).
- black, isort and flake8 copyright clean; mypy reports only a pre-existing redundant-cast error in `_builtins_serialization_plugin.py` that is present on `main`.
- End to end: the unresponsive-server scenario now fails after the configured 5 s with the `TimeoutError` instead of after 60 s with an `ExceptionGroup`.

## Note

The `AttributeError` from the report could not be reproduced with mcp 1.28.1 or 1.30.0, which only build `McpError` from `ErrorData`; the defensive read covers whichever SDK version or code path produces the string payload.
